### PR TITLE
Correct documentation around the indices.validate_query method

### DIFF
--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/validate_query.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/validate_query.rb
@@ -38,7 +38,7 @@ module Elasticsearch
         #                                 use `_all` or empty string to perform the operation on all indices
         # @option arguments [List] :type A comma-separated list of document types to restrict the operation;
         #                                leave empty to perform the operation on all types
-        # @option arguments [Hash] :body The query definition (*without* the top-level `query` element)
+        # @option arguments [Hash] :body The query definition (The query being sent in the body must be nested in a query key, same as the search api)
         # @option arguments [Boolean] :allow_no_indices Whether to ignore if a wildcard indices expression resolves into
         #                                               no concrete indices. (This includes `_all` string or when no
         #                                               indices have been specified)


### PR DESCRIPTION
Correct documentation around the indices.validate_query method and the 'body' key of the options hash. This has been incorrect since 1.0.0 RC1