### PR TITLE
Update termvector.rb

### DIFF
--- a/elasticsearch-api/lib/elasticsearch/api/actions/termvector.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/termvector.rb
@@ -49,7 +49,6 @@ module Elasticsearch
       def termvector(arguments={})
         raise ArgumentError, "Required argument 'index' missing" unless arguments[:index]
         raise ArgumentError, "Required argument 'type' missing" unless arguments[:type]
-        raise ArgumentError, "Required argument 'id' missing" unless arguments[:id]
 
         valid_params = [
           :term_statistics,


### PR DESCRIPTION
Argument :id no longer required with artificial documents in termvectors API (Elasticsearch version 1.4)
