### PR TITLE
[CLIENT] Support Faraday builder custom handlers

### DIFF
--- a/elasticsearch-transport/lib/elasticsearch/transport/client.rb
+++ b/elasticsearch-transport/lib/elasticsearch/transport/client.rb
@@ -65,6 +65,14 @@ module Elasticsearch
       #
       # @option arguments [Hash] :transport_options Options to be passed to the `Faraday::Connection` constructor
       #
+      # @option arguments [Symbol] :request_builder Type of request to be built by the `Faraday::Request` builder
+      #
+      # @option arguments [Hash] :request_builder_options Options to be passed to the `Faraday::Request` builder
+      #
+      # @option arguments [Symbol] :response_builder Type of response to be built by the `Faraday::Response` builder
+      #
+      # @option arguments [Hash] :response_builder_options Options to be passed to the `Faraday::Response` builder
+      #
       # @option arguments [Constant] :transport_class  A specific transport class to use, will be initialized by
       #                                                the client and passed hosts and all arguments
       #
@@ -103,6 +111,8 @@ module Elasticsearch
         @transport       = arguments[:transport] || begin
           if transport_class == Transport::HTTP::Faraday
             transport_class.new(:hosts => __extract_hosts(hosts, arguments), :options => arguments) do |faraday|
+              faraday.request(arguments[:request_builder], arguments[:request_builder_options]) if arguments[:request_builder]
+              faraday.response(arguments[:response_builder], arguments[:response_builder_options]) if arguments[:response_builder]
               faraday.adapter(arguments[:adapter] || __auto_detect_adapter)
             end
           else


### PR DESCRIPTION
Default client accepts options for setting custom handlers to Faraday RackBuilder.

Just like that:
```ruby
Elasticsearch::Client.new request_builder: :foo, request_builder_options: { foo: 'bar' }
```

Then [Faraday::RackMiddleware](https://github.com/lostisland/faraday/blob/77d7546d6d626b91086f427c56bc2cdd951353b3/lib/faraday/rack_builder.rb#L6) request handler is customized according to passed options. Same is possible to response handlers through `response_builder` and `response_builder_options`.