### PR TITLE
Catch more Faraday request errors.

### DIFF
--- a/elasticsearch-transport/lib/elasticsearch/transport/transport/base.rb
+++ b/elasticsearch-transport/lib/elasticsearch/transport/transport/base.rb
@@ -129,7 +129,7 @@ module Elasticsearch
         # @api private
         def __raise_transport_error(response)
           error = ERRORS[response.status] || ServerError
-          raise error.new "[#{response.status}] #{response.body}"
+          raise error.new "HTTP Transport Error: [#{response.status}] #{response.body}"
         end
 
         # Converts any non-String object to JSON
@@ -217,7 +217,7 @@ module Elasticsearch
 
           duration = Time.now-start if logger || tracer
 
-          if response.status.to_i >= 300
+          if !response.success?
             __log    method, path, params, body, url, response, nil, 'N/A', duration if logger
             __trace  method, path, params, body, url, response, nil, 'N/A', duration if tracer
             __log_failed response if logger


### PR DESCRIPTION
I was having trouble connecting to an elasticsearch instance in my production environment, and I finally realized that it was because I was using a self-signed certificate in front of elasticsearch. To my surprise, there was no real error reported, just a vague `NoMethodError: undefined method '[]' for nil:NilClass`. 

This was because this gem doesn't check for all Faraday errors. I made the check more accurate, and also added a bit to the error exception, because at least for SSL certificate verification failures using Typhoeus, the response comes back with an empty body and status 0, so the entire exception message was `[0]` which I figured is just a little too vague.
