### PR TITLE
Expose Request Objects For API Actions

### DIFF
--- a/elasticsearch-api/lib/elasticsearch/api/actions/abort_benchmark.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/abort_benchmark.rb
@@ -13,14 +13,16 @@ module Elasticsearch
       # @see http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/search-benchmark.html
       #
       def abort_benchmark(arguments={})
-        valid_params = [
-           ]
+        abort_benchmark_request_for(arguments).body
+      end
+
+      def abort_benchmark_request_for(arguments={})
         method = HTTP_POST
         path   = "_bench/abort/#{arguments[:name]}"
         params = {}
         body   = nil
 
-        perform_request(method, path, params, body).body
+        perform_request(method, path, params, body)
       end
     end
   end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/benchmark.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/benchmark.rb
@@ -2,6 +2,8 @@ module Elasticsearch
   module API
     module Actions
 
+      VALID_BENCHMARK_PARAMS = [ :verbose ].freeze
+
       # Run a single query, or a set of queries, and return statistics on their performance
       #
       # @example Return statistics for a single query
@@ -48,14 +50,16 @@ module Elasticsearch
       # @see http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/search-benchmark.html
       #
       def benchmark(arguments={})
-        valid_params = [
-          :verbose ]
+        benchmark_request_for(arguments).body
+      end
+
+      def benchmark_request_for(arguments={})
         method = HTTP_PUT
         path   = "_bench"
-        params = Utils.__validate_and_extract_params arguments, valid_params
+        params = Utils.__validate_and_extract_params arguments, VALID_BENCHMARK_PARAMS
         body   = arguments[:body]
 
-        perform_request(method, path, params, body).body
+        perform_request(method, path, params, body)
       end
     end
   end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/bulk.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/bulk.rb
@@ -2,6 +2,14 @@ module Elasticsearch
   module API
     module Actions
 
+      VALID_BULK_PARAMS = [
+        :consistency,
+        :refresh,
+        :replication,
+        :type,
+        :timeout
+      ].freeze
+
       # Perform multiple index, delete or update operations in a single request.
       #
       # Pass the operations in the `:body` option as an array of hashes, following Elasticsearch conventions.
@@ -58,17 +66,14 @@ module Elasticsearch
       # @see http://elasticsearch.org/guide/reference/api/bulk/
       #
       def bulk(arguments={})
-        valid_params = [
-          :consistency,
-          :refresh,
-          :replication,
-          :type,
-          :timeout ]
+        bulk_request_for(arguments).body
+      end
 
+      def bulk_request_for(arguments={})
         method = HTTP_POST
         path   = Utils.__pathify Utils.__escape(arguments[:index]), Utils.__escape(arguments[:type]), '_bulk'
 
-        params = Utils.__validate_and_extract_params arguments, valid_params
+        params = Utils.__validate_and_extract_params arguments, VALID_BULK_PARAMS
         body   = arguments[:body]
 
         if body.is_a? Array
@@ -77,7 +82,7 @@ module Elasticsearch
           payload = body
         end
 
-        perform_request(method, path, params, payload).body
+        perform_request(method, path, params, payload)
       end
     end
   end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/cat/aliases.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/cat/aliases.rb
@@ -3,6 +3,14 @@ module Elasticsearch
     module Cat
       module Actions
 
+        VALID_ALIASES_PARAMS = [
+          :local,
+          :master_timeout,
+          :h,
+          :help,
+          :v
+        ].freeze
+
         # Returns information about aliases, including associated routing values and filters.
         #
         # @example Display all aliases in the cluster
@@ -41,12 +49,10 @@ module Elasticsearch
         # @see http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/cat-aliases.html
         #
         def aliases(arguments={})
-          valid_params = [
-            :local,
-            :master_timeout,
-            :h,
-            :help,
-            :v ]
+          aliases_request_for(arguments).body
+        end
+
+        def aliases_request_for(arguments={})
 
           name = arguments.delete(:name)
 
@@ -54,12 +60,12 @@ module Elasticsearch
 
           path   = Utils.__pathify '_cat/aliases', Utils.__listify(name)
 
-          params = Utils.__validate_and_extract_params arguments, valid_params
+          params = Utils.__validate_and_extract_params arguments, VALID_ALIASES_PARAMS
           params[:h] = Utils.__listify(params[:h]) if params[:h]
 
           body   = nil
 
-          perform_request(method, path, params, body).body
+          perform_request(method, path, params, body)
         end
       end
     end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/cat/allocation.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/cat/allocation.rb
@@ -3,6 +3,15 @@ module Elasticsearch
     module Cat
       module Actions
 
+        VALID_ALLOCATION_PARAMS = [
+          :bytes,
+          :local,
+          :master_timeout,
+          :h,
+          :help,
+          :v
+          ].freeze
+
         # Return shard allocation information
         #
         # @example Display allocation for all nodes in the cluster
@@ -42,26 +51,22 @@ module Elasticsearch
         # @see http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/cat-allocation.html
         #
         def allocation(arguments={})
-          valid_params = [
-            :bytes,
-            :local,
-            :master_timeout,
-            :h,
-            :help,
-            :v ]
+          allocation_request_for(arguments).body
+        end
 
+        def allocation_request_for(arguments={})
           node_id = arguments.delete(:node_id)
 
           method = HTTP_GET
 
           path   = Utils.__pathify '_cat/allocation', Utils.__listify(node_id)
 
-          params = Utils.__validate_and_extract_params arguments, valid_params
+          params = Utils.__validate_and_extract_params arguments, VALID_ALLOCATION_PARAMS
           params[:h] = Utils.__listify(params[:h]) if params[:h]
 
           body   = nil
 
-          perform_request(method, path, params, body).body
+          perform_request(method, path, params, body)
         end
       end
     end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/cat/count.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/cat/count.rb
@@ -3,6 +3,14 @@ module Elasticsearch
     module Cat
       module Actions
 
+        VALID_COUNT_PARAMS = [
+          :local,
+          :master_timeout,
+          :h,
+          :help,
+          :v
+        ].freeze
+
         # Return document counts for the entire cluster or specific indices
         #
         # @example Display number of documents in the cluster
@@ -37,25 +45,22 @@ module Elasticsearch
         # @see http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/cat-count.html
         #
         def count(arguments={})
-          valid_params = [
-            :local,
-            :master_timeout,
-            :h,
-            :help,
-            :v ]
+          count_request_for(arguments).body
+        end
 
+        def count_request_for(arguments={})
           index = arguments.delete(:index)
 
           method = HTTP_GET
 
           path   = Utils.__pathify '_cat/count', Utils.__listify(index)
 
-          params = Utils.__validate_and_extract_params arguments, valid_params
+          params = Utils.__validate_and_extract_params arguments, VALID_COUNT_PARAMS
           params[:h] = Utils.__listify(params[:h]) if params[:h]
 
           body   = nil
 
-          perform_request(method, path, params, body).body
+          perform_request(method, path, params, body)
         end
       end
     end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/cat/fielddata.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/cat/fielddata.rb
@@ -3,6 +3,16 @@ module Elasticsearch
     module Cat
       module Actions
 
+        VALID_FIELDDATA_PARAMS = [
+          :bytes,
+          :local,
+          :master_timeout,
+          :h,
+          :help,
+          :v,
+          :fields
+        ].freeze
+
         # Return information about field data usage across the cluster
         #
         # @example Return the total size of field data
@@ -25,23 +35,18 @@ module Elasticsearch
         # @see http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/cat-fielddata.html
         #
         def fielddata(arguments={})
-          valid_params = [
-            :bytes,
-            :local,
-            :master_timeout,
-            :h,
-            :help,
-            :v,
-            :fields ]
+          fielddata_request_for(arguments).body
+        end
 
+        def fielddata_request_for(arguments={})
           fields = arguments.delete(:fields)
 
           method = HTTP_GET
           path   = Utils.__pathify "_cat/fielddata", Utils.__listify(fields)
-          params = Utils.__validate_and_extract_params arguments, valid_params
+          params = Utils.__validate_and_extract_params arguments, VALID_FIELDDATA_PARAMS
           body   = nil
 
-          perform_request(method, path, params, body).body
+          perform_request(method, path, params, body)
         end
       end
     end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/cat/health.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/cat/health.rb
@@ -3,6 +3,15 @@ module Elasticsearch
     module Cat
       module Actions
 
+        VALID_HEALTH_PARAMS = [
+          :local,
+          :master_timeout,
+          :h,
+          :help,
+          :ts,
+          :v
+        ].freeze
+
         # Display a terse version of the {Elasticsearch::API::Cluster::Actions#health} API output
         #
         # @example Display cluster health
@@ -29,21 +38,17 @@ module Elasticsearch
         # @see http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/cat-health.html
         #
         def health(arguments={})
-          valid_params = [
-            :local,
-            :master_timeout,
-            :h,
-            :help,
-            :ts,
-            :v ]
+          health_request_for(arguments).body
+        end
 
+        def health_request_for(arguments={})
           method = HTTP_GET
           path   = "_cat/health"
-          params = Utils.__validate_and_extract_params arguments, valid_params
+          params = Utils.__validate_and_extract_params arguments, VALID_HEALTH_PARAMS
           params[:h] = Utils.__listify(params[:h]) if params[:h]
           body   = nil
 
-          perform_request(method, path, params, body).body
+          perform_request(method, path, params, body)
         end
       end
     end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/cat/help.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/cat/help.rb
@@ -3,6 +3,8 @@ module Elasticsearch
     module Cat
       module Actions
 
+        VALID_HELP_PARAMS = [ :help ].freeze
+
         # Help information for the Cat API
         #
         # @option arguments [Boolean] :help Return help information
@@ -10,14 +12,16 @@ module Elasticsearch
         # @see http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/cat.html
         #
         def help(arguments={})
-          valid_params = [
-            :help ]
+          help_request_for(arguments).body
+        end
+
+        def help_request_for(arguments={})
           method = HTTP_GET
           path   = "_cat"
-          params = Utils.__validate_and_extract_params arguments, valid_params
+          params = Utils.__validate_and_extract_params arguments, VALID_HELP_PARAMS
           body   = nil
 
-          perform_request(method, path, params, body).body
+          perform_request(method, path, params, body)
         end
       end
     end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/cat/indices.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/cat/indices.rb
@@ -3,6 +3,16 @@ module Elasticsearch
     module Cat
       module Actions
 
+        VALID_INDICES_PARAMS = [
+          :bytes,
+          :local,
+          :master_timeout,
+          :h,
+          :help,
+          :pri,
+          :v
+        ].freeze
+
         # Return the most important statistics about indices, across the cluster nodes
         #
         # Use the `help` parameter to display available statistics.
@@ -49,27 +59,22 @@ module Elasticsearch
         # @see http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/cat-indices.html
         #
         def indices(arguments={})
-          valid_params = [
-            :bytes,
-            :local,
-            :master_timeout,
-            :h,
-            :help,
-            :pri,
-            :v ]
+          indices_request_for(arguments).body
+        end
 
+        def indices_request_for(arguments={})
           index = arguments.delete(:index)
 
           method = HTTP_GET
 
           path   = Utils.__pathify '_cat/indices', Utils.__listify(index)
 
-          params = Utils.__validate_and_extract_params arguments, valid_params
+          params = Utils.__validate_and_extract_params arguments, VALID_INDICES_PARAMS
           params[:h] = Utils.__listify(params[:h]) if params[:h]
 
           body   = nil
 
-          perform_request(method, path, params, body).body
+          perform_request(method, path, params, body)
         end
       end
     end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/cat/master.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/cat/master.rb
@@ -3,6 +3,14 @@ module Elasticsearch
     module Cat
       module Actions
 
+        VALID_MASTER_PARAMS = [
+          :local,
+          :master_timeout,
+          :h,
+          :help,
+          :v
+        ].freeze
+
         # Display basic information about the master node
         #
         # @example
@@ -28,19 +36,16 @@ module Elasticsearch
         # @see http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/cat-master.html
         #
         def master(arguments={})
-          valid_params = [
-            :local,
-            :master_timeout,
-            :h,
-            :help,
-            :v ]
+          master_request_for(arguments).body
+        end
 
+        def master_request_for(arguments={})
           method = HTTP_GET
           path   = "_cat/master"
-          params = Utils.__validate_and_extract_params arguments, valid_params
+          params = Utils.__validate_and_extract_params arguments, VALID_MASTER_PARAMS
           body   = nil
 
-          perform_request(method, path, params, body).body
+          perform_request(method, path, params, body)
         end
       end
     end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/cat/nodes.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/cat/nodes.rb
@@ -3,6 +3,14 @@ module Elasticsearch
     module Cat
       module Actions
 
+        VALID_NODES_PARAMS = [
+          :local,
+          :master_timeout,
+          :h,
+          :help,
+          :v
+        ].freeze
+
         # Display information about cluster topology and nodes statistics
         #
         # @example Display basic information about nodes in the cluster (host, node name, memory usage, master, etc.)
@@ -36,22 +44,19 @@ module Elasticsearch
         # @see http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/cat-nodes.html
         #
         def nodes(arguments={})
-          valid_params = [
-            :local,
-            :master_timeout,
-            :h,
-            :help,
-            :v ]
+          nodes_request_for(arguments).body
+        end
 
+        def nodes_request_for(arguments={})
           method = HTTP_GET
           path   = "_cat/nodes"
 
-          params = Utils.__validate_and_extract_params arguments, valid_params
+          params = Utils.__validate_and_extract_params arguments, VALID_NODES_PARAMS
           params[:h] = Utils.__listify(params[:h], :escape => false) if params[:h]
 
           body   = nil
 
-          perform_request(method, path, params, body).body
+          perform_request(method, path, params, body)
         end
       end
     end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/cat/pending_tasks.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/cat/pending_tasks.rb
@@ -3,6 +3,14 @@ module Elasticsearch
     module Cat
       module Actions
 
+        VALID_PENDING_TASKS_PARAMS = [
+          :local,
+          :master_timeout,
+          :h,
+          :help,
+          :v
+        ].freeze
+
         # Display the information from the {Cluster::Actions#pending_tasks} API in a tabular format
         #
         # @example
@@ -28,20 +36,17 @@ module Elasticsearch
         # @see http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/cat-pending-tasks.html
         #
         def pending_tasks(arguments={})
-          valid_params = [
-            :local,
-            :master_timeout,
-            :h,
-            :help,
-            :v ]
+          pending_tasks_request_for(arguments).body
+        end
 
+        def pending_tasks_request_for(arguments={})
           method = HTTP_GET
           path   = "_cat/pending_tasks"
-          params = Utils.__validate_and_extract_params arguments, valid_params
+          params = Utils.__validate_and_extract_params arguments, VALID_PENDING_TASKS_PARAMS
           params[:h] = Utils.__listify(params[:h]) if params[:h]
           body   = nil
 
-          perform_request(method, path, params, body).body
+          perform_request(method, path, params, body)
         end
       end
     end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/cat/plugins.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/cat/plugins.rb
@@ -3,6 +3,14 @@ module Elasticsearch
     module Cat
       module Actions
 
+        VALID_PLUGINS_PARAMS = [
+          :local,
+          :master_timeout,
+          :h,
+          :help,
+          :v
+        ].freeze
+
         # Return information about installed plugins
         #
         # @option arguments [Boolean] :local Return local information, do not retrieve the state from master node
@@ -15,18 +23,16 @@ module Elasticsearch
         # @see http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-plugins.html
         #
         def plugins(arguments={})
-          valid_params = [
-            :local,
-            :master_timeout,
-            :h,
-            :help,
-            :v ]
+          plugins_request_for(arguments).body
+        end
+
+        def plugins_request_for(arguments={})
           method = 'GET'
           path   = "/_cat/plugins"
-          params = Utils.__validate_and_extract_params arguments, valid_params
+          params = Utils.__validate_and_extract_params arguments, VALID_PLUGINS_PARAMS
           body   = nil
 
-          perform_request(method, path, params, body).body
+          perform_request(method, path, params, body)
         end
       end
     end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/cat/recovery.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/cat/recovery.rb
@@ -3,6 +3,15 @@ module Elasticsearch
     module Cat
       module Actions
 
+        VALID_RECOVERY_PARAMS = [
+          :bytes,
+          :local,
+          :master_timeout,
+          :h,
+          :help,
+          :v
+        ].freeze
+
         # Display information about the recovery process (allocating shards)
         #
         # @example Display information for all indices
@@ -46,26 +55,22 @@ module Elasticsearch
         # @see http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/cat-recovery.html
         #
         def recovery(arguments={})
-          valid_params = [
-            :bytes,
-            :local,
-            :master_timeout,
-            :h,
-            :help,
-            :v ]
+          recovery_request_for(arguments).body
+        end
 
+        def recovery_request_for(arguments={})
           index = arguments.delete(:index)
 
           method = HTTP_GET
 
           path   = Utils.__pathify '_cat/recovery', Utils.__listify(index)
 
-          params = Utils.__validate_and_extract_params arguments, valid_params
+          params = Utils.__validate_and_extract_params arguments, VALID_RECOVERY_PARAMS
           params[:h] = Utils.__listify(params[:h]) if params[:h]
 
           body   = nil
 
-          perform_request(method, path, params, body).body
+          perform_request(method, path, params, body)
         end
       end
     end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/cat/segments.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/cat/segments.rb
@@ -3,6 +3,12 @@ module Elasticsearch
     module Cat
       module Actions
 
+        VALID_SEGMENTS_PARAMS = [
+          :h,
+          :help,
+          :v
+        ].freeze
+
         # Display information about the segments in the shards of an index
         #
         # @example Display information for all indices
@@ -17,16 +23,16 @@ module Elasticsearch
         # @see http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/cat-segments.html
         #
         def segments(arguments={})
-          valid_params = [
-            :h,
-            :help,
-            :v ]
+          segments_request_for(arguments).body
+        end
+
+        def segments_request_for(arguments={})
           method = 'GET'
           path   = "_cat/segments"
-          params = Utils.__validate_and_extract_params arguments, valid_params
+          params = Utils.__validate_and_extract_params arguments, VALID_SEGMENTS_PARAMS
           body   = nil
 
-          perform_request(method, path, params, body).body
+          perform_request(method, path, params, body)
         end
       end
     end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/cat/shards.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/cat/shards.rb
@@ -3,6 +3,14 @@ module Elasticsearch
     module Cat
       module Actions
 
+        VALID_SHARDS_PARAMS = [
+          :local,
+          :master_timeout,
+          :h,
+          :help,
+          :v
+        ].freeze
+
         # Display shard allocation across nodes
         #
         # @example Display information for all indices
@@ -46,25 +54,22 @@ module Elasticsearch
         # @see http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/cat-shards.html
         #
         def shards(arguments={})
-          valid_params = [
-            :local,
-            :master_timeout,
-            :h,
-            :help,
-            :v ]
+          shards_request_for(arguments).body
+        end
 
+        def shards_request_for(arguments={})
           index = arguments.delete(:index)
 
           method = HTTP_GET
 
           path   = Utils.__pathify '_cat/shards', Utils.__listify(index)
 
-          params = Utils.__validate_and_extract_params arguments, valid_params
+          params = Utils.__validate_and_extract_params arguments, VALID_SHARDS_PARAMS
           params[:h] = Utils.__listify(params[:h]) if params[:h]
 
           body   = nil
 
-          perform_request(method, path, params, body).body
+          perform_request(method, path, params, body)
         end
       end
     end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/cat/thread_pool.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/cat/thread_pool.rb
@@ -3,6 +3,15 @@ module Elasticsearch
     module Cat
       module Actions
 
+        VALID_THREAD_POOL_PARAMS = [
+          :full_id,
+          :local,
+          :master_timeout,
+          :h,
+          :help,
+          :v
+        ].freeze
+
         # Display thread pool statistics across nodes (use the `help` parameter to display a list
         # of avaialable thread pools)
         #
@@ -34,21 +43,17 @@ module Elasticsearch
         # @see http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/cat-thread-pool.html
         #
         def thread_pool(arguments={})
-          valid_params = [
-            :full_id,
-            :local,
-            :master_timeout,
-            :h,
-            :help,
-            :v ]
+          thread_pool_request_for(arguments).body
+        end
 
+        def thread_pool_request_for(arguments={})
           method = HTTP_GET
           path   = "_cat/thread_pool"
-          params = Utils.__validate_and_extract_params arguments, valid_params
+          params = Utils.__validate_and_extract_params arguments, VALID_THREAD_POOL_PARAMS
           params[:h] = Utils.__listify(params[:h]) if params[:h]
           body   = nil
 
-          perform_request(method, path, params, body).body
+          perform_request(method, path, params, body)
         end
       end
     end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/clear_scroll.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/clear_scroll.rb
@@ -10,6 +10,10 @@ module Elasticsearch
       # @see http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/search-request-search-type.html#clear-scroll
       #
       def clear_scroll(arguments={})
+        clear_scroll_request_for(arguments).body
+      end
+
+      def clear_scroll_request_for(arguments={})
         raise ArgumentError, "Required argument 'scroll_id' missing" unless arguments[:scroll_id]
 
         scroll_id = arguments[:body] || arguments.delete(:scroll_id)
@@ -26,7 +30,7 @@ module Elasticsearch
         params = {}
         body   = scroll_ids
 
-        perform_request(method, path, params, body).body
+        perform_request(method, path, params, body)
       end
     end
   end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/cluster/get_settings.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/cluster/get_settings.rb
@@ -3,6 +3,8 @@ module Elasticsearch
     module Cluster
       module Actions
 
+        VALID_GET_SETTINGS_PARAMS = [ :flat_settings ].freeze
+
         # Get the cluster settings (previously set with {Cluster::Actions#put_settings})
         #
         # @example Get cluster settings
@@ -14,16 +16,16 @@ module Elasticsearch
         # @see http://elasticsearch.org/guide/reference/api/admin-cluster-update-settings/
         #
         def get_settings(arguments={})
-          valid_params = [
-            :flat_settings
-          ]
+          get_settings_request_for(arguments).body
+        end
 
+        def get_settings_request_for(arguments={})
           method = HTTP_GET
           path   = "_cluster/settings"
-          params = Utils.__validate_and_extract_params arguments, valid_params
+          params = Utils.__validate_and_extract_params arguments, VALID_GET_SETTINGS_PARAMS
           body   = nil
 
-          perform_request(method, path, params, body).body
+          perform_request(method, path, params, body)
         end
       end
     end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/cluster/health.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/cluster/health.rb
@@ -3,6 +3,17 @@ module Elasticsearch
     module Cluster
       module Actions
 
+        VALID_HEALTH_PARAMS = [
+          :level,
+          :local,
+          :master_timeout,
+          :timeout,
+          :wait_for_active_shards,
+          :wait_for_nodes,
+          :wait_for_relocating_shards,
+          :wait_for_status
+        ].freeze
+
         # Returns information about cluster "health".
         #
         # @example Get the cluster health information
@@ -30,23 +41,17 @@ module Elasticsearch
         # @see http://elasticsearch.org/guide/reference/api/admin-cluster-health/
         #
         def health(arguments={})
-          valid_params = [
-            :level,
-            :local,
-            :master_timeout,
-            :timeout,
-            :wait_for_active_shards,
-            :wait_for_nodes,
-            :wait_for_relocating_shards,
-            :wait_for_status ]
+          health_request_for(arguments).body
+        end
 
+        def health_request_for(arguments={})
           method = HTTP_GET
           path   = "_cluster/health"
 
-          params = Utils.__validate_and_extract_params arguments, valid_params
+          params = Utils.__validate_and_extract_params arguments, VALID_HEALTH_PARAMS
           body = nil
 
-          perform_request(method, path, params, body).body
+          perform_request(method, path, params, body)
         end
       end
     end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/cluster/pending_tasks.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/cluster/pending_tasks.rb
@@ -3,6 +3,11 @@ module Elasticsearch
     module Cluster
       module Actions
 
+        VALID_PENDINGS_TASKS_PARAMS = [
+          :local,
+          :master_timeout
+        ].freeze
+
         # Returns a list of any cluster-level changes (e.g. create index, update mapping, allocate or fail shard)
         # which have not yet been executed and are queued up.
         #
@@ -17,15 +22,16 @@ module Elasticsearch
         # @see http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/cluster-pending.html
         #
         def pending_tasks(arguments={})
-          valid_params = [
-            :local,
-            :master_timeout ]
+          pending_tasks_request_for(arguments).body
+        end
+
+        def pending_tasks_request_for(arguments={})
           method = HTTP_GET
           path   = "/_cluster/pending_tasks"
-          params = Utils.__validate_and_extract_params arguments, valid_params
+          params = Utils.__validate_and_extract_params arguments, VALID_PENDINGS_TASKS_PARAMS
           body   = nil
 
-          perform_request(method, path, params, body).body
+          perform_request(method, path, params, body)
         end
       end
     end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/cluster/put_settings.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/cluster/put_settings.rb
@@ -3,6 +3,8 @@ module Elasticsearch
     module Cluster
       module Actions
 
+        VALID_PUT_SETTINGS_PARAMS = [ :flat_settings ].freeze
+
         # Update cluster settings.
         #
         # @example Disable shard allocation in the cluster until restart
@@ -15,14 +17,16 @@ module Elasticsearch
         # @see http://elasticsearch.org/guide/reference/api/admin-cluster-update-settings/
         #
         def put_settings(arguments={})
-          valid_params = [ :flat_settings ]
+          put_settings_request_for(arguments).body
+        end
 
+        def put_settings_request_for(arguments={})
           method = HTTP_PUT
           path   = "_cluster/settings"
-          params = Utils.__validate_and_extract_params arguments, valid_params
+          params = Utils.__validate_and_extract_params arguments, VALID_PUT_SETTINGS_PARAMS
           body   = arguments[:body] || {}
 
-          perform_request(method, path, params, body).body
+          perform_request(method, path, params, body)
         end
       end
     end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/cluster/reroute.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/cluster/reroute.rb
@@ -3,6 +3,14 @@ module Elasticsearch
     module Cluster
       module Actions
 
+        VALID_REROUTE_PARAMS = [
+          :dry_run,
+          :explain,
+          :metric,
+          :master_timeout,
+          :timeout
+        ].freeze
+
         # Perform manual shard allocation in the cluster.
         #
         # Pass the operations you want to perform in the `:body` option. Use the `dry_run` option to
@@ -30,15 +38,17 @@ module Elasticsearch
         # @see http://elasticsearch.org/guide/reference/api/admin-cluster-reroute/
         #
         def reroute(arguments={})
-          valid_params = [ :dry_run, :explain, :metric, :master_timeout, :timeout ]
+          reroute_request_for(arguments).body
+        end
 
+        def reroute_request_for(arguments={})
           method = HTTP_POST
           path   = "_cluster/reroute"
 
-          params = Utils.__validate_and_extract_params arguments, valid_params
+          params = Utils.__validate_and_extract_params arguments, VALID_REROUTE_PARAMS
           body   = arguments[:body] || {}
 
-          perform_request(method, path, params, body).body
+          perform_request(method, path, params, body)
         end
       end
     end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/cluster/state.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/cluster/state.rb
@@ -3,6 +3,16 @@ module Elasticsearch
     module Cluster
       module Actions
 
+        VALID_STATE_PARAMS = [
+          :metric,
+          :index_templates,
+          :local,
+          :master_timeout,
+          :flat_settings,
+          :expand_wildcards,
+          :ignore_unavailable
+        ].freeze
+
         # Get information about the cluster state (indices settings, allocations, etc)
         #
         # @example
@@ -27,18 +37,13 @@ module Elasticsearch
         # @see http://elasticsearch.org/guide/reference/api/admin-cluster-state/
         #
         def state(arguments={})
+          state_request_for(arguments).body
+        end
+
+        def state_request_for(arguments={})
           arguments = arguments.clone
           index     = arguments.delete(:index)
           metric    = arguments.delete(:metric)
-
-          valid_params = [
-            :metric,
-            :index_templates,
-            :local,
-            :master_timeout,
-            :flat_settings,
-            :expand_wildcards,
-            :ignore_unavailable ]
 
           method = HTTP_GET
           path   = "_cluster/state"
@@ -47,7 +52,7 @@ module Elasticsearch
                                    Utils.__listify(metric),
                                    Utils.__listify(index)
 
-          params = Utils.__validate_and_extract_params arguments, valid_params
+          params = Utils.__validate_and_extract_params arguments, VALID_STATE_PARAMS
 
           [:index_templates].each do |key|
             params[key] = Utils.__listify(params[key]) if params[key]
@@ -55,7 +60,7 @@ module Elasticsearch
 
           body = nil
 
-          perform_request(method, path, params, body).body
+          perform_request(method, path, params, body)
         end
       end
     end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/count.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/count.rb
@@ -2,6 +2,22 @@ module Elasticsearch
   module API
     module Actions
 
+      VALID_COUNT_PARAMS = [
+        :ignore_unavailable,
+        :allow_no_indices,
+        :expand_wildcards,
+        :min_score,
+        :preference,
+        :routing,
+        :q,
+        :analyzer,
+        :analyze_wildcard,
+        :default_operator,
+        :df,
+        :lenient,
+        :lowercase_expanded_terms
+      ].freeze
+
       # Get the number of documents for the cluster, index, type, or a query.
       #
       # @example Get the number of all documents in the cluster
@@ -45,28 +61,17 @@ module Elasticsearch
       # @see http://elasticsearch.org/guide/reference/api/count/
       #
       def count(arguments={})
-        valid_params = [
-          :ignore_unavailable,
-          :allow_no_indices,
-          :expand_wildcards,
-          :min_score,
-          :preference,
-          :routing,
-          :q,
-          :analyzer,
-          :analyze_wildcard,
-          :default_operator,
-          :df,
-          :lenient,
-          :lowercase_expanded_terms ]
+        count_request_for(arguments).body
+      end
 
+      def count_request_for(arguments={})
         method = HTTP_GET
         path   = Utils.__pathify( Utils.__listify(arguments[:index]), Utils.__listify(arguments[:type]), '_count' )
 
-        params = Utils.__validate_and_extract_params arguments, valid_params
+        params = Utils.__validate_and_extract_params arguments, VALID_COUNT_PARAMS
         body   = arguments[:body]
 
-        perform_request(method, path, params, body).body
+        perform_request(method, path, params, body)
       end
     end
   end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/count_percolate.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/count_percolate.rb
@@ -2,6 +2,18 @@ module Elasticsearch
   module API
     module Actions
 
+      VALID_COUNT_PERCOLATE_PARAMS = [
+        :routing,
+        :preference,
+        :ignore_unavailable,
+        :allow_no_indices,
+        :expand_wildcards,
+        :percolate_index,
+        :percolate_type,
+        :version,
+        :version_type
+      ].freeze
+
       # Return the number of queries matching a document.
       #
       # Percolator allows you to register queries and then evaluate a document against them:
@@ -49,18 +61,12 @@ module Elasticsearch
       # @see http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/search-percolate.html
       #
       def count_percolate(arguments={})
+        count_percolate_request_for(arguments).body
+      end
+
+      def count_percolate_request_for(arguments={})
         raise ArgumentError, "Required argument 'index' missing" unless arguments[:index]
         raise ArgumentError, "Required argument 'type' missing"  unless arguments[:type]
-        valid_params = [
-          :routing,
-          :preference,
-          :ignore_unavailable,
-          :allow_no_indices,
-          :expand_wildcards,
-          :percolate_index,
-          :percolate_type,
-          :version,
-          :version_type ]
 
         method = HTTP_GET
         path   = Utils.__pathify Utils.__escape(arguments[:index]),
@@ -68,10 +74,10 @@ module Elasticsearch
                                  arguments[:id],
                                  '_percolate/count'
 
-        params = Utils.__validate_and_extract_params arguments, valid_params
+        params = Utils.__validate_and_extract_params arguments, VALID_COUNT_PERCOLATE_PARAMS
         body   = arguments[:body]
 
-        perform_request(method, path, params, body).body
+        perform_request(method, path, params, body)
       end
     end
   end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/create.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/create.rb
@@ -29,6 +29,10 @@ module Elasticsearch
       def create(arguments={})
         index arguments.update :op_type => 'create'
       end
+
+      def create_request_for(arguments={})
+        index_request_for arguments.update :op_type => 'create'
+      end
     end
   end
 end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/delete_by_query.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/delete_by_query.rb
@@ -2,6 +2,22 @@ module Elasticsearch
   module API
     module Actions
 
+      VALID_DELETE_BY_QUERY_PARAMS = [
+        :analyzer,
+        :consistency,
+        :default_operator,
+        :df,
+        :ignore_indices,
+        :ignore_unavailable,
+        :allow_no_indices,
+        :expand_wildcards,
+        :replication,
+        :q,
+        :routing,
+        :source,
+        :timeout
+      ].freeze
+
       # Delete documents which match specified query.
       #
       # Provide the query either as a "query string" query in the `:q` argument, or using the Elasticsearch's
@@ -43,32 +59,21 @@ module Elasticsearch
       # @see http://www.elasticsearch.org/guide/reference/api/delete-by-query/
       #
       def delete_by_query(arguments={})
-        raise ArgumentError, "Required argument 'index' missing" unless arguments[:index]
+        delete_by_query_request_for(arguments).body
+      end
 
-        valid_params = [
-          :analyzer,
-          :consistency,
-          :default_operator,
-          :df,
-          :ignore_indices,
-          :ignore_unavailable,
-          :allow_no_indices,
-          :expand_wildcards,
-          :replication,
-          :q,
-          :routing,
-          :source,
-          :timeout ]
+      def delete_by_query_request_for(arguments={})
+        raise ArgumentError, "Required argument 'index' missing" unless arguments[:index]
 
         method = HTTP_DELETE
         path   = Utils.__pathify Utils.__listify(arguments[:index]),
                                  Utils.__listify(arguments[:type]),
                                  '/_query'
 
-        params = Utils.__validate_and_extract_params arguments, valid_params
+        params = Utils.__validate_and_extract_params arguments, VALID_DELETE_BY_QUERY_PARAMS
         body   = arguments[:body]
 
-        perform_request(method, path, params, body).body
+        perform_request(method, path, params, body)
       end
     end
   end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/delete_script.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/delete_script.rb
@@ -2,6 +2,11 @@ module Elasticsearch
   module API
     module Actions
 
+      VALID_DELETE_SCRIPT_PARAMS = [
+        :version,
+        :version_type
+      ].freeze
+
       # Remove an indexed script from Elasticsearch
       #
       # @option arguments [String] :id Script ID (*Required*)
@@ -12,19 +17,19 @@ module Elasticsearch
       # @see http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/modules-scripting.html
       #
       def delete_script(arguments={})
+        delete_script_request_for(arguments).body
+      end
+
+      def delete_script_request_for(arguments={})
         raise ArgumentError, "Required argument 'id' missing"   unless arguments[:id]
         raise ArgumentError, "Required argument 'lang' missing" unless arguments[:lang]
 
-        valid_params = [
-          :version,
-          :version_type ]
-
         method = HTTP_DELETE
         path   = "_scripts/#{arguments.delete(:lang)}/#{arguments[:id]}"
-        params = Utils.__validate_and_extract_params arguments, valid_params
+        params = Utils.__validate_and_extract_params arguments, VALID_DELETE_SCRIPT_PARAMS
         body   = nil
 
-        perform_request(method, path, params, body).body
+        perform_request(method, path, params, body)
       end
     end
   end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/delete_template.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/delete_template.rb
@@ -9,12 +9,16 @@ module Elasticsearch
       # @see http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/search-template.html
       #
       def delete_template(arguments={})
+        delete_template_request_for(arguments).body
+      end
+
+      def delete_template_request_for(arguments={})
         method = HTTP_DELETE
         path   = "_search/template/#{arguments[:id]}"
         params = {}
         body   = nil
 
-        perform_request(method, path, params, body).body
+        perform_request(method, path, params, body)
       end
     end
   end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/explain.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/explain.rb
@@ -2,6 +2,24 @@ module Elasticsearch
   module API
     module Actions
 
+      VALID_EXPLAIN_PARAMS = [
+        :analyze_wildcard,
+        :analyzer,
+        :default_operator,
+        :df,
+        :fields,
+        :lenient,
+        :lowercase_expanded_terms,
+        :parent,
+        :preference,
+        :q,
+        :routing,
+        :source,
+        :_source,
+        :_source_include,
+        :_source_exclude
+      ].freeze
+
       # Return information if and how well a document matches a query.
       #
       # The returned information contains a `_score` and its explanation, if the document matches the query.
@@ -43,26 +61,13 @@ module Elasticsearch
       # @see http://elasticsearch.org/guide/reference/api/explain/
       #
       def explain(arguments={})
+        explain_request_for(arguments).body
+      end
+
+      def explain_request_for(arguments={})
         raise ArgumentError, "Required argument 'index' missing" unless arguments[:index]
         raise ArgumentError, "Required argument 'type' missing"  unless arguments[:type]
         raise ArgumentError, "Required argument 'id' missing"    unless arguments[:id]
-
-        valid_params = [
-          :analyze_wildcard,
-          :analyzer,
-          :default_operator,
-          :df,
-          :fields,
-          :lenient,
-          :lowercase_expanded_terms,
-          :parent,
-          :preference,
-          :q,
-          :routing,
-          :source,
-          :_source,
-          :_source_include,
-          :_source_exclude ]
 
         method = HTTP_GET
         path   = Utils.__pathify Utils.__escape(arguments[:index]),
@@ -70,12 +75,12 @@ module Elasticsearch
                                  Utils.__escape(arguments[:id]),
                                  '_explain'
 
-        params = Utils.__validate_and_extract_params arguments, valid_params
+        params = Utils.__validate_and_extract_params arguments, VALID_EXPLAIN_PARAMS
         body   = arguments[:body]
 
         params[:fields] = Utils.__listify(params[:fields]) if params[:fields]
 
-        perform_request(method, path, params, body).body
+        perform_request(method, path, params, body)
       end
     end
   end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/field_stats.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/field_stats.rb
@@ -2,6 +2,14 @@ module Elasticsearch
   module API
     module Actions
 
+      VALID_FIELD_STATS_PARAMS = [
+        :fields,
+        :level,
+        :ignore_unavailable,
+        :allow_no_indices,
+        :expand_wildcards
+      ].freeze
+
       # Returns statistical information about a field without executing a search.
       #
       # @option arguments [List] :index A comma-separated list of index names; use `_all` or empty string to perform the operation on all indices
@@ -14,18 +22,16 @@ module Elasticsearch
       # @see http://www.elastic.co/guide/en/elasticsearch/reference/master/search-field-stats.html
       #
       def field_stats(arguments={})
-        valid_params = [
-          :fields,
-          :level,
-          :ignore_unavailable,
-          :allow_no_indices,
-          :expand_wildcards ]
+        field_stats_request_for(arguments).body
+      end
+
+      def field_stats_request_for(arguments={})
         method = 'GET'
         path   = "_field_stats"
-        params = Utils.__validate_and_extract_params arguments, valid_params
+        params = Utils.__validate_and_extract_params arguments, VALID_FIELD_STATS_PARAMS
         body   = nil
 
-        perform_request(method, path, params, body).body
+        perform_request(method, path, params, body)
       end
     end
   end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/get_script.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/get_script.rb
@@ -10,6 +10,10 @@ module Elasticsearch
       # @see http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/modules-scripting.html#_indexed_scripts
       #
       def get_script(arguments={})
+        get_script_request_for(arguments).body
+      end
+
+      def get_script_request_for(arguments={})
         raise ArgumentError, "Required argument 'id' missing"   unless arguments[:id]
         raise ArgumentError, "Required argument 'lang' missing" unless arguments[:lang]
         method = HTTP_GET
@@ -17,7 +21,7 @@ module Elasticsearch
         params = {}
         body   = nil
 
-        perform_request(method, path, params, body).body
+        perform_request(method, path, params, body)
       end
     end
   end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/get_template.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/get_template.rb
@@ -10,17 +10,21 @@ module Elasticsearch
       # @see http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/search-template.html
       #
       def get_template(arguments={})
+        if Array(arguments[:ignore]).include?(404)
+          Utils.__rescue_from_not_found { get_template_request_for(arguments).body }
+        else
+          get_template_request_for(arguments).body
+        end
+      end
+
+      def get_template_request_for(arguments)
         raise ArgumentError, "Required argument 'id' missing" unless arguments[:id]
         method = HTTP_GET
         path   = "_search/template/#{arguments[:id]}"
         params = {}
         body   = arguments[:body]
 
-        if Array(arguments[:ignore]).include?(404)
-          Utils.__rescue_from_not_found { perform_request(method, path, params, body).body }
-        else
-          perform_request(method, path, params, body).body
-        end
+        perform_request(method, path, params, body)
       end
     end
   end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/index.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/index.rb
@@ -2,6 +2,21 @@ module Elasticsearch
   module API
     module Actions
 
+      VALID_INDEX_PARAMS = [
+        :consistency,
+        :op_type,
+        :parent,
+        :percolate,
+        :refresh,
+        :replication,
+        :routing,
+        :timeout,
+        :timestamp,
+        :ttl,
+        :version,
+        :version_type
+      ].freeze
+
       # Create or update a document.
       #
       # The `index` API will either _create_ a new document, or _update_ an existing one, when a document `:id`
@@ -71,32 +86,22 @@ module Elasticsearch
       # @see http://elasticsearch.org/guide/reference/api/index_/
       #
       def index(arguments={})
+        index_request_for(arguments).body
+      end
+
+      def index_request_for(arguments={})
         raise ArgumentError, "Required argument 'index' missing" unless arguments[:index]
         raise ArgumentError, "Required argument 'type' missing"  unless arguments[:type]
-
-        valid_params = [
-          :consistency,
-          :op_type,
-          :parent,
-          :percolate,
-          :refresh,
-          :replication,
-          :routing,
-          :timeout,
-          :timestamp,
-          :ttl,
-          :version,
-          :version_type ]
 
         method = arguments[:id] ? HTTP_PUT : HTTP_POST
         path   = Utils.__pathify Utils.__escape(arguments[:index]),
                                  Utils.__escape(arguments[:type]),
                                  Utils.__escape(arguments[:id])
 
-        params = Utils.__validate_and_extract_params arguments, valid_params
+        params = Utils.__validate_and_extract_params arguments, VALID_INDEX_PARAMS
         body   = arguments[:body]
 
-        perform_request(method, path, params, body).body
+        perform_request(method, path, params, body)
       end
     end
   end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/analyze.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/analyze.rb
@@ -3,6 +3,19 @@ module Elasticsearch
     module Indices
       module Actions
 
+        VALID_ANALYZE_PARAMS = [
+          :analyzer,
+          :char_filters,
+          :field,
+          :filters,
+          :index,
+          :prefer_local,
+          :text,
+          :tokenizer,
+          :token_filters,
+          :format
+        ].freeze
+
         # Return the result of the analysis process (tokens)
         #
         # Allows to "test-drive" the Elasticsearch analysis process by performing the analysis on the
@@ -47,27 +60,19 @@ module Elasticsearch
         # @see http://www.elasticsearch.org/guide/reference/api/admin-indices-analyze/
         #
         def analyze(arguments={})
-          valid_params = [
-            :analyzer,
-            :char_filters,
-            :field,
-            :filters,
-            :index,
-            :prefer_local,
-            :text,
-            :tokenizer,
-            :token_filters,
-            :format ]
+          analyze_request_for(arguments).body
+        end
 
+        def analyze_request_for(arguments={})
           method = HTTP_GET
           path   = Utils.__pathify Utils.__listify(arguments[:index]), '_analyze'
 
-          params = Utils.__validate_and_extract_params arguments, valid_params
+          params = Utils.__validate_and_extract_params arguments, VALID_ANALYZE_PARAMS
           params[:filters] = Utils.__listify(params[:filters]) if params[:filters]
 
           body   = arguments[:body]
 
-          perform_request(method, path, params, body).body
+          perform_request(method, path, params, body)
         end
       end
     end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/clear_cache.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/clear_cache.rb
@@ -3,6 +3,22 @@ module Elasticsearch
     module Indices
       module Actions
 
+        VALID_CLEAR_CACHE_PARAMS = [
+          :field_data,
+          :fielddata,
+          :fields,
+          :filter,
+          :filter_cache,
+          :filter_keys,
+          :id,
+          :id_cache,
+          :ignore_indices,
+          :ignore_unavailable,
+          :allow_no_indices,
+          :expand_wildcards,
+          :recycler
+        ].freeze
+
         # Clear caches and other auxiliary data structures.
         #
         # Can be performed against a specific index, or against all indices.
@@ -48,30 +64,19 @@ module Elasticsearch
         # @see http://www.elasticsearch.org/guide/reference/api/admin-indices-clearcache/
         #
         def clear_cache(arguments={})
-          valid_params = [
-            :field_data,
-            :fielddata,
-            :fields,
-            :filter,
-            :filter_cache,
-            :filter_keys,
-            :id,
-            :id_cache,
-            :ignore_indices,
-            :ignore_unavailable,
-            :allow_no_indices,
-            :expand_wildcards,
-            :recycler ]
+          clear_cache_request_for(arguments).body
+        end
 
+        def clear_cache_request_for(arguments={})
           method = HTTP_POST
           path   = Utils.__pathify Utils.__listify(arguments[:index]), '_cache/clear'
 
-          params = Utils.__validate_and_extract_params arguments, valid_params
+          params = Utils.__validate_and_extract_params arguments, VALID_CLEAR_CACHE_PARAMS
           body   = nil
 
           params[:fields] = Utils.__listify(params[:fields]) if params[:fields]
 
-          perform_request(method, path, params, body).body
+          perform_request(method, path, params, body)
         end
       end
     end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/close.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/close.rb
@@ -3,6 +3,14 @@ module Elasticsearch
     module Indices
       module Actions
 
+        VALID_CLOSE_PARAMS = [
+          :ignore_indices,
+          :ignore_unavailable,
+          :allow_no_indices,
+          :expand_wildcards,
+          :timeout
+        ].freeze
+
         # Close an index (keep the data on disk, but deny operations with the index).
         #
         # A closed index can be opened again with the {Indices::Actions#close} API.
@@ -26,23 +34,19 @@ module Elasticsearch
         # @see http://www.elasticsearch.org/guide/reference/api/admin-indices-open-close/
         #
         def close(arguments={})
-          raise ArgumentError, "Required argument 'index' missing" unless arguments[:index]
+          close_request_for(arguments).body
+        end
 
-          valid_params = [
-            :ignore_indices,
-            :ignore_unavailable,
-            :allow_no_indices,
-            :expand_wildcards,
-            :timeout
-          ]
+        def close_request_for(arguments={})
+          raise ArgumentError, "Required argument 'index' missing" unless arguments[:index]
 
           method = HTTP_POST
           path   = Utils.__pathify Utils.__listify(arguments[:index]), '_close'
 
-          params = Utils.__validate_and_extract_params arguments, valid_params
+          params = Utils.__validate_and_extract_params arguments, VALID_CLOSE_PARAMS
           body   = nil
 
-          perform_request(method, path, params, body).body
+          perform_request(method, path, params, body)
         end
       end
     end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/create.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/create.rb
@@ -3,6 +3,8 @@ module Elasticsearch
     module Indices
       module Actions
 
+        VALID_CREATE_PARAMS = [ :timeout ].freeze
+
         # Create an index.
         #
         # Pass the index `settings` and `mappings` in the `:body` attribute.
@@ -65,16 +67,18 @@ module Elasticsearch
         # @see http://www.elasticsearch.org/guide/reference/api/admin-indices-create-index/
         #
         def create(arguments={})
-          raise ArgumentError, "Required argument 'index' missing" unless arguments[:index]
-          valid_params = [ :timeout ]
+          create_request_for(arguments).body
+        end
 
+        def create_request_for(arguments={})
+          raise ArgumentError, "Required argument 'index' missing" unless arguments[:index]
           method = HTTP_PUT
           path   = Utils.__pathify Utils.__escape(arguments[:index])
 
-          params = Utils.__validate_and_extract_params arguments, valid_params
+          params = Utils.__validate_and_extract_params arguments, VALID_CREATE_PARAMS
           body   = arguments[:body]
 
-          perform_request(method, path, params, body).body
+          perform_request(method, path, params, body)
         end
       end
     end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/delete_alias.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/delete_alias.rb
@@ -3,6 +3,8 @@ module Elasticsearch
     module Indices
       module Actions
 
+        VALID_DELETE_ALIAS_PARAMS = [ :timeout ].freeze
+
         # Delete a single index alias.
         #
         # @example Delete an alias
@@ -18,17 +20,19 @@ module Elasticsearch
         # @see http://www.elasticsearch.org/guide/reference/api/admin-indices-aliases/
         #
         def delete_alias(arguments={})
+          delete_alias_request_for(arguments).body
+        end
+
+        def delete_alias_request_for(arguments={})
           raise ArgumentError, "Required argument 'index' missing" unless arguments[:index]
           raise ArgumentError, "Required argument 'name' missing"  unless arguments[:name]
-          valid_params = [ :timeout ]
-
           method = HTTP_DELETE
           path   = Utils.__pathify Utils.__escape(arguments[:index]), '_alias', Utils.__escape(arguments[:name])
 
-          params = Utils.__validate_and_extract_params arguments, valid_params
+          params = Utils.__validate_and_extract_params arguments, VALID_DELETE_ALIAS_PARAMS
           body   = nil
 
-          perform_request(method, path, params, body).body
+          perform_request(method, path, params, body)
         end
       end
     end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/delete_mapping.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/delete_mapping.rb
@@ -11,6 +11,10 @@ module Elasticsearch
         # @see http://www.elasticsearch.org/guide/reference/api/admin-indices-delete-mapping/
         #
         def delete_mapping(arguments={})
+          delete_mapping_request_for(arguments).body
+        end
+
+        def delete_mapping_request_for(arguments={})
           raise ArgumentError, "Required argument 'index' missing" unless arguments[:index]
           raise ArgumentError, "Required argument 'type' missing"  unless arguments[:type]
           method = HTTP_DELETE
@@ -18,7 +22,7 @@ module Elasticsearch
           params = {}
           body   = nil
 
-          perform_request(method, path, params, body).body
+          perform_request(method, path, params, body)
         end
       end
     end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/delete_warmer.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/delete_warmer.rb
@@ -18,13 +18,17 @@ module Elasticsearch
         # @see http://www.elasticsearch.org/guide/reference/api/admin-indices-warmers/
         #
         def delete_warmer(arguments={})
+          delete_warmer_request_for(arguments).body
+        end
+
+        def delete_warmer_request_for(arguments={})
           raise ArgumentError, "Required argument 'index' missing" unless arguments[:index]
           method = HTTP_DELETE
           path   = Utils.__pathify Utils.__listify(arguments[:index]), '_warmer', Utils.__listify(arguments[:name])
           params = {}
           body = nil
 
-          perform_request(method, path, params, body).body
+          perform_request(method, path, params, body)
         end
       end
     end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/exists_alias.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/exists_alias.rb
@@ -3,6 +3,14 @@ module Elasticsearch
     module Indices
       module Actions
 
+        VALID_EXISTS_ALIAS_PARAMS = [
+          :ignore_indices,
+          :ignore_unavailable,
+          :allow_no_indices,
+          :expand_wildcards,
+          :local
+        ].freeze
+
         # Return true if the specified alias exists, false otherwise.
         #
         # @example Check whether index alias named _myalias_ exists
@@ -26,23 +34,19 @@ module Elasticsearch
         # @see http://www.elasticsearch.org/guide/reference/api/admin-indices-aliases/
         #
         def exists_alias(arguments={})
-          valid_params = [
-            :ignore_indices,
-            :ignore_unavailable,
-            :allow_no_indices,
-            :expand_wildcards,
-            :local
-          ]
+          Utils.__rescue_from_not_found do
+            exists_alias_request_for(arguments).status == 200
+          end
+        end
 
+        def exists_alias_request_for(arguments={})
           method = HTTP_HEAD
           path   = Utils.__pathify Utils.__listify(arguments[:index]), '_alias', Utils.__escape(arguments[:name])
 
-          params = Utils.__validate_and_extract_params arguments, valid_params
+          params = Utils.__validate_and_extract_params arguments, VALID_EXISTS_ALIAS_PARAMS
           body = nil
 
-          Utils.__rescue_from_not_found do
-            perform_request(method, path, params, body).status == 200 ? true : false
-          end
+          perform_request(method, path, params, body)
         end
 
         alias_method :exists_alias?, :exists_alias

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/flush.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/flush.rb
@@ -3,6 +3,16 @@ module Elasticsearch
     module Indices
       module Actions
 
+        VALID_FLUSH_PARAMS = [
+          :force,
+          :full,
+          :ignore_indices,
+          :ignore_unavailable,
+          :allow_no_indices,
+          :expand_wildcards,
+          :refresh
+        ].freeze
+
         # "Flush" the index or indices.
         #
         # The "flush" operation clears the transaction log and memory and writes data to disk.
@@ -29,22 +39,17 @@ module Elasticsearch
         # @see http://www.elasticsearch.org/guide/reference/api/admin-indices-flush/
         #
         def flush(arguments={})
-          valid_params = [
-            :force,
-            :full,
-            :ignore_indices,
-            :ignore_unavailable,
-            :allow_no_indices,
-            :expand_wildcards,
-            :refresh ]
+          flush_request_for(arguments).body
+        end
 
+        def flush_request_for(arguments={})
           method = HTTP_POST
           path   = Utils.__pathify Utils.__listify(arguments[:index]), '_flush'
 
-          params = Utils.__validate_and_extract_params arguments, valid_params
+          params = Utils.__validate_and_extract_params arguments, VALID_FLUSH_PARAMS
           body = nil
 
-          perform_request(method, path, params, body).body
+          perform_request(method, path, params, body)
         end
       end
     end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/flush_synced.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/flush_synced.rb
@@ -3,6 +3,7 @@ module Elasticsearch
     module Indices
       module Actions
 
+        VALID_FLUSH_SYNCED_PARAMS = [].freeze
         # @option arguments [List] :index A comma-separated list of index names; use `_all` or empty string for all indices
         # @option arguments [Boolean] :ignore_unavailable Whether specified concrete indices should be ignored when unavailable (missing or closed)
         # @option arguments [Boolean] :allow_no_indices Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)
@@ -11,19 +12,21 @@ module Elasticsearch
         # @see http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-flush.html
         #
         def flush_synced(arguments={})
-          valid_params = [
-             ]
+          if Array(arguments[:ignore]).include?(404)
+            Utils.__rescue_from_not_found { flush_synced_request_for(arguments).body }
+          else
+            flush_synced_request_for(arguments).body
+          end
+        end
+
+        def flush_synced_request_for(arguments={})
           method = HTTP_POST
           path   = Utils.__pathify Utils.__listify(arguments[:index]), '_flush/synced'
 
-          params = Utils.__validate_and_extract_params arguments, valid_params
+          params = Utils.__validate_and_extract_params arguments, VALID_FLUSH_SYNCED_PARAMS
           body   = nil
 
-          if Array(arguments[:ignore]).include?(404)
-            Utils.__rescue_from_not_found { perform_request(method, path, params, body).body }
-          else
-            perform_request(method, path, params, body).body
-          end
+          perform_request(method, path, params, body)
         end
       end
     end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/get.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/get.rb
@@ -3,6 +3,13 @@ module Elasticsearch
     module Indices
       module Actions
 
+        VALID_GET_PARAMS = [
+          :local,
+          :ignore_unavailable,
+          :allow_no_indices,
+          :expand_wildcards
+        ].freeze
+
         # Retrieve information about one or more indices
         #
         # @option arguments [List] :index A comma-separated list of index names (*Required*)
@@ -18,22 +25,20 @@ module Elasticsearch
         # @see http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/indices-get-index.html
         #
         def get(arguments={})
-          raise ArgumentError, "Required argument 'index' missing" unless arguments[:index]
+          get_request_for(arguments).body
+        end
 
-          valid_params = [
-            :local,
-            :ignore_unavailable,
-            :allow_no_indices,
-            :expand_wildcards ]
+        def get_request_for(arguments={})
+          raise ArgumentError, "Required argument 'index' missing" unless arguments[:index]
 
           method = HTTP_GET
 
           path   = Utils.__pathify Utils.__listify(arguments[:index]), Utils.__listify(arguments.delete(:feature))
 
-          params = Utils.__validate_and_extract_params arguments, valid_params
+          params = Utils.__validate_and_extract_params arguments, VALID_GET_PARAMS
           body = nil
 
-          perform_request(method, path, params, body).body
+          perform_request(method, path, params, body)
         end
       end
     end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/get_alias.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/get_alias.rb
@@ -3,6 +3,14 @@ module Elasticsearch
     module Indices
       module Actions
 
+        VALID_GET_ALIAS_PARAMS = [
+          :ignore_indices,
+          :ignore_unavailable,
+          :allow_no_indices,
+          :expand_wildcards,
+          :local
+        ].freeze
+
         # Get information about a specific alias.
         #
         # @example Return all indices an alias points to
@@ -30,21 +38,17 @@ module Elasticsearch
         # @see http://www.elasticsearch.org/guide/reference/api/admin-indices-aliases/
         #
         def get_alias(arguments={})
-          valid_params = [
-            :ignore_indices,
-            :ignore_unavailable,
-            :allow_no_indices,
-            :expand_wildcards,
-            :local
-          ]
+          get_alias_request_for(arguments).body
+        end
 
+        def get_alias_request_for(arguments={})
           method = HTTP_GET
           path   = Utils.__pathify Utils.__listify(arguments[:index]), '_alias', Utils.__escape(arguments[:name])
 
-          params = Utils.__validate_and_extract_params arguments, valid_params
+          params = Utils.__validate_and_extract_params arguments, VALID_GET_ALIAS_PARAMS
           body   = nil
 
-          perform_request(method, path, params, body).body
+          perform_request(method, path, params, body)
         end
       end
     end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/get_aliases.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/get_aliases.rb
@@ -3,6 +3,11 @@ module Elasticsearch
     module Indices
       module Actions
 
+        VALID_GET_ALIASES_PARAMS = [
+          :timeout,
+          :local
+        ].freeze
+
         # Get a list of all aliases, or aliases for a specific index.
         #
         # @example Get a list of all aliases
@@ -18,15 +23,17 @@ module Elasticsearch
         # @see http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/indices-aliases.html
         #
         def get_aliases(arguments={})
-          valid_params = [ :timeout, :local ]
+          get_aliases_request_for(arguments).body
+        end
 
+        def get_aliases_request_for(arguments={})
           method = HTTP_GET
           path   = Utils.__pathify Utils.__listify(arguments[:index]), '_aliases', Utils.__listify(arguments[:name])
 
-          params = Utils.__validate_and_extract_params arguments, valid_params
+          params = Utils.__validate_and_extract_params arguments, VALID_GET_ALIASES_PARAMS
           body   = nil
 
-          perform_request(method, path, params, body).body
+          perform_request(method, path, params, body)
         end
       end
     end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/get_field_mapping.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/get_field_mapping.rb
@@ -3,6 +3,14 @@ module Elasticsearch
     module Indices
       module Actions
 
+        VALID_GET_FIELD_MAPPING_PARAMS = [
+          :include_defaults,
+          :ignore_indices,
+          :ignore_unavailable,
+          :allow_no_indices,
+          :expand_wildcards
+        ].freeze
+
         # Return the mapping definition for specific field (or fields)
         #
         # @example Get mapping for a specific field across all indices
@@ -34,14 +42,11 @@ module Elasticsearch
         # @see http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/indices-get-field-mapping.html
         #
         def get_field_mapping(arguments={})
+          get_field_mapping_request_for(arguments).body
+        end
+
+        def get_field_mapping_request_for(arguments={})
           raise ArgumentError, "Required argument 'field' missing" unless arguments[:field]
-          valid_params = [
-            :include_defaults,
-            :ignore_indices,
-            :ignore_unavailable,
-            :allow_no_indices,
-            :expand_wildcards
-          ]
 
           method = HTTP_GET
           path   = Utils.__pathify(
@@ -51,10 +56,10 @@ module Elasticsearch
                      'field',
                      Utils.__listify(arguments[:field])
                    )
-          params = Utils.__validate_and_extract_params arguments, valid_params
+          params = Utils.__validate_and_extract_params arguments, VALID_GET_FIELD_MAPPING_PARAMS
           body   = nil
 
-          perform_request(method, path, params, body).body
+          perform_request(method, path, params, body)
         end
       end
     end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/get_mapping.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/get_mapping.rb
@@ -3,6 +3,14 @@ module Elasticsearch
     module Indices
       module Actions
 
+        VALID_GET_MAPPING_PARAMS = [
+          :ignore_indices,
+          :ignore_unavailable,
+          :allow_no_indices,
+          :expand_wildcards,
+          :local
+        ].freeze
+
         # Return the mapping definitions for all indices, or specific indices/types.
         #
         # @example Get all mappings in the cluster
@@ -34,22 +42,18 @@ module Elasticsearch
         # @see http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/indices-get-mapping.html
         #
         def get_mapping(arguments={})
-          valid_params = [
-            :ignore_indices,
-            :ignore_unavailable,
-            :allow_no_indices,
-            :expand_wildcards,
-            :local
-          ]
+          get_mapping_request_for(arguments).body
+        end
 
+        def get_mapping_request_for(arguments={})
           method = HTTP_GET
           path   = Utils.__pathify Utils.__listify(arguments[:index]),
                                    '_mapping',
                                    Utils.__listify(arguments[:type])
-          params = Utils.__validate_and_extract_params arguments, valid_params
+          params = Utils.__validate_and_extract_params arguments, VALID_GET_MAPPING_PARAMS
           body = nil
 
-          perform_request(method, path, params, body).body
+          perform_request(method, path, params, body)
         end
       end
     end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/get_settings.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/get_settings.rb
@@ -3,6 +3,16 @@ module Elasticsearch
     module Indices
       module Actions
 
+        VALID_GET_SETTINGS_PARAMS = [
+          :prefix,
+          :ignore_indices,
+          :ignore_unavailable,
+          :allow_no_indices,
+          :expand_wildcards,
+          :flat_settings,
+          :local
+        ].freeze
+
         # Return the settings for all indices, or a list of indices.
         #
         # @example Get settings for all indices
@@ -41,26 +51,20 @@ module Elasticsearch
         # @see http://www.elasticsearch.org/guide/reference/api/admin-indices-get-settings/
         #
         def get_settings(arguments={})
-          valid_params = [
-            :prefix,
-            :ignore_indices,
-            :ignore_unavailable,
-            :allow_no_indices,
-            :expand_wildcards,
-            :flat_settings,
-            :local
-          ]
-
+          get_settings_request_for(arguments).body
+        end
+        
+        def get_settings_request_for(arguments={})
           method = HTTP_GET
           path   = Utils.__pathify Utils.__listify(arguments[:index]),
                                    Utils.__listify(arguments[:type]),
                                    arguments.delete(:prefix),
                                    '_settings',
                                    Utils.__escape(arguments[:name])
-          params = Utils.__validate_and_extract_params arguments, valid_params
+          params = Utils.__validate_and_extract_params arguments, VALID_GET_SETTINGS_PARAMS
           body   = nil
 
-          perform_request(method, path, params, body).body
+          perform_request(method, path, params, body)
         end
       end
     end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/get_template.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/get_template.rb
@@ -3,6 +3,12 @@ module Elasticsearch
     module Indices
       module Actions
 
+        VALID_GET_TEMPLATE_PARAMS = [
+          :flat_settings,
+          :local,
+          :master_timeout
+        ].freeze
+
         # Get a single index template.
         #
         # @example Get all templates
@@ -24,15 +30,18 @@ module Elasticsearch
         # @see http://www.elasticsearch.org/guide/reference/api/admin-indices-templates/
         #
         def get_template(arguments={})
-          valid_params = [ :flat_settings, :local, :master_timeout ]
+          get_template_request_for(arguments).body
+        end
+
+        def get_template_request_for(arguments={})
 
           method = HTTP_GET
           path   = Utils.__pathify '_template', Utils.__escape(arguments[:name])
 
-          params = Utils.__validate_and_extract_params arguments, valid_params
+          params = Utils.__validate_and_extract_params arguments, VALID_GET_TEMPLATE_PARAMS
           body   = arguments[:body]
 
-          perform_request(method, path, params, body).body
+          perform_request(method, path, params, body)
         end
       end
     end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/get_warmer.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/get_warmer.rb
@@ -3,6 +3,13 @@ module Elasticsearch
     module Indices
       module Actions
 
+        VALID_GET_WARMER_PARAMS = [
+          :ignore_indices,
+          :ignore_unavailable,
+          :allow_no_indices,
+          :expand_wildcards
+        ].freeze
+
         # Get one or more warmers for an index.
         #
         # @example Get all warmers
@@ -39,19 +46,16 @@ module Elasticsearch
         # @see http://www.elasticsearch.org/guide/reference/api/admin-indices-warmers/
         #
         def get_warmer(arguments={})
-          valid_params = [
-            :ignore_indices,
-            :ignore_unavailable,
-            :allow_no_indices,
-            :expand_wildcards
-          ]
+          get_warmer_request_for(arguments).body
+        end
 
+        def get_warmer_request_for(arguments={})
           method = HTTP_GET
           path   = Utils.__pathify( Utils.__listify(arguments[:index]), '_warmer', Utils.__escape(arguments[:name]) )
-          params = {}
+          params = Utils.__validate_and_extract_params arguments, VALID_GET_WARMER_PARAMS
           body   = nil
 
-          perform_request(method, path, params, body).body
+          perform_request(method, path, params, body)
         end
       end
     end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/open.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/open.rb
@@ -3,6 +3,14 @@ module Elasticsearch
     module Indices
       module Actions
 
+        VALID_OPEN_PARAMS = [
+          :ignore_indices,
+          :ignore_unavailable,
+          :allow_no_indices,
+          :expand_wildcards,
+          :timeout
+        ].freeze
+
         # Open a previously closed index (see the {Indices::Actions#close} API).
         #
         # @example Open index named _myindex_
@@ -24,23 +32,19 @@ module Elasticsearch
         # @see http://www.elasticsearch.org/guide/reference/api/admin-indices-open-close/
         #
         def open(arguments={})
-          raise ArgumentError, "Required argument 'index' missing" unless arguments[:index]
+          open_request_for(arguments).body
+        end
 
-          valid_params = [
-            :ignore_indices,
-            :ignore_unavailable,
-            :allow_no_indices,
-            :expand_wildcards,
-            :timeout
-          ]
+        def open_request_for(arguments={})
+          raise ArgumentError, "Required argument 'index' missing" unless arguments[:index]
 
           method = HTTP_POST
           path   = Utils.__pathify Utils.__escape(arguments[:index]), '_open'
 
-          params = Utils.__validate_and_extract_params arguments, valid_params
+          params = Utils.__validate_and_extract_params arguments, VALID_OPEN_PARAMS
           body = nil
 
-          perform_request(method, path, params, body).body
+          perform_request(method, path, params, body)
         end
       end
     end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/optimize.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/optimize.rb
@@ -3,6 +3,21 @@ module Elasticsearch
     module Indices
       module Actions
 
+        VALID_OPTIMIZE_PARAMS = [
+          :ignore_indices,
+          :ignore_unavailable,
+          :allow_no_indices,
+          :expand_wildcards,
+          :flush,
+          :force,
+          :master_timeout,
+          :max_num_segments,
+          :only_expunge_deletes,
+          :operation_threading,
+          :refresh,
+          :wait_for_merge
+        ].freeze
+
         # Perform an index optimization.
         #
         # The "optimize" operation merges the index segments, increasing search performance.
@@ -44,27 +59,17 @@ module Elasticsearch
         # @see http://www.elasticsearch.org/guide/reference/api/admin-indices-optimize/
         #
         def optimize(arguments={})
-          valid_params = [
-            :ignore_indices,
-            :ignore_unavailable,
-            :allow_no_indices,
-            :expand_wildcards,
-            :flush,
-            :force,
-            :master_timeout,
-            :max_num_segments,
-            :only_expunge_deletes,
-            :operation_threading,
-            :refresh,
-            :wait_for_merge ]
+          optimize_request_for(arguments).body
+        end
 
+        def optimize_request_for(arguments={})
           method = HTTP_POST
           path   = Utils.__pathify Utils.__listify(arguments[:index]), '_optimize'
 
-          params = Utils.__validate_and_extract_params arguments, valid_params
+          params = Utils.__validate_and_extract_params arguments, VALID_OPTIMIZE_PARAMS
           body = nil
 
-          perform_request(method, path, params, body).body
+          perform_request(method, path, params, body)
         end
       end
     end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/put_alias.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/put_alias.rb
@@ -3,6 +3,8 @@ module Elasticsearch
     module Indices
       module Actions
 
+        VALID_PUT_ALIAS_PARAMS = [ :timeout ].freeze
+
         # Create or update a single index alias.
         #
         # @example Create an alias for current month
@@ -24,16 +26,18 @@ module Elasticsearch
         # @see http://www.elasticsearch.org/guide/reference/api/admin-indices-aliases/
         #
         def put_alias(arguments={})
-          raise ArgumentError, "Required argument 'name' missing"  unless arguments[:name]
-          valid_params = [ :timeout ]
+          put_alias_request_for(arguments).body
+        end
 
+        def put_alias_request_for(arguments={})
+          raise ArgumentError, "Required argument 'name' missing"  unless arguments[:name]
           method = HTTP_PUT
           path   = Utils.__pathify Utils.__listify(arguments[:index]), '_alias', Utils.__escape(arguments[:name])
 
-          params = Utils.__validate_and_extract_params arguments, valid_params
+          params = Utils.__validate_and_extract_params arguments, VALID_PUT_ALIAS_PARAMS
           body   = arguments[:body]
 
-          perform_request(method, path, params, body).body
+          perform_request(method, path, params, body)
         end
       end
     end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/put_mapping.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/put_mapping.rb
@@ -3,6 +3,16 @@ module Elasticsearch
     module Indices
       module Actions
 
+        VALID_PUT_MAPPING_PARAMS = [
+          :ignore_conflicts,
+          :ignore_indices,
+          :ignore_unavailable,
+          :allow_no_indices,
+          :expand_wildcards,
+          :master_timeout,
+          :timeout
+        ].freeze
+
         # Create or update mapping.
         #
         # Pass the mapping definition(s) in the `:body` argument.
@@ -46,26 +56,20 @@ module Elasticsearch
         # @see http://www.elasticsearch.org/guide/reference/api/admin-indices-put-mapping/
         #
         def put_mapping(arguments={})
+          put_mapping_request_for(arguments).body
+        end
+
+        def put_mapping_request_for(arguments={})
           raise ArgumentError, "Required argument 'type' missing"  unless arguments[:type]
           raise ArgumentError, "Required argument 'body' missing"  unless arguments[:body]
-
-          valid_params = [
-            :ignore_conflicts,
-            :ignore_indices,
-            :ignore_unavailable,
-            :allow_no_indices,
-            :expand_wildcards,
-            :master_timeout,
-            :timeout
-          ]
 
           method = HTTP_PUT
           path   = Utils.__pathify Utils.__listify(arguments[:index]), '_mapping', Utils.__escape(arguments[:type])
 
-          params = Utils.__validate_and_extract_params arguments, valid_params
+          params = Utils.__validate_and_extract_params arguments, VALID_PUT_MAPPING_PARAMS
           body   = arguments[:body]
 
-          perform_request(method, path, params, body).body
+          perform_request(method, path, params, body)
         end
       end
     end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/put_settings.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/put_settings.rb
@@ -3,6 +3,15 @@ module Elasticsearch
     module Indices
       module Actions
 
+        VALID_PUT_SETTINGS_PARAMS = [
+          :ignore_indices,
+          :ignore_unavailable,
+          :allow_no_indices,
+          :expand_wildcards,
+          :master_timeout,
+          :flat_settings
+        ].freeze
+
         # Update the settings for one or multiple indices.
         #
         # @example Change the number of replicas for all indices
@@ -42,23 +51,18 @@ module Elasticsearch
         # @see http://www.elasticsearch.org/guide/reference/api/admin-indices-update-settings/
         #
         def put_settings(arguments={})
-          raise ArgumentError, "Required argument 'body' missing" unless arguments[:body]
+          put_settings_request_for(arguments).body
+        end
 
-          valid_params = [
-            :ignore_indices,
-            :ignore_unavailable,
-            :allow_no_indices,
-            :expand_wildcards,
-            :master_timeout,
-            :flat_settings
-          ]
+        def put_settings_request_for(arguments={})
+          raise ArgumentError, "Required argument 'body' missing" unless arguments[:body]
 
           method = HTTP_PUT
           path   = Utils.__pathify Utils.__listify(arguments[:index]), '_settings'
-          params = Utils.__validate_and_extract_params arguments, valid_params
+          params = Utils.__validate_and_extract_params arguments, VALID_PUT_SETTINGS_PARAMS
           body   = arguments[:body]
 
-          perform_request(method, path, params, body).body
+          perform_request(method, path, params, body)
         end
       end
     end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/put_template.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/put_template.rb
@@ -3,6 +3,12 @@ module Elasticsearch
     module Indices
       module Actions
 
+        VALID_PUT_TEMPLATE_PARAMS = [
+          :create,
+          :order,
+          :timeout
+        ].freeze
+
         # Create or update an index template.
         #
         # @example Create a template for all indices starting with `logs-`
@@ -22,17 +28,20 @@ module Elasticsearch
         # @see http://www.elasticsearch.org/guide/reference/api/admin-indices-templates/
         #
         def put_template(arguments={})
+          put_template_request_for(arguments).body
+        end
+
+        def put_template_request_for(arguments={})
           raise ArgumentError, "Required argument 'name' missing" unless arguments[:name]
           raise ArgumentError, "Required argument 'body' missing" unless arguments[:body]
-          valid_params = [ :create, :order, :timeout ]
 
           method = HTTP_PUT
           path   = Utils.__pathify '_template', Utils.__escape(arguments[:name])
 
-          params = Utils.__validate_and_extract_params arguments, valid_params
+          params = Utils.__validate_and_extract_params arguments, VALID_PUT_TEMPLATE_PARAMS
           body   = arguments[:body]
 
-          perform_request(method, path, params, body).body
+          perform_request(method, path, params, body)
         end
       end
     end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/put_warmer.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/put_warmer.rb
@@ -3,6 +3,13 @@ module Elasticsearch
     module Indices
       module Actions
 
+        VALID_PUT_WARMER_PARAMS = [
+          :ignore_indices,
+          :ignore_unavailable,
+          :allow_no_indices,
+          :expand_wildcards
+        ].freeze
+
         # Create or update an index warmer.
         #
         # An index warmer will run before an index is refreshed, ie. available for search.
@@ -38,25 +45,22 @@ module Elasticsearch
         # @see http://www.elasticsearch.org/guide/reference/api/admin-indices-warmers/
         #
         def put_warmer(arguments={})
+          put_warmer_request_for(arguments).body
+        end
+
+        def put_warmer_request_for(arguments={})
           raise ArgumentError, "Required argument 'name' missing"  unless arguments[:name]
           raise ArgumentError, "Required argument 'body' missing"  unless arguments[:body]
-
-          valid_params = [
-            :ignore_indices,
-            :ignore_unavailable,
-            :allow_no_indices,
-            :expand_wildcards
-          ]
 
           method = HTTP_PUT
           path   = Utils.__pathify( Utils.__listify(arguments[:index]),
                                     Utils.__listify(arguments[:type]),
                                     '_warmer',
                                     Utils.__listify(arguments[:name]) )
-          params = Utils.__validate_and_extract_params arguments, valid_params
+          params = Utils.__validate_and_extract_params arguments, VALID_PUT_WARMER_PARAMS
           body   = arguments[:body]
 
-          perform_request(method, path, params, body).body
+          perform_request(method, path, params, body)
         end
       end
     end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/recovery.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/recovery.rb
@@ -3,6 +3,12 @@ module Elasticsearch
     module Indices
       module Actions
 
+        VALID_RECOVERY_PARAMS = [
+          :detailed,
+          :active_only,
+          :human
+        ].freeze
+
         # Return information about shard recovery for one or more indices
         #
         # @example Get recovery information for a single index
@@ -25,16 +31,16 @@ module Elasticsearch
         # @see http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/indices-recovery.html
         #
         def recovery(arguments={})
-          valid_params = [
-            :detailed,
-            :active_only,
-            :human ]
+          recovery_request_for(arguments).body
+        end
+
+        def recovery_request_for(arguments={})
           method = HTTP_GET
           path   = Utils.__pathify Utils.__listify(arguments[:index]), '_recovery'
-          params = Utils.__validate_and_extract_params arguments, valid_params
+          params = Utils.__validate_and_extract_params arguments, VALID_RECOVERY_PARAMS
           body   = nil
 
-          perform_request(method, path, params, body).body
+          perform_request(method, path, params, body)
         end
       end
     end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/refresh.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/refresh.rb
@@ -3,6 +3,13 @@ module Elasticsearch
     module Indices
       module Actions
 
+        VALID_REFRESH_PARAMS = [
+          :ignore_indices,
+          :ignore_unavailable,
+          :allow_no_indices,
+          :expand_wildcards
+        ].freeze
+
         # Refresh the index and to make the changes (creates, updates, deletes) searchable.
         #
         # By default, Elasticsearch has a delay of 1 second until changes to an index are
@@ -33,20 +40,17 @@ module Elasticsearch
         # @see http://www.elasticsearch.org/guide/reference/api/admin-indices-refresh/
         #
         def refresh(arguments={})
-          valid_params = [
-            :ignore_indices,
-            :ignore_unavailable,
-            :allow_no_indices,
-            :expand_wildcards
-          ]
+          refresh_request_for(arguments).body
+        end
 
+        def refresh_request_for(arguments={})
           method = HTTP_POST
           path   = Utils.__pathify Utils.__listify(arguments[:index]), '_refresh'
 
-          params = Utils.__validate_and_extract_params arguments, valid_params
+          params = Utils.__validate_and_extract_params arguments, VALID_REFRESH_PARAMS
           body   = nil
 
-          perform_request(method, path, params, body).body
+          perform_request(method, path, params, body)
         end
       end
     end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/seal.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/seal.rb
@@ -11,14 +11,16 @@ module Elasticsearch
         # @see http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-seal.html
         #
         def seal(arguments={})
-          valid_params = [
-             ]
+          seal_request_for(arguments).body
+        end
+
+        def seal_request_for(arguments={})
           method = 'POST'
           path   = Utils.__pathify Utils.__listify(arguments[:index]), '_seal'
           params = {}
           body   = nil
 
-          perform_request(method, path, params, body).body
+          perform_request(method, path, params, body)
         end
       end
     end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/segments.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/segments.rb
@@ -3,6 +3,13 @@ module Elasticsearch
     module Indices
       module Actions
 
+        VALID_SEGMENTS_PARAMS = [
+          :ignore_indices,
+          :ignore_unavailable,
+          :allow_no_indices,
+          :expand_wildcards
+        ].freeze
+
         # Return information about segments for one or more indices.
         #
         # The response contains information about segment size, number of documents, deleted documents, etc.
@@ -23,20 +30,17 @@ module Elasticsearch
         # @see http://elasticsearch.org/guide/reference/api/admin-indices-segments/
         #
         def segments(arguments={})
-          valid_params = [
-            :ignore_indices,
-            :ignore_unavailable,
-            :allow_no_indices,
-            :expand_wildcards
-          ]
+          segments_request_for(arguments).body
+        end
 
+        def segments_request_for(arguments={})
           method = HTTP_GET
           path   = Utils.__pathify Utils.__listify(arguments[:index]), '_segments'
 
-          params = Utils.__validate_and_extract_params arguments, valid_params
+          params = Utils.__validate_and_extract_params arguments, VALID_SEGMENTS_PARAMS
           body   = nil
 
-          perform_request(method, path, params, body).body
+          perform_request(method, path, params, body)
         end
       end
     end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/snapshot_index.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/snapshot_index.rb
@@ -3,6 +3,13 @@ module Elasticsearch
     module Indices
       module Actions
 
+        VALID_SNAPSHOT_INDEX_PARAMS = [
+          :ignore_indices,
+          :ignore_unavailable,
+          :allow_no_indices,
+          :expand_wildcards
+        ].freeze
+
         # When using the shared storage gateway, manually trigger the snapshot operation.
         #
         # @deprecated The shared gateway has been deprecated [https://github.com/elasticsearch/elasticsearch/issues/2458]
@@ -22,20 +29,17 @@ module Elasticsearch
         # @see http://www.elasticsearch.org/guide/reference/api/admin-indices-gateway-snapshot/
         #
         def snapshot_index(arguments={})
-          valid_params = [
-            :ignore_indices,
-            :ignore_unavailable,
-            :allow_no_indices,
-            :expand_wildcards
-          ]
+          snapshot_index_request_for(arguments).body
+        end
 
+        def snapshot_index_request_for(arguments={})
           method = HTTP_POST
           path   = Utils.__pathify Utils.__listify(arguments[:index]), '_gateway/snapshot'
 
-          params = Utils.__validate_and_extract_params arguments, valid_params
+          params = Utils.__validate_and_extract_params arguments, VALID_SNAPSHOT_INDEX_PARAMS
           body   = nil
 
-          perform_request(method, path, params, body).body
+          perform_request(method, path, params, body)
         end
       end
     end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/stats.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/stats.rb
@@ -3,6 +3,35 @@ module Elasticsearch
     module Indices
       module Actions
 
+        VALID_STATS_PARTS = [
+          :docs,
+          :fielddata,
+          :filter_cache,
+          :flush,
+          :get,
+          :indexing,
+          :merge,
+          :metric,
+          :refresh,
+          :search,
+          :suggest,
+          :store,
+          :warmer
+        ].freeze
+
+        VALID_STATS_PARAMS = [
+          :fields,
+          :completion_fields,
+          :fielddata_fields,
+          :groups,
+          :level,
+          :types,
+          :ignore_indices,
+          :ignore_unavailable,
+          :allow_no_indices,
+          :expand_wildcards
+        ].freeze
+
         # Return statistical information about one or more indices.
         #
         # The response contains comprehensive statistical information about metrics related to index:
@@ -74,45 +103,22 @@ module Elasticsearch
         # @see http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/indices-stats.html
         #
         def stats(arguments={})
-          valid_parts = [
-            :docs,
-            :fielddata,
-            :filter_cache,
-            :flush,
-            :get,
-            :indexing,
-            :merge,
-            :metric,
-            :refresh,
-            :search,
-            :suggest,
-            :store,
-            :warmer ]
+          stats_request_for(arguments).body
+        end
 
-          valid_params = [
-            :fields,
-            :completion_fields,
-            :fielddata_fields,
-            :groups,
-            :level,
-            :types,
-            :ignore_indices,
-            :ignore_unavailable,
-            :allow_no_indices,
-            :expand_wildcards ]
-
+        def stats_request_for(arguments={})
           method = HTTP_GET
 
-          parts  = Utils.__extract_parts arguments, valid_parts
+          parts  = Utils.__extract_parts arguments, VALID_STATS_PARTS
           path   = Utils.__pathify Utils.__listify(arguments[:index]), '_stats', Utils.__listify(parts)
 
-          params = Utils.__validate_and_extract_params arguments, valid_params
+          params = Utils.__validate_and_extract_params arguments, VALID_STATS_PARAMS
           params[:fields] = Utils.__listify(params[:fields]) if params[:fields]
           params[:groups] = Utils.__listify(params[:groups]) if params[:groups]
 
           body   = nil
 
-          perform_request(method, path, params, body).body
+          perform_request(method, path, params, body)
         end
       end
     end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/status.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/status.rb
@@ -3,6 +3,15 @@ module Elasticsearch
     module Indices
       module Actions
 
+        VALID_STATUS_PARAMS = [
+          :ignore_indices,
+          :ignore_unavailable,
+          :allow_no_indices,
+          :expand_wildcards,
+          :recovery,
+          :snapshot
+        ].freeze
+
         # Return information about one or more indices
         #
         # @example Get information about all indices
@@ -34,21 +43,17 @@ module Elasticsearch
         # @see http://elasticsearch.org/guide/reference/api/admin-indices-status/
         #
         def status(arguments={})
-          valid_params = [
-            :ignore_indices,
-            :ignore_unavailable,
-            :allow_no_indices,
-            :expand_wildcards,
-            :recovery,
-            :snapshot ]
+          status_request_for(arguments).body
+        end
 
+        def status_request_for(arguments={})
           method = HTTP_GET
           path   = Utils.__pathify Utils.__listify(arguments[:index]), '_status'
 
-          params = Utils.__validate_and_extract_params arguments, valid_params
+          params = Utils.__validate_and_extract_params arguments, VALID_STATUS_PARAMS
           body   = nil
 
-          perform_request(method, path, params, body).body
+          perform_request(method, path, params, body)
         end
       end
     end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/update_aliases.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/update_aliases.rb
@@ -3,6 +3,8 @@ module Elasticsearch
     module Indices
       module Actions
 
+        VALID_UPDATE_ALIASES_PARAMS = [ :timeout ].freeze
+
         # Perform multiple operation on index aliases in a single request.
         #
         # Pass the `actions` (add, remove) in the `body` argument.
@@ -31,16 +33,19 @@ module Elasticsearch
         # @see http://www.elasticsearch.org/guide/reference/api/admin-indices-aliases/
         #
         def update_aliases(arguments={})
+          update_aliases_request_for(arguments).body
+        end
+
+        def update_aliases_request_for(arguments={})
           raise ArgumentError, "Required argument 'body' missing" unless arguments[:body]
-          valid_params = [ :timeout ]
 
           method = HTTP_POST
           path   = "_aliases"
 
-          params = Utils.__validate_and_extract_params arguments, valid_params
+          params = Utils.__validate_and_extract_params arguments, VALID_UPDATE_ALIASES_PARAMS
           body   = arguments[:body]
 
-          perform_request(method, path, params, body).body
+          perform_request(method, path, params, body)
         end
       end
     end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/upgrade.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/upgrade.rb
@@ -3,6 +3,13 @@ module Elasticsearch
     module Indices
       module Actions
 
+        VALID_UPGRADE_PARAMS = [
+          :ignore_unavailable,
+          :allow_no_indices,
+          :expand_wildcards,
+          :wait_for_completion
+        ].freeze
+
         # Upgrade the index or indices to the latest Lucene format.
         #
         # @option arguments [List] :index A comma-separated list of index names;
@@ -19,18 +26,16 @@ module Elasticsearch
         # @see http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/indices-upgrade.html
         #
         def upgrade(arguments={})
-          valid_params = [
-            :ignore_unavailable,
-            :allow_no_indices,
-            :expand_wildcards,
-            :wait_for_completion ]
+          upgrade_request_for(arguments).body
+        end
 
+        def upgrade_request_for(arguments={})
           method = HTTP_POST
           path   = "_upgrade"
-          params = Utils.__validate_and_extract_params arguments, valid_params
+          params = Utils.__validate_and_extract_params arguments, VALID_UPGRADE_PARAMS
           body   = nil
 
-          perform_request(method, path, params, body).body
+          perform_request(method, path, params, body)
         end
       end
     end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/validate_query.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/validate_query.rb
@@ -3,6 +3,21 @@ module Elasticsearch
     module Indices
       module Actions
 
+        VALID_VALIDATE_QUERY_PARAMS = [
+          :explain,
+          :ignore_unavailable,
+          :allow_no_indices,
+          :expand_wildcards,
+          :operation_threading,
+          :q,
+          :analyzer,
+          :analyze_wildcard,
+          :default_operator,
+          :df,
+          :lenient,
+          :lowercase_expanded_terms
+        ].freeze
+
         # Validate a query
         #
         # @example Validate a simple query string query
@@ -63,29 +78,19 @@ module Elasticsearch
         # @see http://www.elasticsearch.org/guide/reference/api/validate/
         #
         def validate_query(arguments={})
-          valid_params = [
-            :explain,
-            :ignore_unavailable,
-            :allow_no_indices,
-            :expand_wildcards,
-            :operation_threading,
-            :q,
-            :analyzer,
-            :analyze_wildcard,
-            :default_operator,
-            :df,
-            :lenient,
-            :lowercase_expanded_terms ]
+          validate_query_request_for(arguments).body
+        end
 
+        def validate_query_request_for(arguments={})
           method = HTTP_GET
           path   = Utils.__pathify Utils.__listify(arguments[:index]),
                                    Utils.__listify(arguments[:type]),
                                    '_validate/query'
 
-          params = Utils.__validate_and_extract_params arguments, valid_params
+          params = Utils.__validate_and_extract_params arguments, VALID_VALIDATE_QUERY_PARAMS
           body   = arguments[:body]
 
-          perform_request(method, path, params, body).body
+          perform_request(method, path, params, body)
         end
       end
     end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/info.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/info.rb
@@ -7,12 +7,16 @@ module Elasticsearch
       # @see http://elasticsearch.org/guide/
       #
       def info(arguments={})
+        info_request_for(arguments).body
+      end
+
+      def info_request_for(arguments={})
         method = HTTP_GET
         path   = ""
         params = {}
         body   = nil
 
-        perform_request(method, path, params, body).body
+        perform_request(method, path, params, body)
       end
     end
   end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/list_benchmarks.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/list_benchmarks.rb
@@ -15,14 +15,16 @@ module Elasticsearch
       # @see http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/search-benchmark.html
       #
       def list_benchmarks(arguments={})
-        valid_params = [
-           ]
+        list_benchmarks_request_for(arguments).body
+      end
+
+      def list_benchmarks_request_for(arguments={})
         method = HTTP_GET
         path   = "_bench"
         params = {}
         body   = nil
 
-        perform_request(method, path, params, body).body
+        perform_request(method, path, params, body)
       end
     end
   end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/mget.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/mget.rb
@@ -2,6 +2,18 @@ module Elasticsearch
   module API
     module Actions
 
+      VALID_MGET_PARAMS = [
+        :fields,
+        :parent,
+        :preference,
+        :realtime,
+        :refresh,
+        :routing,
+        :_source,
+        :_source_include,
+        :_source_exclude
+      ].freeze
+
       # Return multiple documents from one or more indices in a single request.
       #
       # Pass the request definition in the `:body` argument, either as an Array of `docs` specifications,
@@ -44,30 +56,23 @@ module Elasticsearch
       # @see http://elasticsearch.org/guide/reference/api/multi-get/
       #
       def mget(arguments={})
-        raise ArgumentError, "Required argument 'body' missing" unless arguments[:body]
+        mget_request_for(arguments).body
+      end
 
-        valid_params = [
-          :fields,
-          :parent,
-          :preference,
-          :realtime,
-          :refresh,
-          :routing,
-          :_source,
-          :_source_include,
-          :_source_exclude ]
+      def mget_request_for(arguments={})
+        raise ArgumentError, "Required argument 'body' missing" unless arguments[:body]
 
         method = HTTP_GET
         path   = Utils.__pathify Utils.__escape(arguments[:index]),
                                  Utils.__escape(arguments[:type]),
                                  '_mget'
 
-        params = Utils.__validate_and_extract_params arguments, valid_params
+        params = Utils.__validate_and_extract_params arguments, VALID_MGET_PARAMS
         body   = arguments[:body]
 
         params[:fields] = Utils.__listify(params[:fields]) if params[:fields]
 
-        perform_request(method, path, params, body).body
+        perform_request(method, path, params, body)
       end
     end
   end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/mlt.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/mlt.rb
@@ -2,6 +2,28 @@ module Elasticsearch
   module API
     module Actions
 
+      VALID_MLT_PARAMS = [
+        :boost_terms,
+        :max_doc_freq,
+        :max_query_terms,
+        :max_word_len,
+        :min_doc_freq,
+        :min_term_freq,
+        :min_word_len,
+        :mlt_fields,
+        :percent_terms_to_match,
+        :routing,
+        :search_from,
+        :search_indices,
+        :search_query_hint,
+        :search_scroll,
+        :search_size,
+        :search_source,
+        :search_type,
+        :search_types,
+        :stop_words
+      ].freeze
+
       # Return documents similar to the specified one.
       #
       # Performs a `more_like_this` query with the specified document as the input.
@@ -82,30 +104,13 @@ module Elasticsearch
       # @see http://elasticsearch.org/guide/reference/api/more-like-this/
       #
       def mlt(arguments={})
+        mlt_request_for(arguments).body
+      end
+
+      def mlt_request_for(arguments={})
         raise ArgumentError, "Required argument 'index' missing" unless arguments[:index]
         raise ArgumentError, "Required argument 'type' missing"  unless arguments[:type]
         raise ArgumentError, "Required argument 'id' missing"    unless arguments[:id]
-
-        valid_params = [
-          :boost_terms,
-          :max_doc_freq,
-          :max_query_terms,
-          :max_word_len,
-          :min_doc_freq,
-          :min_term_freq,
-          :min_word_len,
-          :mlt_fields,
-          :percent_terms_to_match,
-          :routing,
-          :search_from,
-          :search_indices,
-          :search_query_hint,
-          :search_scroll,
-          :search_size,
-          :search_source,
-          :search_type,
-          :search_types,
-          :stop_words ]
 
         method = HTTP_GET
         path   = Utils.__pathify Utils.__escape(arguments[:index]),
@@ -113,7 +118,7 @@ module Elasticsearch
                                  Utils.__escape(arguments[:id]),
                                  '_mlt'
 
-        params = Utils.__validate_and_extract_params arguments, valid_params
+        params = Utils.__validate_and_extract_params arguments, VALID_MLT_PARAMS
 
         [:mlt_fields, :search_indices, :search_types, :stop_words].each do |name|
           params[name] = Utils.__listify(params[name]) if params[name]
@@ -121,7 +126,7 @@ module Elasticsearch
 
         body   = arguments[:body]
 
-        perform_request(method, path, params, body).body
+        perform_request(method, path, params, body)
       end
     end
   end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/mpercolate.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/mpercolate.rb
@@ -2,6 +2,12 @@ module Elasticsearch
   module API
     module Actions
 
+      VALID_MPERCOPATE_PARAMS = [
+        :ignore_unavailable,
+        :allow_no_indices,
+        :expand_wildcards
+      ].freeze
+
       # Perform multiple percolate operations in a single request, similar to the {#msearch} API
       #
       # Pass the percolate definitions as header-body pairs in the `:body` argument, as an Array of Hashes.
@@ -30,16 +36,16 @@ module Elasticsearch
       # @see http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/search-percolate.html
       #
       def mpercolate(arguments={})
+        mpercolate_request_for(arguments).body
+      end
+
+      def mpercolate_request_for(arguments={})
         raise ArgumentError, "Required argument 'body' missing" unless arguments[:body]
-        valid_params = [
-          :ignore_unavailable,
-          :allow_no_indices,
-          :expand_wildcards ]
 
         method = HTTP_GET
         path   = "_mpercolate"
 
-        params = Utils.__validate_and_extract_params arguments, valid_params
+        params = Utils.__validate_and_extract_params arguments, VALID_MPERCOPATE_PARAMS
         body   = arguments[:body]
 
         case
@@ -51,7 +57,7 @@ module Elasticsearch
           payload = body
         end
 
-        perform_request(method, path, params, payload).body
+        perform_request(method, path, params, payload)
       end
     end
   end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/msearch.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/msearch.rb
@@ -2,6 +2,8 @@ module Elasticsearch
   module API
     module Actions
 
+      VALID_MSEARCH_PARAMS = [ :search_type ].freeze
+
       # Perform multiple search operations in a single request.
       #
       # Pass the search definitions in the `:body` argument
@@ -36,13 +38,16 @@ module Elasticsearch
       # @see http://www.elasticsearch.org/guide/reference/api/multi-search/
       #
       def msearch(arguments={})
+        msearch_request_for(arguments).body
+      end
+
+      def msearch_request_for(arguments={})
         raise ArgumentError, "Required argument 'body' missing" unless arguments[:body]
-        valid_params = [ :search_type ]
 
         method = HTTP_GET
         path   = Utils.__pathify( Utils.__listify(arguments[:index]), Utils.__listify(arguments[:type]), '_msearch' )
 
-        params = Utils.__validate_and_extract_params arguments, valid_params
+        params = Utils.__validate_and_extract_params arguments, VALID_MSEARCH_PARAMS
         body   = arguments[:body]
 
         case
@@ -67,7 +72,7 @@ module Elasticsearch
           payload = body
         end
 
-        perform_request(method, path, params, payload).body
+        perform_request(method, path, params, payload)
       end
     end
   end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/mtermvectors.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/mtermvectors.rb
@@ -2,6 +2,20 @@ module Elasticsearch
   module API
     module Actions
 
+      VALID_MTERMVECTORS_PARAMS = [
+        :ids,
+        :term_statistics,
+        :field_statistics,
+        :fields,
+        :offsets,
+        :positions,
+        :payloads,
+        :preference,
+        :realtime,
+        :routing,
+        :parent
+      ].freeze
+
       # Returns information and statistics about terms in the fields of multiple documents
       # in a single request/response. The semantics are similar to the {#mget} API.
       #
@@ -35,19 +49,10 @@ module Elasticsearch
       # @see #termvector
       #
       def mtermvectors(arguments={})
-        valid_params = [
-          :ids,
-          :term_statistics,
-          :field_statistics,
-          :fields,
-          :offsets,
-          :positions,
-          :payloads,
-          :preference,
-          :realtime,
-          :routing,
-          :parent ]
+        mtermvectors_request_for(arguments).body
+      end
 
+      def mtermvectors_request_for(arguments={})
         ids = arguments.delete(:ids)
 
         method = HTTP_GET
@@ -55,7 +60,7 @@ module Elasticsearch
                                  Utils.__escape(arguments[:type]),
                                  '_mtermvectors'
 
-        params = Utils.__validate_and_extract_params arguments, valid_params
+        params = Utils.__validate_and_extract_params arguments, VALID_MTERMVECTORS_PARAMS
 
         if ids
           body = { :ids => ids }
@@ -63,7 +68,7 @@ module Elasticsearch
           body = arguments[:body]
         end
 
-        perform_request(method, path, params, body).body
+        perform_request(method, path, params, body)
       end
     end
   end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/nodes/hot_threads.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/nodes/hot_threads.rb
@@ -3,6 +3,13 @@ module Elasticsearch
     module Nodes
       module Actions
 
+        VALID_HOT_THREADS_PARAMS = [
+          :interval,
+          :snapshots,
+          :threads,
+          :type
+        ].freeze
+
         # Returns information about the hottest threads in the cluster or on a specific node as a String.
         #
         #
@@ -26,19 +33,17 @@ module Elasticsearch
         # @see http://www.elasticsearch.org/guide/reference/api/admin-cluster-nodes-hot-threads/
         #
         def hot_threads(arguments={})
-          valid_params = [
-            :interval,
-            :snapshots,
-            :threads,
-            :type ]
+          hot_threads_request_for(arguments).body
+        end
 
+        def hot_threads_request_for(arguments={})
           method = HTTP_GET
           path   = Utils.__pathify '_nodes', Utils.__listify(arguments[:node_id]), 'hot_threads'
 
-          params = Utils.__validate_and_extract_params arguments, valid_params
+          params = Utils.__validate_and_extract_params arguments, VALID_HOT_THREADS_PARAMS
           body = nil
 
-          perform_request(method, path, params, body).body
+          perform_request(method, path, params, body)
         end
       end
     end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/nodes/info.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/nodes/info.rb
@@ -3,6 +3,21 @@ module Elasticsearch
     module Nodes
       module Actions
 
+        VALID_INFO_PARTS = [
+          :_all,
+          :http,
+          :jvm,
+          :network,
+          :os,
+          :plugins,
+          :process,
+          :settings,
+          :thread_pool,
+          :transport
+        ].freeze
+
+        VALID_INFO_PARAMS = [].freeze
+
         # Returns information about nodes in the cluster (cluster settings, JVM version, etc).
         #
         # Use the `all` option to return all available settings, or limit the information returned
@@ -39,37 +54,27 @@ module Elasticsearch
         # @see http://elasticsearch.org/guide/reference/api/admin-cluster-nodes-info/
         #
         def info(arguments={})
+          info_request_for(arguments).body
+        end
+
+        def info_request_for(arguments={})
           arguments = arguments.clone
           metric    = arguments.delete(:metric)
-
-          valid_parts = [
-            :_all,
-            :http,
-            :jvm,
-            :network,
-            :os,
-            :plugins,
-            :process,
-            :settings,
-            :thread_pool,
-            :transport ]
-
-          valid_params = []
 
           method = HTTP_GET
 
           if metric
             parts = metric
           else
-            parts = Utils.__extract_parts arguments, valid_parts
+            parts = Utils.__extract_parts arguments, VALID_INFO_PARTS
           end
 
           path   = Utils.__pathify '_nodes', Utils.__listify(arguments[:node_id]), Utils.__listify(parts)
 
-          params = Utils.__validate_and_extract_params arguments, valid_params
+          params = Utils.__validate_and_extract_params arguments, VALID_INFO_PARAMS
           body   = nil
 
-          perform_request(method, path, params, body).body
+          perform_request(method, path, params, body)
         end
       end
     end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/nodes/shutdown.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/nodes/shutdown.rb
@@ -3,6 +3,11 @@ module Elasticsearch
     module Nodes
       module Actions
 
+        VALID_SHUTDOWN_PARAMS = [
+          :delay,
+          :exit
+        ].freeze
+
         # Shutdown one or all nodes
         #
         # @example Shut down node named _Bloke_
@@ -18,17 +23,17 @@ module Elasticsearch
         # @see http://elasticsearch.org/guide/reference/api/admin-cluster-nodes-shutdown/
         #
         def shutdown(arguments={})
-          valid_params = [
-            :delay,
-            :exit ]
+          shutdown_request_for(arguments).body
+        end
 
+        def shutdown_request_for(arguments={})
           method = HTTP_POST
           path   = Utils.__pathify '_cluster/nodes', Utils.__listify(arguments[:node_id]), '_shutdown'
 
-          params = Utils.__validate_and_extract_params arguments, valid_params
+          params = Utils.__validate_and_extract_params arguments, VALID_SHUTDOWN_PARAMS
           body   = nil
 
-          perform_request(method, path, params, body).body
+          perform_request(method, path, params, body)
         end
       end
     end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/nodes/stats.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/nodes/stats.rb
@@ -3,6 +3,19 @@ module Elasticsearch
     module Nodes
       module Actions
 
+        VALID_STATS_PARAMS = [
+          :metric,
+          :index_metric,
+          :node_id,
+          :completion_fields,
+          :fielddata_fields,
+          :fields,
+          :groups,
+          :human,
+          :level,
+          :types
+        ].freeze
+
         # Returns statistical information about nodes in the cluster.
         #
         # @example Return statistics about JVM
@@ -41,19 +54,11 @@ module Elasticsearch
         # @see http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/cluster-nodes-stats.html
         #
         def stats(arguments={})
-          arguments = arguments.clone
+          stats_request_for(arguments).body
+        end
 
-          valid_params = [
-            :metric,
-            :index_metric,
-            :node_id,
-            :completion_fields,
-            :fielddata_fields,
-            :fields,
-            :groups,
-            :human,
-            :level,
-            :types ]
+        def stats_request_for(arguments={})
+          arguments = arguments.clone
 
           method = HTTP_GET
 
@@ -63,7 +68,7 @@ module Elasticsearch
                                    Utils.__listify(arguments.delete(:metric)),
                                    Utils.__listify(arguments.delete(:index_metric))
 
-          params = Utils.__validate_and_extract_params arguments, valid_params
+          params = Utils.__validate_and_extract_params arguments, VALID_STATS_PARAMS
 
           [:completion_fields, :fielddata_fields, :fields, :groups, :types].each do |key|
             params[key] = Utils.__listify(params[key]) if params[key]
@@ -71,7 +76,7 @@ module Elasticsearch
 
           body   = nil
 
-          perform_request(method, path, params, body).body
+          perform_request(method, path, params, body)
         end
       end
     end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/percolate.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/percolate.rb
@@ -2,6 +2,19 @@ module Elasticsearch
   module API
     module Actions
 
+      VALID_PERCOLATE_PARAMS = [
+        :routing,
+        :preference,
+        :ignore_unavailable,
+        :allow_no_indices,
+        :expand_wildcards,
+        :percolate_index,
+        :percolate_type,
+        :percolate_format,
+        :version,
+        :version_type
+      ].freeze
+
       # Return names of queries matching a document.
       #
       # Percolator allows you to register queries and then evaluate a document against them:
@@ -75,20 +88,12 @@ module Elasticsearch
       # @see http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/search-percolate.html
       #
       def percolate(arguments={})
+        percolate_request_for(arguments).body
+      end
+
+      def percolate_request_for(arguments={})
         raise ArgumentError, "Required argument 'index' missing" unless arguments[:index]
         raise ArgumentError, "Required argument 'type' missing"  unless arguments[:type]
-
-        valid_params = [
-          :routing,
-          :preference,
-          :ignore_unavailable,
-          :allow_no_indices,
-          :expand_wildcards,
-          :percolate_index,
-          :percolate_type,
-          :percolate_format,
-          :version,
-          :version_type ]
 
         method = HTTP_GET
         path   = Utils.__pathify Utils.__escape(arguments[:index]),
@@ -96,10 +101,10 @@ module Elasticsearch
                                  arguments[:id],
                                  '_percolate'
 
-        params = Utils.__validate_and_extract_params arguments, valid_params
+        params = Utils.__validate_and_extract_params arguments, VALID_PERCOLATE_PARAMS
         body   = arguments[:body]
 
-        perform_request(method, path, params, body).body
+        perform_request(method, path, params, body)
       end
     end
   end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/ping.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/ping.rb
@@ -11,14 +11,18 @@ module Elasticsearch
       # @see http://elasticsearch.org/guide/
       #
       def ping(arguments={})
+        Utils.__rescue_from_not_found do
+          ping_request_for(arguments).status == 200
+        end
+      end
+
+      def ping_request_for(arguments={})
         method = HTTP_HEAD
         path   = ""
         params = {}
         body   = nil
 
-        Utils.__rescue_from_not_found do
-          perform_request(method, path, params, body).status == 200 ? true : false
-        end
+        perform_request(method, path, params, body)
       end
     end
   end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/put_script.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/put_script.rb
@@ -2,6 +2,12 @@ module Elasticsearch
   module API
     module Actions
 
+      VALID_PUT_SCRIPT_PARAMS = [
+        :op_type,
+        :version,
+        :version_type
+      ].freeze
+
       # Store a script in an internal index (`.scripts`), to be able to reference them
       # in search definitions (with dynamic scripting disabled)
       #
@@ -28,23 +34,22 @@ module Elasticsearch
       # @see http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/modules-scripting.html#_indexed_scripts
       #
       def put_script(arguments={})
+        put_script_request_for(arguments).body
+      end
+
+      def put_script_request_for(arguments={})
         raise ArgumentError, "Required argument 'id' missing"   unless arguments[:id]
         raise ArgumentError, "Required argument 'lang' missing" unless arguments[:lang]
         raise ArgumentError, "Required argument 'body' missing" unless arguments[:body]
 
-        valid_params = [
-          :op_type,
-          :version,
-          :version_type ]
-
         method = HTTP_PUT
         path   = "_scripts/#{arguments.delete(:lang)}/#{arguments[:id]}"
 
-        params = Utils.__validate_and_extract_params arguments, valid_params
+        params = Utils.__validate_and_extract_params arguments, VALID_PUT_SCRIPT_PARAMS
 
         body   = arguments[:body]
 
-        perform_request(method, path, params, body).body
+        perform_request(method, path, params, body)
       end
     end
   end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/put_template.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/put_template.rb
@@ -11,6 +11,10 @@ module Elasticsearch
       # @see http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/search-template.html
       #
       def put_template(arguments={})
+        put_template_request_for(arguments).body
+      end
+
+      def put_template_request_for(arguments={})
         raise ArgumentError, "Required argument 'id' missing"   unless arguments[:id]
         raise ArgumentError, "Required argument 'body' missing" unless arguments[:body]
         method = HTTP_PUT
@@ -18,7 +22,7 @@ module Elasticsearch
         params = {}
         body   = arguments[:body]
 
-        perform_request(method, path, params, body).body
+        perform_request(method, path, params, body)
       end
     end
   end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/scroll.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/scroll.rb
@@ -2,6 +2,11 @@ module Elasticsearch
   module API
     module Actions
 
+      VALID_SCROLL_PARAMS = [
+        :scroll,
+        :scroll_id
+      ].freeze
+
       # Efficiently iterate over a large result set.
       #
       # When using `from` and `size` to return a large result sets, performance drops as you "paginate" in the set,
@@ -44,16 +49,16 @@ module Elasticsearch
       # @see http://www.elasticsearch.org/guide/reference/api/search/search-type/
       #
       def scroll(arguments={})
+        scroll_request_for(arguments).body
+      end
+
+      def scroll_request_for(arguments={})
         method = HTTP_GET
         path   = "_search/scroll"
-        valid_params = [
-          :scroll,
-          :scroll_id ]
-
-        params = Utils.__validate_and_extract_params arguments, valid_params
+        params = Utils.__validate_and_extract_params arguments, VALID_SCROLL_PARAMS
         body   = arguments[:body] || params.delete(:scroll_id)
 
-        perform_request(method, path, params, body).body
+        perform_request(method, path, params, body)
       end
     end
   end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/search.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/search.rb
@@ -2,6 +2,42 @@ module Elasticsearch
   module API
     module Actions
 
+      VALID_SEARCH_PARAMS = [
+        :analyzer,
+        :analyze_wildcard,
+        :default_operator,
+        :df,
+        :explain,
+        :fielddata_fields,
+        :fields,
+        :from,
+        :ignore_indices,
+        :ignore_unavailable,
+        :allow_no_indices,
+        :expand_wildcards,
+        :lenient,
+        :lowercase_expanded_terms,
+        :preference,
+        :q,
+        :query_cache,
+        :routing,
+        :scroll,
+        :search_type,
+        :size,
+        :sort,
+        :source,
+        :_source,
+        :_source_include,
+        :_source_exclude,
+        :stats,
+        :suggest_field,
+        :suggest_mode,
+        :suggest_size,
+        :suggest_text,
+        :timeout,
+        :version
+      ].freeze
+
       # Return documents matching a query, as well as aggregations (facets), highlighted snippets, suggestions, etc.
       #
       # The search API is used to query one or more indices either using simple
@@ -114,47 +150,16 @@ module Elasticsearch
       # @see http://www.elasticsearch.org/guide/reference/api/search/request-body/
       #
       def search(arguments={})
-        arguments[:index] = UNDERSCORE_ALL if ! arguments[:index] && arguments[:type]
+        search_request_for(arguments).body
+      end
 
-        valid_params = [
-          :analyzer,
-          :analyze_wildcard,
-          :default_operator,
-          :df,
-          :explain,
-          :fielddata_fields,
-          :fields,
-          :from,
-          :ignore_indices,
-          :ignore_unavailable,
-          :allow_no_indices,
-          :expand_wildcards,
-          :lenient,
-          :lowercase_expanded_terms,
-          :preference,
-          :q,
-          :query_cache,
-          :routing,
-          :scroll,
-          :search_type,
-          :size,
-          :sort,
-          :source,
-          :_source,
-          :_source_include,
-          :_source_exclude,
-          :stats,
-          :suggest_field,
-          :suggest_mode,
-          :suggest_size,
-          :suggest_text,
-          :timeout,
-          :version ]
+      def search_request_for(arguments)
+        arguments[:index] = UNDERSCORE_ALL if ! arguments[:index] && arguments[:type]
 
         method = HTTP_GET
         path   = Utils.__pathify( Utils.__listify(arguments[:index]), Utils.__listify(arguments[:type]), UNDERSCORE_SEARCH )
 
-        params = Utils.__validate_and_extract_params arguments, valid_params
+        params = Utils.__validate_and_extract_params arguments, VALID_SEARCH_PARAMS
 
         body   = arguments[:body]
 
@@ -164,7 +169,7 @@ module Elasticsearch
         # FIX: Unescape the `filter_path` parameter due to __listify default behavior. Investigate.
         params[:filter_path] =  defined?(EscapeUtils) ? EscapeUtils.unescape_url(params[:filter_path]) : CGI.unescape(params[:filter_path]) if params[:filter_path]
 
-        perform_request(method, path, params, body).body
+        perform_request(method, path, params, body)
       end
     end
   end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/search_exists.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/search_exists.rb
@@ -2,6 +2,22 @@ module Elasticsearch
   module API
     module Actions
 
+      VALID_SEARCH_EXISTS_PARAMS = [
+        :ignore_unavailable,
+        :allow_no_indices,
+        :expand_wildcards,
+        :min_score,
+        :preference,
+        :routing,
+        :q,
+        :analyzer,
+        :analyze_wildcard,
+        :default_operator,
+        :df,
+        :lenient,
+        :lowercase_expanded_terms
+      ].freeze
+
       # Return whether documents exists for a particular query
       #
       # @option arguments [List] :index A comma-separated list of indices to restrict the results
@@ -33,26 +49,16 @@ module Elasticsearch
       # @see http://www.elastic.co/guide/en/elasticsearch/reference/master/search-exists.html
       #
       def search_exists(arguments={})
-        valid_params = [
-          :ignore_unavailable,
-          :allow_no_indices,
-          :expand_wildcards,
-          :min_score,
-          :preference,
-          :routing,
-          :q,
-          :analyzer,
-          :analyze_wildcard,
-          :default_operator,
-          :df,
-          :lenient,
-          :lowercase_expanded_terms ]
+        search_exists_request_for(arguments).body
+      end
+
+      def search_exists_request_for(arguments={})
         method = 'POST'
         path   = "_search/exists"
-        params = Utils.__validate_and_extract_params arguments, valid_params
+        params = Utils.__validate_and_extract_params arguments, VALID_SEARCH_EXISTS_PARAMS
         body   = arguments[:body]
 
-        perform_request(method, path, params, body).body
+        perform_request(method, path, params, body)
       end
     end
   end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/search_shards.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/search_shards.rb
@@ -2,6 +2,15 @@ module Elasticsearch
   module API
     module Actions
 
+      VALID_SEARCH_SHARDS_PARAMS = [
+        :preference,
+        :routing,
+        :local,
+        :ignore_unavailable,
+        :allow_no_indices,
+        :expand_wildcards
+      ].freeze
+
       # Returns the names of indices and shards on which a search request would be executed
       #
       # @option arguments [String] :index The name of the index
@@ -22,19 +31,16 @@ module Elasticsearch
       # @see http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/search-shards.html
       #
       def search_shards(arguments={})
-        valid_params = [
-          :preference,
-          :routing,
-          :local,
-          :ignore_unavailable,
-          :allow_no_indices,
-          :expand_wildcards ]
+        search_shards_request_for(arguments).body
+      end
+
+      def search_shards_request_for(arguments={})
         method = HTTP_GET
         path   = Utils.__pathify( Utils.__listify(arguments[:index]), Utils.__listify(arguments[:type]), '_search_shards' )
-        params = Utils.__validate_and_extract_params arguments, valid_params
+        params = Utils.__validate_and_extract_params arguments, VALID_SEARCH_SHARDS_PARAMS
         body   = nil
 
-        perform_request(method, path, params, body).body
+        perform_request(method, path, params, body)
       end
     end
   end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/search_template.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/search_template.rb
@@ -2,6 +2,16 @@ module Elasticsearch
   module API
     module Actions
 
+      VALID_SEARCH_TEMPLATE_PARAMS = [
+        :ignore_unavailable,
+        :allow_no_indices,
+        :expand_wildcards,
+        :preference,
+        :routing,
+        :scroll,
+        :search_type
+      ].freeze
+
       # Configure the search definition witha template in Mustache and parameters
       #
       # @example Insert the start and end values for the `range` query
@@ -41,20 +51,16 @@ module Elasticsearch
       # @see http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/search-template.html
       #
       def search_template(arguments={})
-        valid_params = [
-          :ignore_unavailable,
-          :allow_no_indices,
-          :expand_wildcards,
-          :preference,
-          :routing,
-          :scroll,
-          :search_type ]
+        search_template_request_for(arguments).body
+      end
+
+      def search_template_request_for(arguments={})
         method = HTTP_GET
         path   = Utils.__pathify( Utils.__listify(arguments[:index]), Utils.__listify(arguments[:type]), '_search/template' )
-        params = Utils.__validate_and_extract_params arguments, valid_params
+        params = Utils.__validate_and_extract_params arguments, VALID_SEARCH_TEMPLATE_PARAMS
         body   = arguments[:body]
 
-        perform_request(method, path, params, body).body
+        perform_request(method, path, params, body)
       end
     end
   end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/snapshot/create.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/snapshot/create.rb
@@ -3,6 +3,11 @@ module Elasticsearch
     module Snapshot
       module Actions
 
+        VALID_CREATE_PARAMS = [
+          :master_timeout,
+          :wait_for_completion
+        ].freeze
+
         # Create a new snapshot in the repository
         #
         # @example Create a snapshot of the whole cluster in the `my-backups` repository
@@ -25,11 +30,12 @@ module Elasticsearch
         # @see http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/modules-snapshots.html#_snapshot
         #
         def create(arguments={})
+          create_request_for(arguments).body
+        end
+
+        def create_request_for(arguments={})
           raise ArgumentError, "Required argument 'repository' missing" unless arguments[:repository]
           raise ArgumentError, "Required argument 'snapshot' missing"   unless arguments[:snapshot]
-          valid_params = [
-            :master_timeout,
-            :wait_for_completion ]
 
           repository = arguments.delete(:repository)
           snapshot   = arguments.delete(:snapshot)
@@ -37,10 +43,10 @@ module Elasticsearch
           method = HTTP_PUT
           path   = Utils.__pathify( '_snapshot', Utils.__escape(repository), Utils.__escape(snapshot) )
 
-          params = Utils.__validate_and_extract_params arguments, valid_params
+          params = Utils.__validate_and_extract_params arguments, VALID_CREATE_PARAMS
           body   = arguments[:body]
 
-          perform_request(method, path, params, body).body
+          perform_request(method, path, params, body)
         end
       end
     end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/snapshot/create_repository.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/snapshot/create_repository.rb
@@ -3,6 +3,12 @@ module Elasticsearch
     module Snapshot
       module Actions
 
+        VALID_CREATE_REPOSITORY_PARAMS = [
+          :repository,
+          :master_timeout,
+          :timeout
+        ].freeze
+
         # Create a repository for storing snapshots
         #
         # @example Create a repository at `/tmp/backup`
@@ -21,22 +27,21 @@ module Elasticsearch
         # @see http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/modules-snapshots.html#_repositories
         #
         def create_repository(arguments={})
+          create_repository_request_for(arguments).body
+        end
+
+        def create_repository_request_for(arguments={})
           raise ArgumentError, "Required argument 'repository' missing" unless arguments[:repository]
           raise ArgumentError, "Required argument 'body' missing"       unless arguments[:body]
-          valid_params = [
-            :repository,
-            :master_timeout,
-            :timeout ]
-
           repository = arguments.delete(:repository)
 
           method = HTTP_PUT
           path   = Utils.__pathify( '_snapshot', Utils.__escape(repository) )
 
-          params = Utils.__validate_and_extract_params arguments, valid_params
+          params = Utils.__validate_and_extract_params arguments, VALID_CREATE_REPOSITORY_PARAMS
           body   = arguments[:body]
 
-          perform_request(method, path, params, body).body
+          perform_request(method, path, params, body)
         end
       end
     end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/snapshot/delete.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/snapshot/delete.rb
@@ -3,6 +3,8 @@ module Elasticsearch
     module Snapshot
       module Actions
 
+        VALID_DELETE_PARAMS = [ :master_timeout ].freeze
+
         # Delete a snapshot from the repository
         #
         # @note Will also abort a currently running snapshot.
@@ -18,11 +20,12 @@ module Elasticsearch
         # @see http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/modules-snapshots.html
         #
         def delete(arguments={})
+          delete_request_for(arguments).body
+        end
+
+        def delete_request_for(arguments={})
           raise ArgumentError, "Required argument 'repository' missing" unless arguments[:repository]
           raise ArgumentError, "Required argument 'snapshot' missing"   unless arguments[:snapshot]
-
-          valid_params = [
-            :master_timeout ]
 
           repository = arguments.delete(:repository)
           snapshot   = arguments.delete(:snapshot)
@@ -30,10 +33,10 @@ module Elasticsearch
           method = HTTP_DELETE
           path   = Utils.__pathify( '_snapshot', Utils.__escape(repository), Utils.__listify(snapshot) )
 
-          params = Utils.__validate_and_extract_params arguments, valid_params
+          params = Utils.__validate_and_extract_params arguments, VALID_DELETE_PARAMS
           body   = nil
 
-          perform_request(method, path, params, body).body
+          perform_request(method, path, params, body)
         end
       end
     end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/snapshot/delete_repository.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/snapshot/delete_repository.rb
@@ -3,6 +3,11 @@ module Elasticsearch
     module Snapshot
       module Actions
 
+        VALID_DELETE_REPOSITORY_PARAMS = [
+          :master_timeout,
+          :timeout
+        ].freeze
+
         # Delete a specific repository or repositories
         #
         # @example Delete the `my-backups` repository
@@ -16,21 +21,21 @@ module Elasticsearch
         # @see http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/modules-snapshots.html
         #
         def delete_repository(arguments={})
-          raise ArgumentError, "Required argument 'repository' missing" unless arguments[:repository]
+          delete_repository_request_for(arguments).body
+        end
 
-          valid_params = [
-            :master_timeout,
-            :timeout ]
+        def delete_repository_request_for(arguments={})
+          raise ArgumentError, "Required argument 'repository' missing" unless arguments[:repository]
 
           repository = arguments.delete(:repository)
 
           method = HTTP_DELETE
           path   = Utils.__pathify( '_snapshot', Utils.__listify(repository) )
 
-          params = Utils.__validate_and_extract_params arguments, valid_params
+          params = Utils.__validate_and_extract_params arguments, VALID_DELETE_REPOSITORY_PARAMS
           body   = nil
 
-          perform_request(method, path, params, body).body
+          perform_request(method, path, params, body)
         end
       end
     end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/snapshot/get.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/snapshot/get.rb
@@ -3,6 +3,8 @@ module Elasticsearch
     module Snapshot
       module Actions
 
+        VALID_GET_PARAMS = [ :master_timeout ].freeze
+
         # Return information about specific (or all) snapshots
         #
         # @example Return information about the `snapshot-2` snapshot
@@ -24,11 +26,12 @@ module Elasticsearch
         # @see http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/modules-snapshots.html
         #
         def get(arguments={})
+          get_request_for(arguments).body
+        end
+
+        def get_request_for(arguments={})
           raise ArgumentError, "Required argument 'repository' missing" unless arguments[:repository]
           raise ArgumentError, "Required argument 'snapshot' missing"   unless arguments[:snapshot]
-
-          valid_params = [
-            :master_timeout ]
 
           repository = arguments.delete(:repository)
           snapshot   = arguments.delete(:snapshot)
@@ -36,10 +39,10 @@ module Elasticsearch
           method = HTTP_GET
           path   = Utils.__pathify( '_snapshot', Utils.__escape(repository), Utils.__listify(snapshot) )
 
-          params = Utils.__validate_and_extract_params arguments, valid_params
+          params = Utils.__validate_and_extract_params arguments, VALID_GET_PARAMS
           body   = nil
 
-          perform_request(method, path, params, body).body
+          perform_request(method, path, params, body)
         end
       end
     end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/snapshot/get_repository.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/snapshot/get_repository.rb
@@ -3,6 +3,11 @@ module Elasticsearch
     module Snapshot
       module Actions
 
+        VALID_GET_REPOSITORY_PARAMS = [
+          :master_timeout,
+          :local
+        ].freeze
+
         # Get information about snapshot repositories or a specific repository
         #
         # @example Get all repositories
@@ -22,19 +27,19 @@ module Elasticsearch
         # @see http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/modules-snapshots.html
         #
         def get_repository(arguments={})
-          valid_params = [
-            :master_timeout,
-            :local ]
+          get_repository_request_for(arguments).body
+        end
 
+        def get_repository_request_for(arguments={})
           repository = arguments.delete(:repository)
 
           method = HTTP_GET
           path   = Utils.__pathify( '_snapshot', Utils.__escape(repository) )
 
-          params = Utils.__validate_and_extract_params arguments, valid_params
+          params = Utils.__validate_and_extract_params arguments, VALID_GET_REPOSITORY_PARAMS
           body   = nil
 
-          perform_request(method, path, params, body).body
+          perform_request(method, path, params, body)
         end
       end
     end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/snapshot/restore.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/snapshot/restore.rb
@@ -3,6 +3,11 @@ module Elasticsearch
     module Snapshot
       module Actions
 
+        VALID_RESTORE_PARAMS = [
+          :master_timeout,
+          :wait_for_completion
+        ].freeze
+
         # Restore the state from a snapshot
         #
         # @example Restore from the `snapshot-1` snapshot
@@ -29,12 +34,12 @@ module Elasticsearch
         # @see http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/modules-snapshots.html
         #
         def restore(arguments={})
+          restore_request_for(arguments).body
+        end
+
+        def restore_request_for(arguments={})
           raise ArgumentError, "Required argument 'repository' missing" unless arguments[:repository]
           raise ArgumentError, "Required argument 'snapshot' missing"   unless arguments[:snapshot]
-
-          valid_params = [
-            :master_timeout,
-            :wait_for_completion ]
 
           repository = arguments.delete(:repository)
           snapshot   = arguments.delete(:snapshot)
@@ -42,10 +47,10 @@ module Elasticsearch
           method = HTTP_POST
           path   = Utils.__pathify( '_snapshot', Utils.__escape(repository), Utils.__escape(snapshot), '_restore' )
 
-          params = Utils.__validate_and_extract_params arguments, valid_params
+          params = Utils.__validate_and_extract_params arguments, VALID_RESTORE_PARAMS
           body   = arguments[:body]
 
-          perform_request(method, path, params, body).body
+          perform_request(method, path, params, body)
         end
       end
     end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/snapshot/status.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/snapshot/status.rb
@@ -3,6 +3,8 @@ module Elasticsearch
     module Snapshot
       module Actions
 
+        VALID_STATUS_PARAMS = [ :master_timeout ].freeze
+
         # Return information about a running snapshot
         #
         # @example Return information about all currently running snapshots
@@ -20,19 +22,20 @@ module Elasticsearch
         # @see http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/modules-snapshots.html#_snapshot_status
         #
         def status(arguments={})
-          valid_params = [
-            :master_timeout ]
+          status_request_for(arguments).body
+        end
 
+        def status_request_for(arguments={})
           repository = arguments.delete(:repository)
           snapshot   = arguments.delete(:snapshot)
 
           method = HTTP_GET
 
           path   = Utils.__pathify( '_snapshot', Utils.__escape(repository), Utils.__escape(snapshot), '_status')
-          params = Utils.__validate_and_extract_params arguments, valid_params
+          params = Utils.__validate_and_extract_params arguments, VALID_STATUS_PARAMS
           body   = nil
 
-          perform_request(method, path, params, body).body
+          perform_request(method, path, params, body)
         end
       end
     end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/snapshot/verify_repository.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/snapshot/verify_repository.rb
@@ -3,6 +3,12 @@ module Elasticsearch
     module Snapshot
       module Actions
 
+        VALID_VERIFY_REPOSITORY_PARAMS = [
+          :repository,
+          :master_timeout,
+          :timeout
+        ].freeze
+
         # Explicitly perform the verification of a repository
         #
         # @option arguments [String] :repository A repository name (*Required*)
@@ -12,20 +18,19 @@ module Elasticsearch
         # @see http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/modules-snapshots.html
         #
         def verify_repository(arguments={})
-          raise ArgumentError, "Required argument 'repository' missing" unless arguments[:repository]
+          verify_repository_request_for(arguments).body
+        end
 
-          valid_params = [
-            :repository,
-            :master_timeout,
-            :timeout ]
+        def verify_repository_request_for(arguments={})
+          raise ArgumentError, "Required argument 'repository' missing" unless arguments[:repository]
 
           repository = arguments.delete(:repository)
           method = HTTP_POST
           path   = Utils.__pathify( '_snapshot', Utils.__escape(repository), '_verify' )
-          params = Utils.__validate_and_extract_params arguments, valid_params
+          params = Utils.__validate_and_extract_params arguments, VALID_VERIFY_REPOSITORY_PARAMS
           body   = nil
 
-          perform_request(method, path, params, body).body
+          perform_request(method, path, params, body)
         end
       end
     end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/suggest.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/suggest.rb
@@ -2,6 +2,13 @@ module Elasticsearch
   module API
     module Actions
 
+      VALID_SUGGEST_PARAMS = [
+        :ignore_indices,
+        :preference,
+        :routing,
+        :source
+      ].freeze
+
       # Return query terms suggestions based on provided text and configuration.
       #
       # Pass the request definition in the `:body` argument.
@@ -27,19 +34,17 @@ module Elasticsearch
       # @see http://elasticsearch.org/guide/reference/api/search/suggest/
       #
       def suggest(arguments={})
-        valid_params = [
-          :ignore_indices,
-          :preference,
-          :routing,
-          :source ]
+        suggest_request_for(arguments).body
+      end
 
+      def suggest_request_for(arguments={})
         method = HTTP_POST
         path   = Utils.__pathify( Utils.__listify(arguments[:index]), '_suggest' )
 
-        params = Utils.__validate_and_extract_params arguments, valid_params
+        params = Utils.__validate_and_extract_params arguments, VALID_SUGGEST_PARAMS
         body   = arguments[:body]
 
-        perform_request(method, path, params, body).body
+        perform_request(method, path, params, body)
       end
     end
   end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/termvectors.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/termvectors.rb
@@ -2,6 +2,19 @@ module Elasticsearch
   module API
     module Actions
 
+      VALID_TERMVECTORS_PARAMS = [
+        :term_statistics,
+        :field_statistics,
+        :fields,
+        :offsets,
+        :positions,
+        :payloads,
+        :preference,
+        :realtime,
+        :routing,
+        :parent
+      ].freeze
+
       # Return information and statistics about terms in the fields of a particular document
       #
       # @example Get statistics for an indexed document
@@ -58,20 +71,12 @@ module Elasticsearch
       # @see http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/docs-termvectors.html
       #
       def termvectors(arguments={})
+        termvectors_request_for(arguments).body
+      end
+
+      def termvectors_request_for(arguments={})
         raise ArgumentError, "Required argument 'index' missing" unless arguments[:index]
         raise ArgumentError, "Required argument 'type' missing" unless arguments[:type]
-
-        valid_params = [
-          :term_statistics,
-          :field_statistics,
-          :fields,
-          :offsets,
-          :positions,
-          :payloads,
-          :preference,
-          :realtime,
-          :routing,
-          :parent ]
 
         method = HTTP_GET
         endpoint = arguments.delete(:endpoint) || '_termvectors'
@@ -81,10 +86,10 @@ module Elasticsearch
                                  arguments[:id],
                                  endpoint
 
-        params = Utils.__validate_and_extract_params arguments, valid_params
+        params = Utils.__validate_and_extract_params arguments, VALID_TERMVECTORS_PARAMS
         body   = arguments[:body]
 
-        perform_request(method, path, params, body).body
+        perform_request(method, path, params, body)
       end
 
       # @deprecated Use the plural version, {#termvectors}


### PR DESCRIPTION
The system we are developing has a number of cases where we need to access the response object -- not just the body -- generated by a call to the elasticsearch API. In particular, we want access to both the `status` and the `body` of the response. 

This changeset provides separate `actionname_request_for(args={})` methods which perform the bulk of the work associated with each action. The behavior of the existing `actionname` methods remains unchanged. 

Refactor Elasticsearch API actions. 
  * Expose request objects with intermediate `actionname_request_for(arguments={})` methods
  * Extract 'valid_params' to constants. `VALID_ACTIONNAME_PARAMS`