### PR TITLE
try INT then KILL on test cluster shutdown

### DIFF
--- a/elasticsearch-extensions/lib/elasticsearch/extensions/test/cluster.rb
+++ b/elasticsearch-extensions/lib/elasticsearch/extensions/test/cluster.rb
@@ -172,18 +172,24 @@ module Elasticsearch
             pids.each_with_index do |pid, i|
               ['INT','KILL'].each do |signal|
                 begin
-                  print "stopped PID #{pid} with #{signal} signal. ".ansi(:green) if Process.kill signal, pid
-                  break # we get here, kill success on current signal
+                  #puts "Attempting shutdown of #{pid} with #{signal} signal"
+                  Process.kill signal, pid
                 rescue Exception => e
                   print "[#{e.class}] PID #{pid} not found. ".ansi(:red)
                 end
+               
+                # give system some breathing space to finish
+                sleep 1
+ 
                 # check that pid really is dead
                 begin
                   Process.getpgid( pid )
                   # getpgid will raise error if pid is dead, 
                   # so if we get here, try next signal.
+                  #puts "Found live pid #{pid}"
                   next
                 rescue Errno::ESRCH
+                  print "stopped PID #{pid} with #{signal} signal. ".ansi(:green)
                   break # pid is dead
                 end
               end

--- a/elasticsearch-extensions/lib/elasticsearch/extensions/test/cluster.rb
+++ b/elasticsearch-extensions/lib/elasticsearch/extensions/test/cluster.rb
@@ -170,10 +170,22 @@ module Elasticsearch
           unless pids.empty?
             print "\nStopping Elasticsearch nodes... ".ansi(:faint)
             pids.each_with_index do |pid, i|
-              begin
-                print "stopped PID #{pid}. ".ansi(:green) if Process.kill 'INT', pid
-              rescue Exception => e
-                print "[#{e.class}] PID #{pid} not found. ".ansi(:red)
+              ['INT','KILL'].each do |signal|
+                begin
+                  print "stopped PID #{pid} with #{signal} signal. ".ansi(:green) if Process.kill signal, pid
+                  break # we get here, kill success on current signal
+                rescue Exception => e
+                  print "[#{e.class}] PID #{pid} not found. ".ansi(:red)
+                end
+                # check that pid really is dead
+                begin
+                  Process.getpgid( pid )
+                  # getpgid will raise error if pid is dead, 
+                  # so if we get here, try next signal.
+                  next
+                rescue Errno::ESRCH
+                  break # pid is dead
+                end
               end
             end
             puts


### PR DESCRIPTION
Follow on to #108 this patch attempts to kill the test cluster first with INT then with KILL.

seems like a lot of code bloat though, when the KILL Just Works (even if unfriendly). My feelings would not be hurt if you just reverted to the original KILL behavior from pre-#108 code.