### PR TITLE
retry_on_failure off-by-one error

### DIFF
--- a/elasticsearch-transport/test/unit/transport_base_test.rb
+++ b/elasticsearch-transport/test/unit/transport_base_test.rb
@@ -242,7 +242,7 @@ class Elasticsearch::Transport::Transport::BaseTest < Test::Unit::TestCase
       @block = Proc.new { |c, u| puts "UNREACHABLE" }
     end
 
-    should "retry DEFAULT_MAX_TRIES when host is unreachable" do
+    should "retry DEFAULT_MAX_RETRIES when host is unreachable" do
       @block.expects(:call).times(4).
             raises(Errno::ECONNREFUSED).
             then.raises(Errno::ECONNREFUSED).


### PR DESCRIPTION
According to the documentation `:retry_on_failure` specifies the number of times a request is **retried** before failing.

The current implementation uses this as the max number of tries (instead of retries). Those 2 patches deal with the issue. I chose to modify function and constant names to make clearer how  they are used.
