### PR TITLE
Curb timeout error

### DIFF
--- a/elasticsearch-transport/lib/elasticsearch/transport/transport/http/curb.rb
+++ b/elasticsearch-transport/lib/elasticsearch/transport/transport/http/curb.rb
@@ -70,7 +70,14 @@ module Elasticsearch
           # @return [Array]
           #
           def host_unreachable_exceptions
-            [::Curl::Err::HostResolutionError, ::Curl::Err::ConnectionFailedError, ::Curl::Err::GotNothingError, ::Curl::Err::RecvError, ::Curl::Err::SendError, ::Curl::Err::TimeoutError]
+            [
+              ::Curl::Err::HostResolutionError,
+              ::Curl::Err::ConnectionFailedError,
+              ::Curl::Err::GotNothingError,
+              ::Curl::Err::RecvError,
+              ::Curl::Err::SendError,
+              ::Curl::Err::TimeoutError
+            ]
           end
         end
 


### PR DESCRIPTION
Hello!

We observed that when an elasticsearch node is down, the client doesn't mark it as dead and the Curl::Err::TimeoutError is raised when it tries to connect to it. With the attached pull request, the node gets marked as dead and our custom selector can exclude it and retry with another healthy node.
