### PR TITLE
Freeze frequently allocated strings

### DIFF
--- a/elasticsearch-api/lib/elasticsearch/api.rb
+++ b/elasticsearch-api/lib/elasticsearch/api.rb
@@ -25,11 +25,11 @@ module Elasticsearch
       :human                          # Return numeric values in human readable format
     ]
 
-    GET = 'GET'.freeze
-    HEAD = 'HEAD'.freeze
-    POST = 'POST'.freeze
-    PUT = 'PUT'.freeze
-    DELETE = 'DELETE'.freeze
+    HTTP_GET = 'GET'.freeze
+    HTTP_HEAD = 'HEAD'.freeze
+    HTTP_POST = 'POST'.freeze
+    HTTP_PUT = 'PUT'.freeze
+    HTTP_DELETE = 'DELETE'.freeze
     UNDERSCORE_SEARCH = '_search'.freeze
     UNDERSCORE_ALL = '_all'.freeze
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/abort_benchmark.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/abort_benchmark.rb
@@ -15,7 +15,7 @@ module Elasticsearch
       def abort_benchmark(arguments={})
         valid_params = [
            ]
-        method = POST
+        method = HTTP_POST
         path   = "_bench/abort/#{arguments[:name]}"
         params = {}
         body   = nil

--- a/elasticsearch-api/lib/elasticsearch/api/actions/benchmark.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/benchmark.rb
@@ -50,7 +50,7 @@ module Elasticsearch
       def benchmark(arguments={})
         valid_params = [
           :verbose ]
-        method = PUT
+        method = HTTP_PUT
         path   = "_bench"
         params = Utils.__validate_and_extract_params arguments, valid_params
         body   = arguments[:body]

--- a/elasticsearch-api/lib/elasticsearch/api/actions/bulk.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/bulk.rb
@@ -65,7 +65,7 @@ module Elasticsearch
           :type,
           :timeout ]
 
-        method = POST
+        method = HTTP_POST
         path   = Utils.__pathify Utils.__escape(arguments[:index]), Utils.__escape(arguments[:type]), '_bulk'
 
         params = Utils.__validate_and_extract_params arguments, valid_params

--- a/elasticsearch-api/lib/elasticsearch/api/actions/cat/aliases.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/cat/aliases.rb
@@ -50,7 +50,7 @@ module Elasticsearch
 
           name = arguments.delete(:name)
 
-          method = GET
+          method = HTTP_GET
 
           path   = Utils.__pathify '_cat/aliases', Utils.__listify(name)
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/cat/allocation.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/cat/allocation.rb
@@ -52,7 +52,7 @@ module Elasticsearch
 
           node_id = arguments.delete(:node_id)
 
-          method = GET
+          method = HTTP_GET
 
           path   = Utils.__pathify '_cat/allocation', Utils.__listify(node_id)
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/cat/count.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/cat/count.rb
@@ -46,7 +46,7 @@ module Elasticsearch
 
           index = arguments.delete(:index)
 
-          method = GET
+          method = HTTP_GET
 
           path   = Utils.__pathify '_cat/count', Utils.__listify(index)
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/cat/fielddata.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/cat/fielddata.rb
@@ -36,7 +36,7 @@ module Elasticsearch
 
           fields = arguments.delete(:fields)
 
-          method = GET
+          method = HTTP_GET
           path   = Utils.__pathify "_cat/fielddata", Utils.__listify(fields)
           params = Utils.__validate_and_extract_params arguments, valid_params
           body   = nil

--- a/elasticsearch-api/lib/elasticsearch/api/actions/cat/health.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/cat/health.rb
@@ -37,7 +37,7 @@ module Elasticsearch
             :ts,
             :v ]
 
-          method = GET
+          method = HTTP_GET
           path   = "_cat/health"
           params = Utils.__validate_and_extract_params arguments, valid_params
           params[:h] = Utils.__listify(params[:h]) if params[:h]

--- a/elasticsearch-api/lib/elasticsearch/api/actions/cat/help.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/cat/help.rb
@@ -12,7 +12,7 @@ module Elasticsearch
         def help(arguments={})
           valid_params = [
             :help ]
-          method = GET
+          method = HTTP_GET
           path   = "_cat"
           params = Utils.__validate_and_extract_params arguments, valid_params
           body   = nil

--- a/elasticsearch-api/lib/elasticsearch/api/actions/cat/indices.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/cat/indices.rb
@@ -60,7 +60,7 @@ module Elasticsearch
 
           index = arguments.delete(:index)
 
-          method = GET
+          method = HTTP_GET
 
           path   = Utils.__pathify '_cat/indices', Utils.__listify(index)
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/cat/master.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/cat/master.rb
@@ -35,7 +35,7 @@ module Elasticsearch
             :help,
             :v ]
 
-          method = GET
+          method = HTTP_GET
           path   = "_cat/master"
           params = Utils.__validate_and_extract_params arguments, valid_params
           body   = nil

--- a/elasticsearch-api/lib/elasticsearch/api/actions/cat/nodes.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/cat/nodes.rb
@@ -43,7 +43,7 @@ module Elasticsearch
             :help,
             :v ]
 
-          method = GET
+          method = HTTP_GET
           path   = "_cat/nodes"
 
           params = Utils.__validate_and_extract_params arguments, valid_params

--- a/elasticsearch-api/lib/elasticsearch/api/actions/cat/pending_tasks.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/cat/pending_tasks.rb
@@ -35,7 +35,7 @@ module Elasticsearch
             :help,
             :v ]
 
-          method = GET
+          method = HTTP_GET
           path   = "_cat/pending_tasks"
           params = Utils.__validate_and_extract_params arguments, valid_params
           params[:h] = Utils.__listify(params[:h]) if params[:h]

--- a/elasticsearch-api/lib/elasticsearch/api/actions/cat/recovery.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/cat/recovery.rb
@@ -56,7 +56,7 @@ module Elasticsearch
 
           index = arguments.delete(:index)
 
-          method = GET
+          method = HTTP_GET
 
           path   = Utils.__pathify '_cat/recovery', Utils.__listify(index)
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/cat/shards.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/cat/shards.rb
@@ -55,7 +55,7 @@ module Elasticsearch
 
           index = arguments.delete(:index)
 
-          method = GET
+          method = HTTP_GET
 
           path   = Utils.__pathify '_cat/shards', Utils.__listify(index)
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/cat/thread_pool.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/cat/thread_pool.rb
@@ -42,7 +42,7 @@ module Elasticsearch
             :help,
             :v ]
 
-          method = GET
+          method = HTTP_GET
           path   = "_cat/thread_pool"
           params = Utils.__validate_and_extract_params arguments, valid_params
           params[:h] = Utils.__listify(params[:h]) if params[:h]

--- a/elasticsearch-api/lib/elasticsearch/api/actions/clear_scroll.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/clear_scroll.rb
@@ -21,7 +21,7 @@ module Elasticsearch
             scroll_id
         end
 
-        method = DELETE
+        method = HTTP_DELETE
         path   = Utils.__pathify '_search/scroll'
         params = {}
         body   = scroll_ids

--- a/elasticsearch-api/lib/elasticsearch/api/actions/cluster/get_settings.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/cluster/get_settings.rb
@@ -18,7 +18,7 @@ module Elasticsearch
             :flat_settings
           ]
 
-          method = GET
+          method = HTTP_GET
           path   = "_cluster/settings"
           params = Utils.__validate_and_extract_params arguments, valid_params
           body   = nil

--- a/elasticsearch-api/lib/elasticsearch/api/actions/cluster/health.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/cluster/health.rb
@@ -40,7 +40,7 @@ module Elasticsearch
             :wait_for_relocating_shards,
             :wait_for_status ]
 
-          method = GET
+          method = HTTP_GET
           path   = "_cluster/health"
 
           params = Utils.__validate_and_extract_params arguments, valid_params

--- a/elasticsearch-api/lib/elasticsearch/api/actions/cluster/pending_tasks.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/cluster/pending_tasks.rb
@@ -20,7 +20,7 @@ module Elasticsearch
           valid_params = [
             :local,
             :master_timeout ]
-          method = GET
+          method = HTTP_GET
           path   = "/_cluster/pending_tasks"
           params = Utils.__validate_and_extract_params arguments, valid_params
           body   = nil

--- a/elasticsearch-api/lib/elasticsearch/api/actions/cluster/put_settings.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/cluster/put_settings.rb
@@ -17,7 +17,7 @@ module Elasticsearch
         def put_settings(arguments={})
           valid_params = [ :flat_settings ]
 
-          method = PUT
+          method = HTTP_PUT
           path   = "_cluster/settings"
           params = Utils.__validate_and_extract_params arguments, valid_params
           body   = arguments[:body] || {}

--- a/elasticsearch-api/lib/elasticsearch/api/actions/cluster/reroute.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/cluster/reroute.rb
@@ -32,7 +32,7 @@ module Elasticsearch
         def reroute(arguments={})
           valid_params = [ :dry_run, :explain, :metric, :master_timeout, :timeout ]
 
-          method = POST
+          method = HTTP_POST
           path   = "_cluster/reroute"
 
           params = Utils.__validate_and_extract_params arguments, valid_params

--- a/elasticsearch-api/lib/elasticsearch/api/actions/cluster/state.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/cluster/state.rb
@@ -34,7 +34,7 @@ module Elasticsearch
             :master_timeout,
             :flat_settings ]
 
-          method = GET
+          method = HTTP_GET
           path   = "_cluster/state"
 
           path   = Utils.__pathify '_cluster/state',

--- a/elasticsearch-api/lib/elasticsearch/api/actions/count.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/count.rb
@@ -45,7 +45,7 @@ module Elasticsearch
           :routing,
           :source ]
 
-        method = GET
+        method = HTTP_GET
         path   = Utils.__pathify( Utils.__listify(arguments[:index]), Utils.__listify(arguments[:type]), '_count' )
 
         params = Utils.__validate_and_extract_params arguments, valid_params

--- a/elasticsearch-api/lib/elasticsearch/api/actions/count_percolate.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/count_percolate.rb
@@ -62,7 +62,7 @@ module Elasticsearch
           :version,
           :version_type ]
 
-        method = GET
+        method = HTTP_GET
         path   = Utils.__pathify Utils.__escape(arguments[:index]),
                                  Utils.__escape(arguments[:type]),
                                  arguments[:id],

--- a/elasticsearch-api/lib/elasticsearch/api/actions/delete.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/delete.rb
@@ -43,7 +43,7 @@ module Elasticsearch
           :version,
           :version_type ]
 
-        method = DELETE
+        method = HTTP_DELETE
         path   = Utils.__pathify Utils.__escape(arguments[:index]),
                                  Utils.__escape(arguments[:type]),
                                  Utils.__escape(arguments[:id])

--- a/elasticsearch-api/lib/elasticsearch/api/actions/delete_by_query.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/delete_by_query.rb
@@ -60,7 +60,7 @@ module Elasticsearch
           :source,
           :timeout ]
 
-        method = DELETE
+        method = HTTP_DELETE
         path   = Utils.__pathify Utils.__listify(arguments[:index]),
                                  Utils.__listify(arguments[:type]),
                                  '/_query'

--- a/elasticsearch-api/lib/elasticsearch/api/actions/delete_script.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/delete_script.rb
@@ -19,7 +19,7 @@ module Elasticsearch
           :version,
           :version_type ]
 
-        method = DELETE
+        method = HTTP_DELETE
         path   = "_scripts/#{arguments.delete(:lang)}/#{arguments[:id]}"
         params = Utils.__validate_and_extract_params arguments, valid_params
         body   = nil

--- a/elasticsearch-api/lib/elasticsearch/api/actions/delete_template.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/delete_template.rb
@@ -9,7 +9,7 @@ module Elasticsearch
       # @see http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/search-template.html
       #
       def delete_template(arguments={})
-        method = DELETE
+        method = HTTP_DELETE
         path   = "_search/template/#{arguments[:id]}"
         params = {}
         body   = nil

--- a/elasticsearch-api/lib/elasticsearch/api/actions/exists.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/exists.rb
@@ -32,7 +32,7 @@ module Elasticsearch
           :refresh,
           :routing ]
 
-        method = HEAD
+        method = HTTP_HEAD
         path   = Utils.__pathify Utils.__escape(arguments[:index]),
                                  Utils.__escape(arguments[:type]),
                                  Utils.__escape(arguments[:id])

--- a/elasticsearch-api/lib/elasticsearch/api/actions/explain.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/explain.rb
@@ -64,7 +64,7 @@ module Elasticsearch
           :_source_include,
           :_source_exclude ]
 
-        method = GET
+        method = HTTP_GET
         path   = Utils.__pathify Utils.__escape(arguments[:index]),
                                  Utils.__escape(arguments[:type]),
                                  Utils.__escape(arguments[:id]),

--- a/elasticsearch-api/lib/elasticsearch/api/actions/get.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/get.rb
@@ -49,7 +49,7 @@ module Elasticsearch
           :_source_include,
           :_source_exclude ]
 
-        method = GET
+        method = HTTP_GET
         path   = Utils.__pathify Utils.__escape(arguments[:index]),
                                  Utils.__escape(arguments[:type]),
                                  Utils.__escape(arguments[:id])

--- a/elasticsearch-api/lib/elasticsearch/api/actions/get_script.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/get_script.rb
@@ -12,7 +12,7 @@ module Elasticsearch
       def get_script(arguments={})
         raise ArgumentError, "Required argument 'id' missing"   unless arguments[:id]
         raise ArgumentError, "Required argument 'lang' missing" unless arguments[:lang]
-        method = GET
+        method = HTTP_GET
         path   = "_scripts/#{arguments[:lang]}/#{arguments[:id]}"
         params = {}
         body   = nil

--- a/elasticsearch-api/lib/elasticsearch/api/actions/get_source.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/get_source.rb
@@ -47,7 +47,7 @@ module Elasticsearch
           :_source_include,
           :_source_exclude ]
 
-        method = GET
+        method = HTTP_GET
         path   = Utils.__pathify Utils.__escape(arguments[:index]),
                                  Utils.__escape(arguments[:type]),
                                  Utils.__escape(arguments[:id]),

--- a/elasticsearch-api/lib/elasticsearch/api/actions/get_template.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/get_template.rb
@@ -11,7 +11,7 @@ module Elasticsearch
       #
       def get_template(arguments={})
         raise ArgumentError, "Required argument 'id' missing" unless arguments[:id]
-        method = GET
+        method = HTTP_GET
         path   = "_search/template/#{arguments[:id]}"
         params = {}
         body   = arguments[:body]

--- a/elasticsearch-api/lib/elasticsearch/api/actions/index.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/index.rb
@@ -88,7 +88,7 @@ module Elasticsearch
           :version,
           :version_type ]
 
-        method = arguments[:id] ? PUT : POST
+        method = arguments[:id] ? HTTP_PUT : HTTP_POST
         path   = Utils.__pathify Utils.__escape(arguments[:index]),
                                  Utils.__escape(arguments[:type]),
                                  Utils.__escape(arguments[:id])

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/analyze.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/analyze.rb
@@ -46,7 +46,7 @@ module Elasticsearch
             :tokenizer,
             :format ]
 
-          method = GET
+          method = HTTP_GET
           path   = Utils.__pathify Utils.__listify(arguments[:index]), '_analyze'
 
           params = Utils.__validate_and_extract_params arguments, valid_params

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/clear_cache.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/clear_cache.rb
@@ -63,7 +63,7 @@ module Elasticsearch
             :expand_wildcards,
             :recycler ]
 
-          method = POST
+          method = HTTP_POST
           path   = Utils.__pathify Utils.__listify(arguments[:index]), '_cache/clear'
 
           params = Utils.__validate_and_extract_params arguments, valid_params

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/close.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/close.rb
@@ -36,7 +36,7 @@ module Elasticsearch
             :timeout
           ]
 
-          method = POST
+          method = HTTP_POST
           path   = Utils.__pathify Utils.__listify(arguments[:index]), '_close'
 
           params = Utils.__validate_and_extract_params arguments, valid_params

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/create.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/create.rb
@@ -68,7 +68,7 @@ module Elasticsearch
           raise ArgumentError, "Required argument 'index' missing" unless arguments[:index]
           valid_params = [ :timeout ]
 
-          method = PUT
+          method = HTTP_PUT
           path   = Utils.__pathify Utils.__escape(arguments[:index])
 
           params = Utils.__validate_and_extract_params arguments, valid_params

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/delete.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/delete.rb
@@ -32,7 +32,7 @@ module Elasticsearch
         def delete(arguments={})
           valid_params = [ :timeout ]
 
-          method = DELETE
+          method = HTTP_DELETE
           path   = Utils.__pathify Utils.__listify(arguments[:index])
 
           params = Utils.__validate_and_extract_params arguments, valid_params

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/delete_alias.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/delete_alias.rb
@@ -22,7 +22,7 @@ module Elasticsearch
           raise ArgumentError, "Required argument 'name' missing"  unless arguments[:name]
           valid_params = [ :timeout ]
 
-          method = DELETE
+          method = HTTP_DELETE
           path   = Utils.__pathify Utils.__escape(arguments[:index]), '_alias', Utils.__escape(arguments[:name])
 
           params = Utils.__validate_and_extract_params arguments, valid_params

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/delete_mapping.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/delete_mapping.rb
@@ -13,7 +13,7 @@ module Elasticsearch
         def delete_mapping(arguments={})
           raise ArgumentError, "Required argument 'index' missing" unless arguments[:index]
           raise ArgumentError, "Required argument 'type' missing"  unless arguments[:type]
-          method = DELETE
+          method = HTTP_DELETE
           path   = Utils.__pathify Utils.__listify(arguments[:index]), Utils.__escape(arguments[:type])
           params = {}
           body   = nil

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/delete_template.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/delete_template.rb
@@ -22,7 +22,7 @@ module Elasticsearch
           raise ArgumentError, "Required argument 'name' missing" unless arguments[:name]
           valid_params = [ :timeout ]
 
-          method = DELETE
+          method = HTTP_DELETE
           path   = Utils.__pathify '_template', Utils.__escape(arguments[:name])
 
           params = Utils.__validate_and_extract_params arguments, valid_params

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/delete_warmer.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/delete_warmer.rb
@@ -19,7 +19,7 @@ module Elasticsearch
         #
         def delete_warmer(arguments={})
           raise ArgumentError, "Required argument 'index' missing" unless arguments[:index]
-          method = DELETE
+          method = HTTP_DELETE
           path   = Utils.__pathify Utils.__listify(arguments[:index]), '_warmer', Utils.__listify(arguments[:name])
           params = {}
           body = nil

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/exists.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/exists.rb
@@ -37,7 +37,7 @@ module Elasticsearch
             :local
           ]
 
-          method = HEAD
+          method = HTTP_HEAD
           path   = Utils.__listify(arguments[:index])
           params = Utils.__validate_and_extract_params arguments, valid_params
           body   = nil

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/exists_alias.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/exists_alias.rb
@@ -34,7 +34,7 @@ module Elasticsearch
             :local
           ]
 
-          method = HEAD
+          method = HTTP_HEAD
           path   = Utils.__pathify Utils.__listify(arguments[:index]), '_alias', Utils.__escape(arguments[:name])
 
           params = Utils.__validate_and_extract_params arguments, valid_params

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/exists_template.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/exists_template.rb
@@ -14,7 +14,7 @@ module Elasticsearch
           raise ArgumentError, "Required argument 'name' missing" unless arguments[:name]
           valid_params = [ :local ]
 
-          method = HEAD
+          method = HTTP_HEAD
           path   = Utils.__pathify '_template', Utils.__escape(arguments[:name])
 
           params = Utils.__validate_and_extract_params arguments, valid_params

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/exists_type.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/exists_type.rb
@@ -33,7 +33,7 @@ module Elasticsearch
             :local
           ]
 
-          method = HEAD
+          method = HTTP_HEAD
           path   = Utils.__pathify Utils.__listify(arguments[:index]), Utils.__escape(arguments[:type])
 
           params = Utils.__validate_and_extract_params arguments, valid_params

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/flush.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/flush.rb
@@ -38,7 +38,7 @@ module Elasticsearch
             :expand_wildcards,
             :refresh ]
 
-          method = POST
+          method = HTTP_POST
           path   = Utils.__pathify Utils.__listify(arguments[:index]), '_flush'
 
           params = Utils.__validate_and_extract_params arguments, valid_params

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/get.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/get.rb
@@ -26,7 +26,7 @@ module Elasticsearch
             :allow_no_indices,
             :expand_wildcards ]
 
-          method = GET
+          method = HTTP_GET
 
           path   = Utils.__pathify Utils.__listify(arguments[:index]), Utils.__listify(arguments.delete(:feature))
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/get_alias.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/get_alias.rb
@@ -38,7 +38,7 @@ module Elasticsearch
             :local
           ]
 
-          method = GET
+          method = HTTP_GET
           path   = Utils.__pathify Utils.__listify(arguments[:index]), '_alias', Utils.__escape(arguments[:name])
 
           params = Utils.__validate_and_extract_params arguments, valid_params

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/get_aliases.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/get_aliases.rb
@@ -20,7 +20,7 @@ module Elasticsearch
         def get_aliases(arguments={})
           valid_params = [ :timeout, :local ]
 
-          method = GET
+          method = HTTP_GET
           path   = Utils.__pathify Utils.__listify(arguments[:index]), '_aliases', Utils.__listify(arguments[:name])
 
           params = Utils.__validate_and_extract_params arguments, valid_params

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/get_field_mapping.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/get_field_mapping.rb
@@ -43,7 +43,7 @@ module Elasticsearch
             :expand_wildcards
           ]
 
-          method = GET
+          method = HTTP_GET
           path   = Utils.__pathify(
                      Utils.__listify(arguments[:index]),
                      '_mapping',

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/get_mapping.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/get_mapping.rb
@@ -42,7 +42,7 @@ module Elasticsearch
             :local
           ]
 
-          method = GET
+          method = HTTP_GET
           path   = Utils.__pathify Utils.__listify(arguments[:index]),
                                    '_mapping',
                                    Utils.__listify(arguments[:type])

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/get_settings.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/get_settings.rb
@@ -51,7 +51,7 @@ module Elasticsearch
             :local
           ]
 
-          method = GET
+          method = HTTP_GET
           path   = Utils.__pathify Utils.__listify(arguments[:index]),
                                    Utils.__listify(arguments[:type]),
                                    arguments.delete(:prefix),

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/get_template.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/get_template.rb
@@ -25,7 +25,7 @@ module Elasticsearch
         def get_template(arguments={})
           valid_params = [ :flat_settings, :local ]
 
-          method = GET
+          method = HTTP_GET
           path   = Utils.__pathify '_template', Utils.__escape(arguments[:name])
 
           params = Utils.__validate_and_extract_params arguments, valid_params

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/get_warmer.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/get_warmer.rb
@@ -46,7 +46,7 @@ module Elasticsearch
             :expand_wildcards
           ]
 
-          method = GET
+          method = HTTP_GET
           path   = Utils.__pathify( Utils.__listify(arguments[:index]), '_warmer', Utils.__escape(arguments[:name]) )
           params = {}
           body   = nil

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/open.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/open.rb
@@ -34,7 +34,7 @@ module Elasticsearch
             :timeout
           ]
 
-          method = POST
+          method = HTTP_POST
           path   = Utils.__pathify Utils.__escape(arguments[:index]), '_open'
 
           params = Utils.__validate_and_extract_params arguments, valid_params

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/optimize.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/optimize.rb
@@ -58,7 +58,7 @@ module Elasticsearch
             :refresh,
             :wait_for_merge ]
 
-          method = POST
+          method = HTTP_POST
           path   = Utils.__pathify Utils.__listify(arguments[:index]), '_optimize'
 
           params = Utils.__validate_and_extract_params arguments, valid_params

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/put_alias.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/put_alias.rb
@@ -27,7 +27,7 @@ module Elasticsearch
           raise ArgumentError, "Required argument 'name' missing"  unless arguments[:name]
           valid_params = [ :timeout ]
 
-          method = PUT
+          method = HTTP_PUT
           path   = Utils.__pathify Utils.__listify(arguments[:index]), '_alias', Utils.__escape(arguments[:name])
 
           params = Utils.__validate_and_extract_params arguments, valid_params

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/put_mapping.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/put_mapping.rb
@@ -59,7 +59,7 @@ module Elasticsearch
             :timeout
           ]
 
-          method = PUT
+          method = HTTP_PUT
           path   = Utils.__pathify Utils.__listify(arguments[:index]), '_mapping', Utils.__escape(arguments[:type])
 
           params = Utils.__validate_and_extract_params arguments, valid_params

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/put_settings.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/put_settings.rb
@@ -53,7 +53,7 @@ module Elasticsearch
             :flat_settings
           ]
 
-          method = PUT
+          method = HTTP_PUT
           path   = Utils.__pathify Utils.__listify(arguments[:index]), '_settings'
           params = Utils.__validate_and_extract_params arguments, valid_params
           body   = arguments[:body]

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/put_template.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/put_template.rb
@@ -26,7 +26,7 @@ module Elasticsearch
           raise ArgumentError, "Required argument 'body' missing" unless arguments[:body]
           valid_params = [ :create, :order, :timeout ]
 
-          method = PUT
+          method = HTTP_PUT
           path   = Utils.__pathify '_template', Utils.__escape(arguments[:name])
 
           params = Utils.__validate_and_extract_params arguments, valid_params

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/put_warmer.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/put_warmer.rb
@@ -48,7 +48,7 @@ module Elasticsearch
             :expand_wildcards
           ]
 
-          method = PUT
+          method = HTTP_PUT
           path   = Utils.__pathify( Utils.__listify(arguments[:index]),
                                     Utils.__listify(arguments[:type]),
                                     '_warmer',

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/recovery.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/recovery.rb
@@ -29,7 +29,7 @@ module Elasticsearch
             :detailed,
             :active_only,
             :human ]
-          method = GET
+          method = HTTP_GET
           path   = Utils.__pathify Utils.__listify(arguments[:index]), '_recovery'
           params = Utils.__validate_and_extract_params arguments, valid_params
           body   = nil

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/refresh.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/refresh.rb
@@ -40,7 +40,7 @@ module Elasticsearch
             :expand_wildcards
           ]
 
-          method = POST
+          method = HTTP_POST
           path   = Utils.__pathify Utils.__listify(arguments[:index]), '_refresh'
 
           params = Utils.__validate_and_extract_params arguments, valid_params

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/segments.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/segments.rb
@@ -30,7 +30,7 @@ module Elasticsearch
             :expand_wildcards
           ]
 
-          method = GET
+          method = HTTP_GET
           path   = Utils.__pathify Utils.__listify(arguments[:index]), '_segments'
 
           params = Utils.__validate_and_extract_params arguments, valid_params

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/snapshot_index.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/snapshot_index.rb
@@ -29,7 +29,7 @@ module Elasticsearch
             :expand_wildcards
           ]
 
-          method = POST
+          method = HTTP_POST
           path   = Utils.__pathify Utils.__listify(arguments[:index]), '_gateway/snapshot'
 
           params = Utils.__validate_and_extract_params arguments, valid_params

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/stats.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/stats.rb
@@ -101,7 +101,7 @@ module Elasticsearch
             :allow_no_indices,
             :expand_wildcards ]
 
-          method = GET
+          method = HTTP_GET
 
           parts  = Utils.__extract_parts arguments, valid_parts
           path   = Utils.__pathify Utils.__listify(arguments[:index]), '_stats', Utils.__listify(parts)

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/status.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/status.rb
@@ -42,7 +42,7 @@ module Elasticsearch
             :recovery,
             :snapshot ]
 
-          method = GET
+          method = HTTP_GET
           path   = Utils.__pathify Utils.__listify(arguments[:index]), '_status'
 
           params = Utils.__validate_and_extract_params arguments, valid_params

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/update_aliases.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/update_aliases.rb
@@ -34,7 +34,7 @@ module Elasticsearch
           raise ArgumentError, "Required argument 'body' missing" unless arguments[:body]
           valid_params = [ :timeout ]
 
-          method = POST
+          method = HTTP_POST
           path   = "_aliases"
 
           params = Utils.__validate_and_extract_params arguments, valid_params

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/upgrade.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/upgrade.rb
@@ -25,7 +25,7 @@ module Elasticsearch
             :expand_wildcards,
             :wait_for_completion ]
 
-          method = POST
+          method = HTTP_POST
           path   = "_upgrade"
           params = Utils.__validate_and_extract_params arguments, valid_params
           body   = nil

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/validate_query.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/validate_query.rb
@@ -64,7 +64,7 @@ module Elasticsearch
             :expand_wildcards,
             :source ]
 
-          method = GET
+          method = HTTP_GET
           path   = Utils.__pathify Utils.__listify(arguments[:index]),
                                    Utils.__listify(arguments[:type]),
                                    '_validate/query'

--- a/elasticsearch-api/lib/elasticsearch/api/actions/info.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/info.rb
@@ -7,7 +7,7 @@ module Elasticsearch
       # @see http://elasticsearch.org/guide/
       #
       def info(arguments={})
-        method = GET
+        method = HTTP_GET
         path   = ""
         params = {}
         body   = nil

--- a/elasticsearch-api/lib/elasticsearch/api/actions/list_benchmarks.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/list_benchmarks.rb
@@ -17,7 +17,7 @@ module Elasticsearch
       def list_benchmarks(arguments={})
         valid_params = [
            ]
-        method = GET
+        method = HTTP_GET
         path   = "_bench"
         params = {}
         body   = nil

--- a/elasticsearch-api/lib/elasticsearch/api/actions/mget.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/mget.rb
@@ -57,7 +57,7 @@ module Elasticsearch
           :_source_include,
           :_source_exclude ]
 
-        method = GET
+        method = HTTP_GET
         path   = Utils.__pathify Utils.__escape(arguments[:index]),
                                  Utils.__escape(arguments[:type]),
                                  '_mget'

--- a/elasticsearch-api/lib/elasticsearch/api/actions/mlt.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/mlt.rb
@@ -107,7 +107,7 @@ module Elasticsearch
           :search_types,
           :stop_words ]
 
-        method = GET
+        method = HTTP_GET
         path   = Utils.__pathify Utils.__escape(arguments[:index]),
                                  Utils.__escape(arguments[:type]),
                                  Utils.__escape(arguments[:id]),

--- a/elasticsearch-api/lib/elasticsearch/api/actions/mpercolate.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/mpercolate.rb
@@ -36,7 +36,7 @@ module Elasticsearch
           :allow_no_indices,
           :expand_wildcards ]
 
-        method = GET
+        method = HTTP_GET
         path   = "_mpercolate"
 
         params = Utils.__validate_and_extract_params arguments, valid_params

--- a/elasticsearch-api/lib/elasticsearch/api/actions/msearch.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/msearch.rb
@@ -39,7 +39,7 @@ module Elasticsearch
         raise ArgumentError, "Required argument 'body' missing" unless arguments[:body]
         valid_params = [ :search_type ]
 
-        method = GET
+        method = HTTP_GET
         path   = Utils.__pathify( Utils.__listify(arguments[:index]), Utils.__listify(arguments[:type]), '_msearch' )
 
         params = Utils.__validate_and_extract_params arguments, valid_params

--- a/elasticsearch-api/lib/elasticsearch/api/actions/mtermvectors.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/mtermvectors.rb
@@ -50,7 +50,7 @@ module Elasticsearch
 
         ids = arguments.delete(:ids)
 
-        method = GET
+        method = HTTP_GET
         path   = Utils.__pathify Utils.__escape(arguments[:index]),
                                  Utils.__escape(arguments[:type]),
                                  '_mtermvectors'

--- a/elasticsearch-api/lib/elasticsearch/api/actions/nodes/hot_threads.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/nodes/hot_threads.rb
@@ -32,7 +32,7 @@ module Elasticsearch
             :threads,
             :type ]
 
-          method = GET
+          method = HTTP_GET
           path   = Utils.__pathify '_nodes', Utils.__listify(arguments[:node_id]), 'hot_threads'
 
           params = Utils.__validate_and_extract_params arguments, valid_params

--- a/elasticsearch-api/lib/elasticsearch/api/actions/nodes/info.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/nodes/info.rb
@@ -45,7 +45,7 @@ module Elasticsearch
 
           valid_params = []
 
-          method = GET
+          method = HTTP_GET
 
           parts  = Utils.__extract_parts arguments, valid_parts
           path   = Utils.__pathify '_nodes', Utils.__listify(arguments[:node_id]), Utils.__listify(parts)

--- a/elasticsearch-api/lib/elasticsearch/api/actions/nodes/shutdown.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/nodes/shutdown.rb
@@ -22,7 +22,7 @@ module Elasticsearch
             :delay,
             :exit ]
 
-          method = POST
+          method = HTTP_POST
           path   = Utils.__pathify '_cluster/nodes', Utils.__listify(arguments[:node_id]), '_shutdown'
 
           params = Utils.__validate_and_extract_params arguments, valid_params

--- a/elasticsearch-api/lib/elasticsearch/api/actions/nodes/stats.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/nodes/stats.rb
@@ -55,7 +55,7 @@ module Elasticsearch
             :level,
             :types ]
 
-          method = GET
+          method = HTTP_GET
 
           path   = Utils.__pathify '_nodes',
                                    Utils.__listify(arguments[:node_id]),

--- a/elasticsearch-api/lib/elasticsearch/api/actions/percolate.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/percolate.rb
@@ -91,7 +91,7 @@ module Elasticsearch
           :version,
           :version_type ]
 
-        method = GET
+        method = HTTP_GET
         path   = Utils.__pathify Utils.__escape(arguments[:index]),
                                  Utils.__escape(arguments[:type]),
                                  arguments[:id],

--- a/elasticsearch-api/lib/elasticsearch/api/actions/ping.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/ping.rb
@@ -11,7 +11,7 @@ module Elasticsearch
       # @see http://elasticsearch.org/guide/
       #
       def ping(arguments={})
-        method = HEAD
+        method = HTTP_HEAD
         path   = ""
         params = {}
         body   = nil

--- a/elasticsearch-api/lib/elasticsearch/api/actions/put_script.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/put_script.rb
@@ -37,7 +37,7 @@ module Elasticsearch
           :version,
           :version_type ]
 
-        method = PUT
+        method = HTTP_PUT
         path   = "_scripts/#{arguments.delete(:lang)}/#{arguments[:id]}"
 
         params = Utils.__validate_and_extract_params arguments, valid_params

--- a/elasticsearch-api/lib/elasticsearch/api/actions/put_template.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/put_template.rb
@@ -13,7 +13,7 @@ module Elasticsearch
       def put_template(arguments={})
         raise ArgumentError, "Required argument 'id' missing"   unless arguments[:id]
         raise ArgumentError, "Required argument 'body' missing" unless arguments[:body]
-        method = PUT
+        method = HTTP_PUT
         path   = "_search/template/#{arguments[:id]}"
         params = {}
         body   = arguments[:body]

--- a/elasticsearch-api/lib/elasticsearch/api/actions/scroll.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/scroll.rb
@@ -44,7 +44,7 @@ module Elasticsearch
       # @see http://www.elasticsearch.org/guide/reference/api/search/search-type/
       #
       def scroll(arguments={})
-        method = GET
+        method = HTTP_GET
         path   = "_search/scroll"
         valid_params = [
           :scroll,

--- a/elasticsearch-api/lib/elasticsearch/api/actions/search.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/search.rb
@@ -147,7 +147,7 @@ module Elasticsearch
           :timeout,
           :version ]
 
-        method = GET
+        method = HTTP_GET
         path   = Utils.__pathify( Utils.__listify(arguments[:index]), Utils.__listify(arguments[:type]), UNDERSCORE_SEARCH )
 
         params = Utils.__validate_and_extract_params arguments, valid_params

--- a/elasticsearch-api/lib/elasticsearch/api/actions/search_shards.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/search_shards.rb
@@ -29,7 +29,7 @@ module Elasticsearch
           :ignore_unavailable,
           :allow_no_indices,
           :expand_wildcards ]
-        method = GET
+        method = HTTP_GET
         path   = Utils.__pathify( Utils.__listify(arguments[:index]), Utils.__listify(arguments[:type]), '_search_shards' )
         params = Utils.__validate_and_extract_params arguments, valid_params
         body   = nil

--- a/elasticsearch-api/lib/elasticsearch/api/actions/search_template.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/search_template.rb
@@ -49,7 +49,7 @@ module Elasticsearch
           :routing,
           :scroll,
           :search_type ]
-        method = GET
+        method = HTTP_GET
         path   = Utils.__pathify( Utils.__listify(arguments[:index]), Utils.__listify(arguments[:type]), '_search/template' )
         params = Utils.__validate_and_extract_params arguments, valid_params
         body   = arguments[:body]

--- a/elasticsearch-api/lib/elasticsearch/api/actions/snapshot/create.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/snapshot/create.rb
@@ -34,7 +34,7 @@ module Elasticsearch
           repository = arguments.delete(:repository)
           snapshot   = arguments.delete(:snapshot)
 
-          method = PUT
+          method = HTTP_PUT
           path   = Utils.__pathify( '_snapshot', Utils.__escape(repository), Utils.__escape(snapshot) )
 
           params = Utils.__validate_and_extract_params arguments, valid_params

--- a/elasticsearch-api/lib/elasticsearch/api/actions/snapshot/create_repository.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/snapshot/create_repository.rb
@@ -30,7 +30,7 @@ module Elasticsearch
 
           repository = arguments.delete(:repository)
 
-          method = PUT
+          method = HTTP_PUT
           path   = Utils.__pathify( '_snapshot', Utils.__escape(repository) )
 
           params = Utils.__validate_and_extract_params arguments, valid_params

--- a/elasticsearch-api/lib/elasticsearch/api/actions/snapshot/delete.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/snapshot/delete.rb
@@ -27,7 +27,7 @@ module Elasticsearch
           repository = arguments.delete(:repository)
           snapshot   = arguments.delete(:snapshot)
 
-          method = DELETE
+          method = HTTP_DELETE
           path   = Utils.__pathify( '_snapshot', Utils.__escape(repository), Utils.__listify(snapshot) )
 
           params = Utils.__validate_and_extract_params arguments, valid_params

--- a/elasticsearch-api/lib/elasticsearch/api/actions/snapshot/delete_repository.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/snapshot/delete_repository.rb
@@ -24,7 +24,7 @@ module Elasticsearch
 
           repository = arguments.delete(:repository)
 
-          method = DELETE
+          method = HTTP_DELETE
           path   = Utils.__pathify( '_snapshot', Utils.__listify(repository) )
 
           params = Utils.__validate_and_extract_params arguments, valid_params

--- a/elasticsearch-api/lib/elasticsearch/api/actions/snapshot/get.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/snapshot/get.rb
@@ -33,7 +33,7 @@ module Elasticsearch
           repository = arguments.delete(:repository)
           snapshot   = arguments.delete(:snapshot)
 
-          method = GET
+          method = HTTP_GET
           path   = Utils.__pathify( '_snapshot', Utils.__escape(repository), Utils.__listify(snapshot) )
 
           params = Utils.__validate_and_extract_params arguments, valid_params

--- a/elasticsearch-api/lib/elasticsearch/api/actions/snapshot/get_repository.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/snapshot/get_repository.rb
@@ -28,7 +28,7 @@ module Elasticsearch
 
           repository = arguments.delete(:repository)
 
-          method = GET
+          method = HTTP_GET
           path   = Utils.__pathify( '_snapshot', Utils.__escape(repository) )
 
           params = Utils.__validate_and_extract_params arguments, valid_params

--- a/elasticsearch-api/lib/elasticsearch/api/actions/snapshot/restore.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/snapshot/restore.rb
@@ -39,7 +39,7 @@ module Elasticsearch
           repository = arguments.delete(:repository)
           snapshot   = arguments.delete(:snapshot)
 
-          method = POST
+          method = HTTP_POST
           path   = Utils.__pathify( '_snapshot', Utils.__escape(repository), Utils.__escape(snapshot), '_restore' )
 
           params = Utils.__validate_and_extract_params arguments, valid_params

--- a/elasticsearch-api/lib/elasticsearch/api/actions/snapshot/status.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/snapshot/status.rb
@@ -26,7 +26,7 @@ module Elasticsearch
           repository = arguments.delete(:repository)
           snapshot   = arguments.delete(:snapshot)
 
-          method = GET
+          method = HTTP_GET
 
           path   = Utils.__pathify( '_snapshot', Utils.__escape(repository), Utils.__escape(snapshot), '_status')
           params = Utils.__validate_and_extract_params arguments, valid_params

--- a/elasticsearch-api/lib/elasticsearch/api/actions/snapshot/verify_repository.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/snapshot/verify_repository.rb
@@ -20,7 +20,7 @@ module Elasticsearch
             :timeout ]
 
           repository = arguments.delete(:repository)
-          method = POST
+          method = HTTP_POST
           path   = Utils.__pathify( '_snapshot', Utils.__escape(repository), '_verify' )
           params = Utils.__validate_and_extract_params arguments, valid_params
           body   = nil

--- a/elasticsearch-api/lib/elasticsearch/api/actions/suggest.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/suggest.rb
@@ -33,7 +33,7 @@ module Elasticsearch
           :routing,
           :source ]
 
-        method = POST
+        method = HTTP_POST
         path   = Utils.__pathify( Utils.__listify(arguments[:index]), '_suggest' )
 
         params = Utils.__validate_and_extract_params arguments, valid_params

--- a/elasticsearch-api/lib/elasticsearch/api/actions/termvectors.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/termvectors.rb
@@ -63,7 +63,7 @@ module Elasticsearch
           :routing,
           :parent ]
 
-        method = GET
+        method = HTTP_GET
         endpoint = arguments.delete(:endpoint) || '_termvectors'
 
         path   = Utils.__pathify Utils.__escape(arguments[:index]),

--- a/elasticsearch-api/lib/elasticsearch/api/actions/update.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/update.rb
@@ -83,7 +83,7 @@ module Elasticsearch
           :version,
           :version_type ]
 
-        method = POST
+        method = HTTP_POST
         path   = Utils.__pathify Utils.__escape(arguments[:index]),
                                  Utils.__escape(arguments[:type]),
                                  Utils.__escape(arguments[:id]),


### PR DESCRIPTION
GCing is expensive in ruby, freeze frequently allocated strings and use these constants instead of reallocating
