### PR TITLE
Unifies NotFound error handling

### DIFF
--- a/elasticsearch-api/lib/elasticsearch/api/actions/exists.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/exists.rb
@@ -21,32 +21,28 @@ module Elasticsearch
       # @see http://elasticsearch.org/guide/reference/api/get/
       #
       def exists(arguments={})
-        raise ArgumentError, "Required argument 'id' missing"    unless arguments[:id]
-        raise ArgumentError, "Required argument 'index' missing" unless arguments[:index]
-        arguments[:type] ||= UNDERSCORE_ALL
+        Utils.__rescue_from_not_found do
+          raise ArgumentError, "Required argument 'id' missing"    unless arguments[:id]
+          raise ArgumentError, "Required argument 'index' missing" unless arguments[:index]
+          arguments[:type] ||= UNDERSCORE_ALL
 
-        valid_params = [
-          :parent,
-          :preference,
-          :realtime,
-          :refresh,
-          :routing ]
+          valid_params = [
+            :parent,
+            :preference,
+            :realtime,
+            :refresh,
+            :routing ]
 
-        method = HTTP_HEAD
-        path   = Utils.__pathify Utils.__escape(arguments[:index]),
-                                 Utils.__escape(arguments[:type]),
-                                 Utils.__escape(arguments[:id])
+          method = HTTP_HEAD
+          path   = Utils.__pathify Utils.__escape(arguments[:index]),
+                                   Utils.__escape(arguments[:type]),
+                                   Utils.__escape(arguments[:id])
 
-        params = Utils.__validate_and_extract_params arguments, valid_params
-        body   = nil
+          params = Utils.__validate_and_extract_params arguments, valid_params
+          body   = nil
 
-        perform_request(method, path, params, body).status == 200 ? true : false
-        rescue Exception => e
-          if e.class.to_s =~ /NotFound/ || e.message =~ /Not\s*Found|404/i
-            false
-          else
-            raise e
-          end
+          perform_request(method, path, params, body).status == 200 ? true : false
+        end
       end
 
       alias_method :exists?, :exists

--- a/elasticsearch-api/lib/elasticsearch/api/actions/exists.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/exists.rb
@@ -21,26 +21,26 @@ module Elasticsearch
       # @see http://elasticsearch.org/guide/reference/api/get/
       #
       def exists(arguments={})
+        raise ArgumentError, "Required argument 'id' missing"    unless arguments[:id]
+        raise ArgumentError, "Required argument 'index' missing" unless arguments[:index]
+        arguments[:type] ||= UNDERSCORE_ALL
+
+        valid_params = [
+          :parent,
+          :preference,
+          :realtime,
+          :refresh,
+          :routing ]
+
+        method = HTTP_HEAD
+        path   = Utils.__pathify Utils.__escape(arguments[:index]),
+                                 Utils.__escape(arguments[:type]),
+                                 Utils.__escape(arguments[:id])
+
+        params = Utils.__validate_and_extract_params arguments, valid_params
+        body   = nil
+
         Utils.__rescue_from_not_found do
-          raise ArgumentError, "Required argument 'id' missing"    unless arguments[:id]
-          raise ArgumentError, "Required argument 'index' missing" unless arguments[:index]
-          arguments[:type] ||= UNDERSCORE_ALL
-
-          valid_params = [
-            :parent,
-            :preference,
-            :realtime,
-            :refresh,
-            :routing ]
-
-          method = HTTP_HEAD
-          path   = Utils.__pathify Utils.__escape(arguments[:index]),
-                                   Utils.__escape(arguments[:type]),
-                                   Utils.__escape(arguments[:id])
-
-          params = Utils.__validate_and_extract_params arguments, valid_params
-          body   = nil
-
           perform_request(method, path, params, body).status == 200 ? true : false
         end
       end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/exists.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/exists.rb
@@ -27,22 +27,22 @@ module Elasticsearch
         # @see http://www.elasticsearch.org/guide/reference/api/admin-indices-indices-exists/
         #
         def exists(arguments={})
+          raise ArgumentError, "Required argument 'index' missing" unless arguments[:index]
+
+          valid_params = [
+            :ignore_indices,
+            :ignore_unavailable,
+            :allow_no_indices,
+            :expand_wildcards,
+            :local
+          ]
+
+          method = HTTP_HEAD
+          path   = Utils.__listify(arguments[:index])
+          params = Utils.__validate_and_extract_params arguments, valid_params
+          body   = nil
+
           Utils.__rescue_from_not_found do
-            raise ArgumentError, "Required argument 'index' missing" unless arguments[:index]
-
-            valid_params = [
-              :ignore_indices,
-              :ignore_unavailable,
-              :allow_no_indices,
-              :expand_wildcards,
-              :local
-            ]
-
-            method = HTTP_HEAD
-            path   = Utils.__listify(arguments[:index])
-            params = Utils.__validate_and_extract_params arguments, valid_params
-            body   = nil
-
             perform_request(method, path, params, body).status == 200 ? true : false
           end
         end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/exists.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/exists.rb
@@ -27,27 +27,23 @@ module Elasticsearch
         # @see http://www.elasticsearch.org/guide/reference/api/admin-indices-indices-exists/
         #
         def exists(arguments={})
-          raise ArgumentError, "Required argument 'index' missing" unless arguments[:index]
+          Utils.__rescue_from_not_found do
+            raise ArgumentError, "Required argument 'index' missing" unless arguments[:index]
 
-          valid_params = [
-            :ignore_indices,
-            :ignore_unavailable,
-            :allow_no_indices,
-            :expand_wildcards,
-            :local
-          ]
+            valid_params = [
+              :ignore_indices,
+              :ignore_unavailable,
+              :allow_no_indices,
+              :expand_wildcards,
+              :local
+            ]
 
-          method = HTTP_HEAD
-          path   = Utils.__listify(arguments[:index])
-          params = Utils.__validate_and_extract_params arguments, valid_params
-          body   = nil
+            method = HTTP_HEAD
+            path   = Utils.__listify(arguments[:index])
+            params = Utils.__validate_and_extract_params arguments, valid_params
+            body   = nil
 
-          perform_request(method, path, params, body).status == 200 ? true : false
-        rescue Exception => e
-          if e.class.to_s =~ /NotFound/ || e.message =~ /Not\s*Found|404/i
-            false
-          else
-            raise e
+            perform_request(method, path, params, body).status == 200 ? true : false
           end
         end
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/exists_alias.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/exists_alias.rb
@@ -26,26 +26,22 @@ module Elasticsearch
         # @see http://www.elasticsearch.org/guide/reference/api/admin-indices-aliases/
         #
         def exists_alias(arguments={})
-          valid_params = [
-            :ignore_indices,
-            :ignore_unavailable,
-            :allow_no_indices,
-            :expand_wildcards,
-            :local
-          ]
+          Utils.__rescue_from_not_found do
+            valid_params = [
+              :ignore_indices,
+              :ignore_unavailable,
+              :allow_no_indices,
+              :expand_wildcards,
+              :local
+            ]
 
-          method = HTTP_HEAD
-          path   = Utils.__pathify Utils.__listify(arguments[:index]), '_alias', Utils.__escape(arguments[:name])
+            method = HTTP_HEAD
+            path   = Utils.__pathify Utils.__listify(arguments[:index]), '_alias', Utils.__escape(arguments[:name])
 
-          params = Utils.__validate_and_extract_params arguments, valid_params
-          body = nil
+            params = Utils.__validate_and_extract_params arguments, valid_params
+            body = nil
 
-          perform_request(method, path, params, body).status == 200 ? true : false
-        rescue Exception => e
-          if e.class.to_s =~ /NotFound/ || e.message =~ /Not\s*Found|404/i
-            false
-          else
-            raise e
+            perform_request(method, path, params, body).status == 200 ? true : false
           end
         end
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/exists_alias.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/exists_alias.rb
@@ -26,21 +26,21 @@ module Elasticsearch
         # @see http://www.elasticsearch.org/guide/reference/api/admin-indices-aliases/
         #
         def exists_alias(arguments={})
+          valid_params = [
+            :ignore_indices,
+            :ignore_unavailable,
+            :allow_no_indices,
+            :expand_wildcards,
+            :local
+          ]
+
+          method = HTTP_HEAD
+          path   = Utils.__pathify Utils.__listify(arguments[:index]), '_alias', Utils.__escape(arguments[:name])
+
+          params = Utils.__validate_and_extract_params arguments, valid_params
+          body = nil
+
           Utils.__rescue_from_not_found do
-            valid_params = [
-              :ignore_indices,
-              :ignore_unavailable,
-              :allow_no_indices,
-              :expand_wildcards,
-              :local
-            ]
-
-            method = HTTP_HEAD
-            path   = Utils.__pathify Utils.__listify(arguments[:index]), '_alias', Utils.__escape(arguments[:name])
-
-            params = Utils.__validate_and_extract_params arguments, valid_params
-            body = nil
-
             perform_request(method, path, params, body).status == 200 ? true : false
           end
         end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/exists_template.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/exists_template.rb
@@ -12,21 +12,17 @@ module Elasticsearch
         # @see http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/indices-templates.html
         #
         def exists_template(arguments={})
-          raise ArgumentError, "Required argument 'name' missing" unless arguments[:name]
-          valid_params = [ :local, :master_timeout ]
+          Utils.__rescue_from_not_found do
+            raise ArgumentError, "Required argument 'name' missing" unless arguments[:name]
+            valid_params = [ :local, :master_timeout ]
 
-          method = HTTP_HEAD
-          path   = Utils.__pathify '_template', Utils.__escape(arguments[:name])
+            method = HTTP_HEAD
+            path   = Utils.__pathify '_template', Utils.__escape(arguments[:name])
 
-          params = Utils.__validate_and_extract_params arguments, valid_params
-          body = nil
+            params = Utils.__validate_and_extract_params arguments, valid_params
+            body = nil
 
-          perform_request(method, path, params, body).status == 200 ? true : false
-        rescue Exception => e
-          if e.class.to_s =~ /NotFound/ || e.message =~ /Not\s*Found|404/i
-            false
-          else
-            raise e
+            perform_request(method, path, params, body).status == 200 ? true : false
           end
         end
       end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/exists_template.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/exists_template.rb
@@ -12,16 +12,16 @@ module Elasticsearch
         # @see http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/indices-templates.html
         #
         def exists_template(arguments={})
+          raise ArgumentError, "Required argument 'name' missing" unless arguments[:name]
+          valid_params = [ :local, :master_timeout ]
+
+          method = HTTP_HEAD
+          path   = Utils.__pathify '_template', Utils.__escape(arguments[:name])
+
+          params = Utils.__validate_and_extract_params arguments, valid_params
+          body = nil
+
           Utils.__rescue_from_not_found do
-            raise ArgumentError, "Required argument 'name' missing" unless arguments[:name]
-            valid_params = [ :local, :master_timeout ]
-
-            method = HTTP_HEAD
-            path   = Utils.__pathify '_template', Utils.__escape(arguments[:name])
-
-            params = Utils.__validate_and_extract_params arguments, valid_params
-            body = nil
-
             perform_request(method, path, params, body).status == 200 ? true : false
           end
         end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/exists_type.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/exists_type.rb
@@ -23,23 +23,23 @@ module Elasticsearch
         # @see http://www.elasticsearch.org/guide/reference/api/admin-indices-types-exists/
         #
         def exists_type(arguments={})
+          raise ArgumentError, "Required argument 'index' missing" unless arguments[:index]
+          raise ArgumentError, "Required argument 'type' missing" unless arguments[:type]
+          valid_params = [
+            :ignore_indices,
+            :ignore_unavailable,
+            :allow_no_indices,
+            :expand_wildcards,
+            :local
+          ]
+
+          method = HTTP_HEAD
+          path   = Utils.__pathify Utils.__listify(arguments[:index]), Utils.__escape(arguments[:type])
+
+          params = Utils.__validate_and_extract_params arguments, valid_params
+          body = nil
+
           Utils.__rescue_from_not_found do
-            raise ArgumentError, "Required argument 'index' missing" unless arguments[:index]
-            raise ArgumentError, "Required argument 'type' missing" unless arguments[:type]
-            valid_params = [
-              :ignore_indices,
-              :ignore_unavailable,
-              :allow_no_indices,
-              :expand_wildcards,
-              :local
-            ]
-
-            method = HTTP_HEAD
-            path   = Utils.__pathify Utils.__listify(arguments[:index]), Utils.__escape(arguments[:type])
-
-            params = Utils.__validate_and_extract_params arguments, valid_params
-            body = nil
-
             perform_request(method, path, params, body).status == 200 ? true : false
           end
         end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/exists_type.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/exists_type.rb
@@ -23,28 +23,24 @@ module Elasticsearch
         # @see http://www.elasticsearch.org/guide/reference/api/admin-indices-types-exists/
         #
         def exists_type(arguments={})
-          raise ArgumentError, "Required argument 'index' missing" unless arguments[:index]
-          raise ArgumentError, "Required argument 'type' missing" unless arguments[:type]
-          valid_params = [
-            :ignore_indices,
-            :ignore_unavailable,
-            :allow_no_indices,
-            :expand_wildcards,
-            :local
-          ]
+          Utils.__rescue_from_not_found do
+            raise ArgumentError, "Required argument 'index' missing" unless arguments[:index]
+            raise ArgumentError, "Required argument 'type' missing" unless arguments[:type]
+            valid_params = [
+              :ignore_indices,
+              :ignore_unavailable,
+              :allow_no_indices,
+              :expand_wildcards,
+              :local
+            ]
 
-          method = HTTP_HEAD
-          path   = Utils.__pathify Utils.__listify(arguments[:index]), Utils.__escape(arguments[:type])
+            method = HTTP_HEAD
+            path   = Utils.__pathify Utils.__listify(arguments[:index]), Utils.__escape(arguments[:type])
 
-          params = Utils.__validate_and_extract_params arguments, valid_params
-          body = nil
+            params = Utils.__validate_and_extract_params arguments, valid_params
+            body = nil
 
-          perform_request(method, path, params, body).status == 200 ? true : false
-        rescue Exception => e
-          if e.class.to_s =~ /NotFound/ || e.message =~ /Not\s*Found|404/i
-            false
-          else
-            raise e
+            perform_request(method, path, params, body).status == 200 ? true : false
           end
         end
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/ping.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/ping.rb
@@ -11,12 +11,12 @@ module Elasticsearch
       # @see http://elasticsearch.org/guide/
       #
       def ping(arguments={})
-        Utils.__rescue_from_not_found do
-          method = HTTP_HEAD
-          path   = ""
-          params = {}
-          body   = nil
+        method = HTTP_HEAD
+        path   = ""
+        params = {}
+        body   = nil
 
+        Utils.__rescue_from_not_found do
           perform_request(method, path, params, body).status == 200 ? true : false
         end
       end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/ping.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/ping.rb
@@ -11,18 +11,14 @@ module Elasticsearch
       # @see http://elasticsearch.org/guide/
       #
       def ping(arguments={})
-        method = HTTP_HEAD
-        path   = ""
-        params = {}
-        body   = nil
+        Utils.__rescue_from_not_found do
+          method = HTTP_HEAD
+          path   = ""
+          params = {}
+          body   = nil
 
-        perform_request(method, path, params, body).status == 200 ? true : false
-        rescue Exception => e
-          if e.class.to_s =~ /NotFound/ || e.message =~ /Not\s*Found|404/i
-            false
-          else
-            raise e
-          end
+          perform_request(method, path, params, body).status == 200 ? true : false
+        end
       end
     end
   end

--- a/elasticsearch-api/lib/elasticsearch/api/utils.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/utils.rb
@@ -178,6 +178,23 @@ module Elasticsearch
         return parts
       end
 
+      # Calls given block, rescuing from any exceptions. Returns `false`
+      # if exception contains NotFound/404 in its class name or message, else re-raises exception.
+      #
+      # @yield [block] A block of code to be executed with exception handling.
+      #
+      # @api private
+      #
+      def __rescue_from_not_found(&block)
+        yield
+      rescue Exception => e
+        if e.class.to_s =~ /NotFound/ || e.message =~ /Not\s*Found|404/i
+          false
+        else
+          raise e
+        end
+      end
+
       extend self
     end
   end

--- a/elasticsearch-api/test/unit/utils_test.rb
+++ b/elasticsearch-api/test/unit/utils_test.rb
@@ -200,6 +200,28 @@ module Elasticsearch
 
         end
 
+        context "__rescue_from_not_found" do
+
+          should "return false if exception class name contains 'NotFound'" do
+            assert_equal( false, __rescue_from_not_found { raise NotFound })
+          end
+
+          should "return false if exception message contains 'Not Found'" do
+            assert_equal( false, __rescue_from_not_found { raise Exception.new "Not Found" })
+          end
+
+          should "return false if exception message contains '404'" do
+            assert_equal( false, __rescue_from_not_found { raise Exception.new "404" })
+          end
+
+          should "raise exception if exception class name and message do not contain NotFound/404" do
+            assert_raise Exception do
+              __rescue_from_not_found { raise Exception.new "Any other exception" }
+            end
+          end
+
+        end
+
       end
     end
   end


### PR DESCRIPTION
I noticed a bit of duplication in the 404/NotFound exception handling across several of the classes under Elasticsearch::API.  This pull request should clear that up.

 - Util#__rescue_from_not_found method to standardize NotFound handling
 - Unit tests for the new method
 - YARD documentation for the new method