### PR TITLE
[TRANSPORT] Client honors environment variable ELASTICSEARCH_URL 

### DIFF
--- a/elasticsearch-transport/lib/elasticsearch/transport/client.rb
+++ b/elasticsearch-transport/lib/elasticsearch/transport/client.rb
@@ -8,6 +8,8 @@ module Elasticsearch
     class Client
       DEFAULT_TRANSPORT_CLASS  = Transport::HTTP::Faraday
 
+      DEFAULT_URL = "localhost:9200"
+
       DEFAULT_LOGGER = lambda do
         require 'logger'
         logger = Logger.new(STDERR)
@@ -103,7 +105,7 @@ module Elasticsearch
       end
 
       def __environment_url
-        ENV['ELASTICSEARCH_URL']
+        ENV.fetch('ELASTICSEARCH_URL', DEFAULT_URL)
       end
 
       # Normalizes and returns hosts configuration.
@@ -118,8 +120,8 @@ module Elasticsearch
       #
       # @api private
       #
-      def __extract_hosts(hosts_config=nil, options={})
-        hosts_config = hosts_config.nil? ? ['localhost'] : Array(hosts_config)
+      def __extract_hosts(hosts_config, options={})
+        hosts_config = Array(hosts_config)
 
         hosts = hosts_config.map do |host|
           case host

--- a/elasticsearch-transport/test/unit/client_test.rb
+++ b/elasticsearch-transport/test/unit/client_test.rb
@@ -90,13 +90,6 @@ class Elasticsearch::Transport::ClientTest < Test::Unit::TestCase
     end
 
     context "extracting hosts" do
-      should "handle defaults" do
-        hosts = @client.__extract_hosts
-
-        assert_equal 'localhost', hosts[0][:host]
-        assert_nil                hosts[0][:port]
-      end
-
       should "extract from string" do
         hosts = @client.__extract_hosts 'myhost'
 


### PR DESCRIPTION
Allows the Client host/URL to be set via the environment variable ELASTICSEARCH_URL.

Closes: https://github.com/elasticsearch/elasticsearch-rails/issues/82

Related to: https://github.com/elasticsearch/elasticsearch-ruby/issues/60
