### PR TITLE
Manticore SSL Enhancements

### DIFF
--- a/elasticsearch-transport/elasticsearch-transport.gemspec
+++ b/elasticsearch-transport/elasticsearch-transport.gemspec
@@ -46,7 +46,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency "curb"   unless defined? JRUBY_VERSION
   s.add_development_dependency "patron" unless defined? JRUBY_VERSION
   s.add_development_dependency "typhoeus", '~> 0.6'
-  s.add_development_dependency "manticore" if defined? JRUBY_VERSION
+  s.add_development_dependency "manticore", '~> 0.3.5' if defined? JRUBY_VERSION
 
   # Prevent unit test failures on Ruby 1.8
   if defined?(RUBY_VERSION) && RUBY_VERSION < '1.9'

--- a/elasticsearch-transport/test/unit/transport_manticore_test.rb
+++ b/elasticsearch-transport/test/unit/transport_manticore_test.rb
@@ -99,12 +99,8 @@ else
           }
         }
 
-        ::Manticore::Client.expects(:new).with(:options => {:ignore_ssl_validation => true})
-
+        ::Manticore::Client.expects(:new).with(options)
         transport = Manticore.new :hosts => [ { :host => 'foobar', :port => 1234 } ], :options => options
-
-        assert_equal java.lang.System.getProperty("javax.net.ssl.trustStore"), "test.jks"
-        assert_equal java.lang.System.getProperty("javax.net.ssl.trustStorePassword"), "test"
       end
     end
 


### PR DESCRIPTION

Manticore now has robust, well-tested SSL support for various options, including truststore and keystore. This PR refactors that adaptor to rely on this functionality. One nice benefit here is that we're not manipulating a JVM-level setting for setting trusted CA certificates. We also gain support for client certificates via Manticore in the process.

On the topic of testing, most of this was not well tested to begin with in this gem. This has largely been addressed by good unit tests for SSL features in Manticore itself, and for my part, I have tested integrating these changes into our environment, which mandates client certificates, with good results.

The following demonstrates how to use this new functionality:

    require 'manticore'
    require 'elasticsearch'
    require 'elasticsearch/transport'
    require 'elasticsearch/transport/transport/http/manticore'

    client = Elasticsearch::Client.new(
      :url             => 'https://elasticsearch.example.org',
      :transport_class => Elasticsearch::Transport::Transport::HTTP::Manticore,
      :ssl             => {
        :truststore          => '/tmp/truststore.jks',
        :truststore_password => 'password',
        :keystore            => '/tmp/keystore.jks',
        :keystore_password   => 'password',
      }
    )
    puts client.cluster.health.inspect