### PR TITLE
Elasticsearch::API::Actions#delete_by_query should honor type

### DIFF
--- a/elasticsearch-api/lib/elasticsearch/api/actions/delete_by_query.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/delete_by_query.rb
@@ -51,7 +51,9 @@ module Elasticsearch
           :timeout ]
 
         method = 'DELETE'
-        path   = Utils.__pathify( Utils.__listify(arguments[:index]), '/_query' )
+        path   = Utils.__pathify Utils.__listify(arguments[:index]),
+                                 Utils.__listify(arguments[:type]),
+                                 '/_query'
 
         params = Utils.__validate_and_extract_params arguments, valid_params
         body   = arguments[:body]

--- a/elasticsearch-api/test/unit/delete_by_query_test.rb
+++ b/elasticsearch-api/test/unit/delete_by_query_test.rb
@@ -25,6 +25,15 @@ module Elasticsearch
           subject.delete_by_query :index => 'foo', :body => { :term => {} }
         end
 
+        should "honor optional :type argument" do
+          subject.expects(:perform_request).with do |method, url, params, body|
+            assert_equal 'foo/tweet,post/_query', url
+            true
+          end.returns(FakeResponse.new)
+
+          subject.delete_by_query :index => 'foo', :type => ['tweet', 'post'], :body => { :term => {} }
+        end
+
         should "pass the query in URL parameters" do
           subject.expects(:perform_request).with do |method, url, params, body|
             assert_equal 'foo/_query', url


### PR DESCRIPTION
As specified in the [documentation](http://rubydoc.info/gems/elasticsearch-api/Elasticsearch/API/Actions#delete_by_query-instance_method), closes #12
