### PR TITLE
Add support for clearing scroll_id

### DIFF
--- a/elasticsearch-api/lib/elasticsearch/api/actions/scroll.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/scroll.rb
@@ -22,12 +22,14 @@ module Elasticsearch
       # @option arguments [Duration] :scroll Specify how long a consistent view of the index
       #                                      should be maintained for scrolled search
       # @option arguments [String] :scroll_id The scroll ID for scrolled search
+      # @option arguments [Boolean] :clear Whether to abort the scroll search by
+      #                                    deleting the scroll_id or not
       #
       # @see http://www.elasticsearch.org/guide/reference/api/search/scroll/
       # @see http://www.elasticsearch.org/guide/reference/api/search/search-type/
       #
       def scroll(arguments={})
-        method = 'GET'
+        method = arguments.delete(:clear) ? 'DELETE' : 'GET'
         path   = "_search/scroll"
         valid_params = [
           :scroll,

--- a/elasticsearch-api/test/unit/scroll_test.rb
+++ b/elasticsearch-api/test/unit/scroll_test.rb
@@ -7,16 +7,34 @@ module Elasticsearch
       context "Scroll" do
         subject { FakeClient.new }
 
-        should "perform correct request" do
-          subject.expects(:perform_request).with do |method, url, params, body|
-            assert_equal 'GET', method
-            assert_equal '_search/scroll', url
-            assert_equal 'cXVlcn...', params[:scroll_id]
-            assert_nil   body
-            true
-          end.returns(FakeResponse.new)
+        context "consuming scroll search" do
 
-          subject.scroll :scroll_id => 'cXVlcn...'
+          should "perform correct request" do
+            subject.expects(:perform_request).with do |method, url, params, body|
+              assert_equal 'GET', method
+              assert_equal '_search/scroll', url
+              assert_equal 'cXVlcn...', params[:scroll_id]
+              assert_nil   body
+              true
+            end.returns(FakeResponse.new)
+
+            subject.scroll :scroll_id => 'cXVlcn...'
+          end
+        end
+
+        context "clearing scroll" do
+
+          should "perform correct request" do
+            subject.expects(:perform_request).with do |method, url, params, body|
+              assert_equal 'DELETE', method
+              assert_equal '_search/scroll', url
+              assert_equal 'cXVlcn...', params[:scroll_id]
+              assert_nil   body
+              true
+            end.returns(FakeResponse.new)
+
+            subject.scroll :scroll_id => 'cXVlcn...', :clear => true
+          end
         end
 
       end


### PR DESCRIPTION
According to the documentation, you can abort the scroll search by deleting the scroll_id. Since the API call is the same with the scrolling and clearing the scroll_id but they only differ in the method of the call, I added an option to the scroll action which determines the method of the API call.

http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/search-request-search-type.html#clear-scroll
