### PR TITLE
Inherit ServerError from Transport::Error instead of StandardError

### DIFF
--- a/elasticsearch-transport/lib/elasticsearch/transport/transport/errors.rb
+++ b/elasticsearch-transport/lib/elasticsearch/transport/transport/errors.rb
@@ -12,7 +12,7 @@ module Elasticsearch
 
       # Elasticsearch server error (HTTP status 5xx)
       #
-      class ServerError < StandardError; end
+      class ServerError < Error; end
 
       module Errors; end
 

--- a/elasticsearch-transport/test/unit/transport_base_test.rb
+++ b/elasticsearch-transport/test/unit/transport_base_test.rb
@@ -452,4 +452,9 @@ class Elasticsearch::Transport::Transport::BaseTest < Test::Unit::TestCase
     end
   end
 
+  context "errors" do
+    should "raise highest-level Error exception for any ServerError" do
+      assert_kind_of Elasticsearch::Transport::Transport::Error, Elasticsearch::Transport::Transport::ServerError.new
+    end
+  end
 end


### PR DESCRIPTION
Currently there is an error in the documentation:

> The highest-level exception is {Elasticsearch::Transport::Transport::Error} and will be raised for any generic client or server errors.

This is not true, because `Transport::ServerError` inherits from StandardError. If you `rescue Elasticsearch::Transport::Transport::Error`, you would actually miss all exceptions such as `NotFound` or `ServiceUnavailable`.

Behavior is now in line with documentation.

Added test may be ditched, it's a very trivial change and testing the exception hierarchy chain doesn't make much sense.
