### PR TITLE
Set body for GET requests when using Curb.

### DIFF
--- a/elasticsearch-transport/lib/elasticsearch/transport/transport/http/curb.rb
+++ b/elasticsearch-transport/lib/elasticsearch/transport/transport/http/curb.rb
@@ -20,15 +20,13 @@ module Elasticsearch
               connection.connection.url = url
 
               case method
-                when 'PUT'
-                  connection.connection.put_data = serializer.dump(body)
-                when 'GET', 'POST'
-                  connection.connection.post_body = __convert_to_json(body) if body
-                when 'HEAD', 'DELETE'
+                when 'HEAD'
+                when 'GET', 'POST', 'PUT', 'DELETE'
+                  connection.connection.put_data = __convert_to_json(body) if body
                 else raise ArgumentError, "Unsupported HTTP method: #{method}"
               end
 
-              connection.connection.http method.downcase.to_sym
+              connection.connection.http(method.to_sym)
 
               Response.new connection.connection.response_code, connection.connection.body_str
             end

--- a/elasticsearch-transport/test/unit/transport_curb_test.rb
+++ b/elasticsearch-transport/test/unit/transport_curb_test.rb
@@ -24,35 +24,35 @@ class Elasticsearch::Transport::Transport::HTTP::FaradayTest < Test::Unit::TestC
     end
 
     should "set body for GET request" do
-      @transport.connections.first.connection.expects(:post_body=).with('{"foo":"bar"}')
-      @transport.connections.first.connection.expects(:http).with(:get).returns(stub_everything)
+      @transport.connections.first.connection.expects(:put_data=).with('{"foo":"bar"}')
+      @transport.connections.first.connection.expects(:http).with(:GET).returns(stub_everything)
       @transport.perform_request 'GET', '/', {}, '{"foo":"bar"}'
     end
 
     should "set body for PUT request" do
       @transport.connections.first.connection.expects(:put_data=)
-      @transport.connections.first.connection.expects(:http).with(:put).returns(stub_everything)
+      @transport.connections.first.connection.expects(:http).with(:PUT).returns(stub_everything)
       @transport.perform_request 'PUT', '/', {}, {:foo => 'bar'}
     end
 
     should "serialize the request body" do
-      @transport.connections.first.connection.expects(:http).with(:post).returns(stub_everything)
+      @transport.connections.first.connection.expects(:http).with(:POST).returns(stub_everything)
       @transport.serializer.expects(:dump)
       @transport.perform_request 'POST', '/', {}, {:foo => 'bar'}
     end
 
     should "not serialize a String request body" do
-      @transport.connections.first.connection.expects(:http).with(:post).returns(stub_everything)
+      @transport.connections.first.connection.expects(:http).with(:POST).returns(stub_everything)
       @transport.serializer.expects(:dump).never
       @transport.perform_request 'POST', '/', {}, '{"foo":"bar"}'
     end
 
     should "handle HTTP methods" do
-      @transport.connections.first.connection.expects(:http).with(:head).returns(stub_everything)
-      @transport.connections.first.connection.expects(:http).with(:get).returns(stub_everything)
-      @transport.connections.first.connection.expects(:http).with(:put).returns(stub_everything)
-      @transport.connections.first.connection.expects(:http).with(:post).returns(stub_everything)
-      @transport.connections.first.connection.expects(:http).with(:delete).returns(stub_everything)
+      @transport.connections.first.connection.expects(:http).with(:HEAD).returns(stub_everything)
+      @transport.connections.first.connection.expects(:http).with(:GET).returns(stub_everything)
+      @transport.connections.first.connection.expects(:http).with(:PUT).returns(stub_everything)
+      @transport.connections.first.connection.expects(:http).with(:POST).returns(stub_everything)
+      @transport.connections.first.connection.expects(:http).with(:DELETE).returns(stub_everything)
 
       %w| HEAD GET PUT POST DELETE |.each { |method| @transport.perform_request method, '/' }
 


### PR DESCRIPTION
This fixes a serious issue when sending GET requests to Curb transport backend. Basically request body was discarded and not used at all. For example any search would yield default search - returning all docs.
