### PR TITLE
Basic pagination example in docs

### DIFF
--- a/elasticsearch-api/lib/elasticsearch/api/actions/search.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/search.rb
@@ -19,17 +19,17 @@ module Elasticsearch
       #     client.search index: 'myindex',
       #                   body: {
       #                     query: { match: { title: 'test' } },
-      #                     facets: { tags: { terms: { field: 'tags' } } }
+      #                     facets: { tags: { terms: { field: 'tags' } } },
+      #                     from: 0, 
+      #                     size: 10
       #                   }
-      #
       #
       # @example Basic pagination (5 documents, beginning from the 10th)
       #
       #     client.search index: 'myindex',
       #                   body: {
       #                     query: { match: { title: 'test' } },
-      #                     from: 10, 
-      #                     size: 5
+      
       #                   }
       #
       # @example Passing the search definition as a `String`, built with a JSON builder


### PR DESCRIPTION
As discussed in #9, adds an example demonstrating basic pagination in `elasticsearch-api` using `from` and `size`. These parameters must be submitted as part of the request body, [as documented](http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/search-request-from-size.html).
