### PR TITLE
Add a network_host argument to Elasticsearch::Extensions::Test::Cluster

### DIFF
--- a/elasticsearch-extensions/lib/elasticsearch/extensions/test/cluster.rb
+++ b/elasticsearch-extensions/lib/elasticsearch/extensions/test/cluster.rb
@@ -51,6 +51,7 @@ module Elasticsearch
         # @option arguments [String]  :path_work    Path to the directory with auxiliary files
         # @option arguments [Boolean] :multicast_enabled Whether multicast is enabled (default: true)
         # @option arguments [Integer] :timeout      Timeout when starting the cluster (default: 30)
+        # @option arguments [String]  :network_host The host that nodes will bind on and publish to
         #
         # You can also use environment variables to set these options.
         #
@@ -83,6 +84,7 @@ module Elasticsearch
           arguments[:es_params]         ||= ENV.fetch('TEST_CLUSTER_PARAMS',    '')
           arguments[:multicast_enabled] ||= ENV.fetch('TEST_CLUSTER_MULTICAST', 'true')
           arguments[:timeout]           ||= (ENV.fetch('TEST_CLUSTER_TIMEOUT', 30).to_i)
+          arguments[:network_host]      ||= ENV.fetch('TEST_CLUSTER_NETWORK_HOST', '0.0.0.0')
 
           # Make sure `cluster_name` is not dangerous
           if arguments[:cluster_name] =~ /^[\/\\]?$/
@@ -115,7 +117,7 @@ module Elasticsearch
                 -D es.path.data=#{arguments[:path_data]} \
                 -D es.path.work=#{arguments[:path_work]} \
                 -D es.cluster.routing.allocation.disk.threshold_enabled=false \
-                -D es.network.host=0.0.0.0 \
+                -D es.network.host=#{arguments[:network_host]} \
                 -D es.discovery.zen.ping.multicast.enabled=#{arguments[:multicast_enabled]} \
                 -D es.script.inline=on \
                 -D es.script.indexed=on \


### PR DESCRIPTION
Using a `network.host` of `0.0.0.0` fails for me (tested with Linux Mint 17.1, and both Elasticsearch 1.4.5 and 2.0.0). If I run with the default two nodes, they never manage to find one another. The launch times out and (although I can `test:cluster:stop` the first node) I have to manually kill the second node. 

Setting the value to `127.0.0.1` solves the problem. I've added an argument to allow people to configure the network host. This defaults to the value that was originally hard-coded so the change should not affect people who don't set it.

I couldn't find any tests covering this but please let me know if there are any that need changing.