### PR TITLE
[API] Documented but not actually used parameters for indices.get_warmer 

### DIFF
--- a/elasticsearch-api/lib/elasticsearch/api/actions/abort_benchmark.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/abort_benchmark.rb
@@ -13,8 +13,6 @@ module Elasticsearch
       # @see http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/search-benchmark.html
       #
       def abort_benchmark(arguments={})
-        valid_params = [
-           ]
         method = HTTP_POST
         path   = "_bench/abort/#{arguments[:name]}"
         params = {}

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/get_warmer.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/get_warmer.rb
@@ -48,7 +48,7 @@ module Elasticsearch
 
           method = HTTP_GET
           path   = Utils.__pathify( Utils.__listify(arguments[:index]), '_warmer', Utils.__escape(arguments[:name]) )
-          params = {}
+          params = Utils.__validate_and_extract_params arguments, valid_params
           body   = nil
 
           perform_request(method, path, params, body).body

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/seal.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/seal.rb
@@ -11,8 +11,6 @@ module Elasticsearch
         # @see http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-seal.html
         #
         def seal(arguments={})
-          valid_params = [
-             ]
           method = 'POST'
           path   = Utils.__pathify Utils.__listify(arguments[:index]), '_seal'
           params = {}

--- a/elasticsearch-api/lib/elasticsearch/api/actions/list_benchmarks.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/list_benchmarks.rb
@@ -15,8 +15,6 @@ module Elasticsearch
       # @see http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/search-benchmark.html
       #
       def list_benchmarks(arguments={})
-        valid_params = [
-           ]
         method = HTTP_GET
         path   = "_bench"
         params = {}


### PR DESCRIPTION
indices.get_warmer accepts some parameters according to its documentation, but these were not actually used.
Also, eliminated some unused extra `valid_params` Array instance creations for several other API calls.