### PR TITLE
Added format option to range filter and query

### DIFF
--- a/elasticsearch-dsl/lib/elasticsearch/dsl/search/filters/range.rb
+++ b/elasticsearch-dsl/lib/elasticsearch/dsl/search/filters/range.rb
@@ -31,6 +31,7 @@ module Elasticsearch
           option_method :lt
           option_method :boost
           option_method :time_zone
+          option_method :format
         end
 
       end

--- a/elasticsearch-dsl/lib/elasticsearch/dsl/search/queries/range.rb
+++ b/elasticsearch-dsl/lib/elasticsearch/dsl/search/queries/range.rb
@@ -39,6 +39,7 @@ module Elasticsearch
           option_method :lt
           option_method :boost
           option_method :time_zone
+          option_method :format
         end
 
       end

--- a/elasticsearch-dsl/test/unit/filters/range_test.rb
+++ b/elasticsearch-dsl/test/unit/filters/range_test.rb
@@ -19,8 +19,9 @@ module Elasticsearch
             subject.gte 'bar'
             subject.lte 'bar'
             subject.time_zone 'bar'
+            subject.format 'bar'
 
-            assert_equal %w[ gte lte time_zone ],
+            assert_equal %w[ format gte lte time_zone ],
                          subject.to_hash[:range][:foo].keys.map(&:to_s).sort
 
             assert_equal 'bar', subject.to_hash[:range][:foo][:gte]

--- a/elasticsearch-dsl/test/unit/queries/range_test.rb
+++ b/elasticsearch-dsl/test/unit/queries/range_test.rb
@@ -19,17 +19,19 @@ module Elasticsearch
               gte   10
               lte   20
               boost 2
+              format 'mm/dd/yyyy'
             end
 
-            assert_equal({:range=>{:age=>{:gte=>10, :lte=>20, :boost=>2}}}, @subject.to_hash)
+            assert_equal({:range=>{:age=>{:gte=>10, :lte=>20, :boost=>2, :format=>'mm/dd/yyyy'}}}, @subject.to_hash)
           end
 
           should "take a method call" do
             @subject = Range.new :age
             @subject.gte 10
             @subject.lte 20
+            @subject.format 'mm/dd/yyyy'
 
-            assert_equal({:range=>{:age=>{:gte=>10, :lte=>20}}}, @subject.to_hash)
+            assert_equal({:range=>{:age=>{:gte=>10, :lte=>20, :format=>'mm/dd/yyyy'}}}, @subject.to_hash)
           end
 
         end


### PR DESCRIPTION
I added the format option to range filter and query for when a the range is a date as per:
https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-range-filter.html
https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-range-query.html