### PR TITLE
Don't recommend patron gem

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,8 +66,8 @@ Both of these libraries are extensively documented.
 and the [`elasticsearch-api`](http://rubydoc.info/gems/elasticsearch-api) documentation carefully.**
 
 Keep in mind, that for optimal performance, you should use a HTTP library which supports persistent
-("keep-alive") connections, e.g. [Patron](https://github.com/toland/patron).
-Just `require 'patron'` in your code, and the library will automatically use it as the Faraday adapter.
+("keep-alive") connections, e.g. [Typhoeus](https://github.com/typhoeus/typhoeus).
+Just `require 'typhoeus'; require 'typhoeus/adapters/faraday'` in your code, and the library will automatically use it as the Faraday adapter.
 
 ### Transport
 


### PR DESCRIPTION
The patron gem hasn't had a new release in over 2 years, and its last release does not support including data with DELETE queries, which completely breaks delete_by_query. Took the directions for using Typhoeus from elasticsearch-transport docs.

This bit me because I followed the README and couldn't get delete_by_query to work.
