### PR TITLE
Added fuzziness option to Match query

### DIFF
--- a/elasticsearch-dsl/lib/elasticsearch/dsl/search/queries/match.rb
+++ b/elasticsearch-dsl/lib/elasticsearch/dsl/search/queries/match.rb
@@ -26,6 +26,7 @@ module Elasticsearch
           option_method :operator
           option_method :type
           option_method :boost
+          option_method :fuzziness
         end
 
       end

--- a/elasticsearch-dsl/test/unit/queries/match_test.rb
+++ b/elasticsearch-dsl/test/unit/queries/match_test.rb
@@ -39,13 +39,14 @@ module Elasticsearch
 
           should "take a block" do
             subject = Match.new :message do
-              query    'test'
-              operator 'and'
-              type     'phrase_prefix'
-              boost    2
+              query     'test'
+              operator  'and'
+              type      'phrase_prefix'
+              boost     2
+              fuzziness 'AUTO'
             end
 
-            assert_equal({match: {message: {query: "test", operator: "and", type: 'phrase_prefix', boost: 2}}},
+            assert_equal({match: {message: {query: "test", operator: "and", type: 'phrase_prefix', boost: 2, fuzziness: 'AUTO'}}},
                          subject.to_hash)
           end
 


### PR DESCRIPTION
Just added the missing fuzziness option to the Match query as seen [here](https://www.elastic.co/guide/en/elasticsearch/guide/current/fuzzy-match-query.html)