### PR TITLE
[CLIENT] Use curl's default resolver (CURL_IPRESOLVE_WHATEVER)

### DIFF
--- a/elasticsearch-transport/lib/elasticsearch/transport/transport/http/curb.rb
+++ b/elasticsearch-transport/lib/elasticsearch/transport/transport/http/curb.rb
@@ -48,7 +48,6 @@ module Elasticsearch
                 host[:port]     ||= DEFAULT_PORT
 
                 client = ::Curl::Easy.new
-                client.resolve_mode = :ipv4
                 client.headers      = {'User-Agent' => "Curb #{Curl::CURB_VERSION}"}
                 client.url          = __full_url(host)
 


### PR DESCRIPTION
Hello!

We are deploying an ipv6-only ES cluster and we are having issues with the enforced resolver.

Curb http transport is broken with ipv6 servers. We shouldn't
enforce an IPv4 resolver, libcurl will do the right thing and use
IPv6 only when a AAAA DNS record exists.

Thank you
