### PR TITLE
respect transport_options in manticore transport

### DIFF
--- a/elasticsearch-transport/lib/elasticsearch/transport/transport/http/manticore.rb
+++ b/elasticsearch-transport/lib/elasticsearch/transport/transport/http/manticore.rb
@@ -84,7 +84,8 @@ module Elasticsearch
               @request_options[:headers] = options[:headers]
             end
 
-            client_options = {:ssl => options[:ssl] || {}}
+            client_options = options[:transport_options] || {}
+            client_options[:ssl] = options[:ssl] || {}
 
             Connections::Collection.new \
               :connections => hosts.map { |host|

--- a/elasticsearch-transport/test/unit/transport_manticore_test.rb
+++ b/elasticsearch-transport/test/unit/transport_manticore_test.rb
@@ -102,6 +102,15 @@ else
         ::Manticore::Client.expects(:new).with(options)
         transport = Manticore.new :hosts => [ { :host => 'foobar', :port => 1234 } ], :options => options
       end
+
+      should "pass :transport_options to Manticore::Client" do
+        options = {
+          :transport_options => { :potatoes => 1 }
+        }
+
+        ::Manticore::Client.expects(:new).with(:potatoes => 1, :ssl => {})
+        transport = Manticore.new :hosts => [ { :host => 'foobar', :port => 1234 } ], :options => options
+      end
     end
 
   end


### PR DESCRIPTION
Elasticsearch::Client.new can have a :transport_options hash and manticore transport wasn't respecting that.

This patch takes that hash and forwards it to ::Manticore::Client.new