### PR TITLE
improve and correct documentation on indices analyze api

### DIFF
--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/analyze.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/analyze.rb
@@ -15,12 +15,15 @@ module Elasticsearch
         #
         # @example Analyze text "Quick Brown Jumping Fox" with a custom tokenizer and filter chain
         #
-        #     client.indices.analyze text: 'The Quick Brown Jumping Fox',
+        #     client.indices.analyze body: 'The Quick Brown Jumping Fox',
         #                            tokenizer: 'whitespace',
         #                            filters: ['lowercase','stop']
         #
+        # If your text for analysis is longer than 4096 bytes then you should
+        # pass it using the :body argument to avoid HTTP transport errors
+        #
         # @option arguments [String] :index The name of the index to scope the operation
-        # @option arguments [Hash] :body The text on which the analysis should be performed
+        # @option arguments [String] :body The text on which the analysis should be performed
         # @option arguments [String] :analyzer The name of the analyzer to use
         # @option arguments [String] :field Use the analyzer configured for this field
         #                                   (instead of passing the analyzer name)

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/analyze.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/analyze.rb
@@ -19,8 +19,7 @@ module Elasticsearch
         #                            tokenizer: 'whitespace',
         #                            filters: ['lowercase','stop']
         #
-        # If your text for analysis is longer than 4096 bytes then you should
-        # pass it using the :body argument to avoid HTTP transport errors
+        # @note If your text for analysis is longer than 4096 bytes then you should use the :body argument, rather than :text, to avoid HTTP transport errors
         #
         # @option arguments [String] :index The name of the index to scope the operation
         # @option arguments [String] :body The text on which the analysis should be performed


### PR DESCRIPTION
I encountered this error
`org.elasticsearch.common.netty.handler.codec.frame.TooLongFrameException: An HTTP line is larger than 4096 bytes.`
analyzing a long piece of text.
Using the :body parameter this works fine. I thought it worth adding a note to the docs.

The change of documented type of the :body parameter is actually already covered by a test in analyze_test.rb
`subject.indices.analyze :body => 'foo'`
