### PR TITLE
Make curb transport pass the selector class option

### DIFF
--- a/elasticsearch-transport/lib/elasticsearch/transport/transport/http/curb.rb
+++ b/elasticsearch-transport/lib/elasticsearch/transport/transport/http/curb.rb
@@ -62,6 +62,7 @@ module Elasticsearch
 
                 Connections::Connection.new :host => host, :connection => client
               },
+              :selector_class => options[:selector_class],
               :selector => options[:selector]
           end
 


### PR DESCRIPTION
Hello Karel,

A collegue just discoved that curb driver doesn't pass the `selector_class` down to `Connections::Collection.new`.

This is a trivial patch that handles that.
