### PR TITLE
add missing char and token filter params

### DIFF
--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/analyze.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/analyze.rb
@@ -19,6 +19,13 @@ module Elasticsearch
         #                            tokenizer: 'whitespace',
         #                            filters: ['lowercase','stop']
         #
+        # @example Analyze text "Quick <b>Brown</b> Jumping Fox" with custom tokenizer, token and character filters
+        #
+        #     client.indices.analyze text: 'The Quick <b>Brown</b> Jumping Fox',
+        #                            tokenizer: 'standard',
+        #                            token_filters: 'lowercase,stop',
+        #                            char_filters: 'html_strip'
+        #
         # @option arguments [String] :index The name of the index to scope the operation
         # @option arguments [Hash] :body The text on which the analysis should be performed
         # @option arguments [String] :analyzer The name of the analyzer to use

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/analyze.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/analyze.rb
@@ -25,6 +25,9 @@ module Elasticsearch
         # @option arguments [String] :field Use the analyzer configured for this field
         #                                   (instead of passing the analyzer name)
         # @option arguments [List] :filters A comma-separated list of filters to use for the analysis
+        # @option arguments [List] :token_filters A comma-separated list of token filters to use for the analysis,
+        #                                         you can use the shorter filters parameter name
+        # @option arguments [List] :char_filters A comma-separated list of char filters to use for the analysis
         # @option arguments [String] :index The name of the index to scope the operation
         # @option arguments [Boolean] :prefer_local With `true`, specify that a local shard should be used if available,
         #                                           with `false`, use a random shard (default: true)
@@ -38,12 +41,14 @@ module Elasticsearch
         def analyze(arguments={})
           valid_params = [
             :analyzer,
+            :char_filters,
             :field,
             :filters,
             :index,
             :prefer_local,
             :text,
             :tokenizer,
+            :token_filters,
             :format ]
 
           method = 'GET'


### PR DESCRIPTION
These parameters are detailed on http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/indices-analyze.html
for 
` building a custom transient analyzer out of tokenizers, token filters and char filters. Token filters can use the shorter filters parameter name`

`client.indices.analyze body: 'this is a <b>test</b>', tokenizer: 'whitespace', token_filters: 'lowercase,stop', char_filters: 'html_strip'`