### PR TITLE
[CLIENT] Make Typhoeus work out of the box

### DIFF
--- a/elasticsearch-transport/README.md
+++ b/elasticsearch-transport/README.md
@@ -29,7 +29,7 @@ Features overview:
 
 For optimal performance, you should use a HTTP library which supports persistent ("keep-alive") connections,
 e.g. [Patron](https://github.com/toland/patron) or [Typhoeus](https://github.com/typhoeus/typhoeus).
-Just `require 'patron'` or `require 'typhoeus'; require 'typhoeus/adapters/faraday'` in your code,
+Just `require 'patron'` or `require 'typhoeus'` in your code,
 and it will be automatically used; other automatically used libraries are
 [HTTPClient](https://rubygems.org/gems/httpclient) and
 [Net::HTTP::Persistent](https://rubygems.org/gems/net-http-persistent).

--- a/elasticsearch-transport/lib/elasticsearch/transport/client.rb
+++ b/elasticsearch-transport/lib/elasticsearch/transport/client.rb
@@ -99,7 +99,9 @@ module Elasticsearch
         @transport       = arguments[:transport] || begin
           if transport_class == Transport::HTTP::Faraday
             transport_class.new(:hosts => __extract_hosts(hosts, arguments), :options => arguments) do |faraday|
-              faraday.adapter(arguments[:adapter] || __auto_detect_adapter)
+              adapter = arguments[:adapter] || __auto_detect_adapter
+              require "typhoeus/adapters/faraday" if adapter == :typhoeus
+              faraday.adapter(adapter)
             end
           else
             transport_class.new(:hosts => __extract_hosts(hosts, arguments), :options => arguments)


### PR DESCRIPTION
I'm wanted to use Typhoeus for Elasticsearch, but I got [`The option: disable_ssl_peer_verification is invalid. (Ethon::Errors::InvalidOption)`](https://github.com/toptal/chewy/issues/22). This is because I forgot to require the official adapter (`typhoeus/adapters/faraday`). I was thinking that it would be make sense if it was automatically required, so that it works out-of-the-box.

By the way, I started using Elasticsearch only a week ago, and I'm really loving the separation of gems you guys made for Elasticsearch, it's just so easy to find everything.