### PR TITLE
Fix repeated spelling mistake

### DIFF
--- a/elasticsearch-api/lib/elasticsearch/api/actions/bulk.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/bulk.rb
@@ -50,7 +50,7 @@ module Elasticsearch
       # @option arguments [String]  :consistency Explicit write consistency setting for the operation
       #                             (options: one, quorum, all)
       # @option arguments [Boolean] :refresh Refresh the index after performing the operation
-      # @option arguments [String]  :replication Explicitely set the replication type (options: sync, async)
+      # @option arguments [String]  :replication Explicitly set the replication type (options: sync, async)
       # @option arguments [Time]    :timeout Explicit operation timeout
       #
       # @return [Hash] Deserialized Elasticsearch response

--- a/elasticsearch-api/lib/elasticsearch/api/actions/cluster/reroute.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/cluster/reroute.rb
@@ -16,7 +16,7 @@ module Elasticsearch
         #       ]
         #     }
         #
-        # @note If you want to explicitely set the shard allocation to a certain node, you might
+        # @note If you want to explicitly set the shard allocation to a certain node, you might
         #       want to look at the `allocation.*` cluster settings.
         #
         # @option arguments [Hash] :body The definition of `commands` to perform (`move`, `cancel`, `allocate`)

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/refresh.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/refresh.rb
@@ -8,7 +8,7 @@ module Elasticsearch
         # By default, Elasticsearch has a delay of 1 second until changes to an index are
         # available for search; the delay is configurable, see {Indices::Actions#put_settings}.
         #
-        # You can trigger this operation explicitely, for example when performing a sequence of commands
+        # You can trigger this operation explicitly, for example when performing a sequence of commands
         # in integration tests, or when you need to perform a manual "synchronization" of the index
         # with an external system at given moment.
         #

--- a/elasticsearch-api/lib/elasticsearch/api/actions/snapshot/verify_repository.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/snapshot/verify_repository.rb
@@ -3,7 +3,7 @@ module Elasticsearch
     module Snapshot
       module Actions
 
-        # Explicitely perform the verification of a repository
+        # Explicitly perform the verification of a repository
         #
         # @option arguments [String] :repository A repository name (*Required*)
         # @option arguments [Time] :master_timeout Explicit operation timeout for connection to master node


### PR DESCRIPTION
Spotted this in multiple places when referring to the docs.