### PR TITLE
Support for reload_connections when using SSL or basic auth

### DIFF
--- a/elasticsearch-transport/lib/elasticsearch/transport/transport/http/faraday.rb
+++ b/elasticsearch-transport/lib/elasticsearch/transport/transport/http/faraday.rb
@@ -34,8 +34,12 @@ module Elasticsearch
           def __build_connections
             Connections::Collection.new \
               :connections => hosts.map { |host|
-                host[:protocol]   = host[:scheme] || DEFAULT_PROTOCOL
-                host[:port]     ||= DEFAULT_PORT
+                host[:protocol]   = host[:scheme] || options[:scheme] || DEFAULT_PROTOCOL
+                host[:port] ||= options[:port] || DEFAULT_PORT
+                if options[:user] && !host[:user]
+                  host[:user] ||= options[:user]
+                  host[:password] ||= options[:password]
+                end
                 url               = __full_url(host)
 
                 Connections::Connection.new \

--- a/elasticsearch-transport/lib/elasticsearch/transport/transport/sniffer.rb
+++ b/elasticsearch-transport/lib/elasticsearch/transport/transport/sniffer.rb
@@ -5,7 +5,7 @@ module Elasticsearch
       # Handles node discovery ("sniffing").
       #
       class Sniffer
-        RE_URL  = /\/([^:]*):([0-9]+)\]/ # Use named groups on Ruby 1.9: /\/(?<host>[^:]*):(?<port>[0-9]+)\]/
+        RE_URL  = /\[([^\/]*)\/([^:]*):([0-9]+)\]/ # Use named groups on Ruby 1.9: /\/(?<host>[^:]*):(?<port>[0-9]+)\]/
 
         attr_reader   :transport
         attr_accessor :timeout
@@ -32,7 +32,8 @@ module Elasticsearch
             hosts = nodes['nodes'].map do |id,info|
               if matches = info["#{transport.protocol}_address"].to_s.match(RE_URL)
                 # TODO: Implement lightweight "indifferent access" here
-                info.merge :host => matches[1], :port => matches[2], :id => id
+                host = (matches[1].nil? || matches[1].empty?) ? matches[2] : matches[1]
+                info.merge :host => host, :port => matches[3], :id => id
               end
             end.compact
 

--- a/elasticsearch-transport/test/unit/sniffer_test.rb
+++ b/elasticsearch-transport/test/unit/sniffer_test.rb
@@ -48,6 +48,33 @@ class Elasticsearch::Transport::Transport::SnifferTest < Test::Unit::TestCase
       assert_equal 'Node 1',       hosts.first['name']
     end
 
+    should "return an array of hosts as hashes when hostname exists" do
+      @transport.expects(:perform_request).returns __nodes_info <<-JSON
+        {
+          "ok" : true,
+          "cluster_name" : "elasticsearch_test",
+          "nodes" : {
+            "N1" : {
+              "name" : "Node 1",
+              "transport_address" : "inet[/192.168.1.23:9300]",
+              "hostname" : "testhost1",
+              "version" : "0.20.6",
+              "http_address" : "inet[testhost1.com/192.168.1.23:9200]",
+              "thrift_address" : "/192.168.1.23:9500",
+              "memcached_address" : "inet[/192.168.1.23:11211]"
+            }
+          }
+        }
+      JSON
+
+      hosts = @sniffer.hosts
+
+      assert_equal 1, hosts.size
+      assert_equal 'testhost1.com', hosts.first[:host]
+      assert_equal '9200',         hosts.first[:port]
+      assert_equal 'Node 1',       hosts.first['name']
+    end
+
     should "skip hosts without a matching transport protocol" do
       @transport = DummyTransport.new :options => { :protocol => 'memcached' }
       @sniffer   = Elasticsearch::Transport::Transport::Sniffer.new @transport

--- a/elasticsearch-transport/test/unit/transport_faraday_test.rb
+++ b/elasticsearch-transport/test/unit/transport_faraday_test.rb
@@ -135,6 +135,43 @@ class Elasticsearch::Transport::Transport::HTTP::FaradayTest < Test::Unit::TestC
       transport = Faraday.new :hosts => [ { :host => 'foobar', :port => 1234, :user => 'foo', :password => 'bar' } ]
       assert_equal 'Basic Zm9vOmJhcg==', transport.connections.first.connection.headers['Authorization']
     end
+
+    should "set the credentials if exist in options" do
+      transport = Faraday.new :hosts => [ { :host => 'foobar', :port => 1234 } ],
+                              :options => { :user => 'foo', :password => 'bar' }
+      assert_equal 'Basic Zm9vOmJhcg==', transport.connections.first.connection.headers['Authorization']
+    end
+
+    should "override options credentials if passed explicitly" do
+      transport = Faraday.new :hosts => [ { :host => 'foobar', :port => 1234, :user => 'foo', :password => 'bar' },
+                                          { :host => 'foobar2', :port => 1234 } ],
+                              :options => { :user => 'foo2', :password => 'bar2' }
+      assert_equal 'Basic Zm9vOmJhcg==', transport.connections.first.connection.headers['Authorization']
+      assert_equal 'Basic Zm9vMjpiYXIy', transport.connections[1].connection.headers['Authorization']
+    end
+
+    should "set connection scheme to https if passed" do
+      transport = Faraday.new :hosts => [ { :host => 'foobar', :port => 1234, :scheme => 'https' } ]
+
+      assert_instance_of ::Faraday::Connection, transport.connections.first.connection
+      assert_equal 'https://foobar:1234/',       transport.connections.first.connection.url_prefix.to_s
+    end
+
+    should "set connection scheme to https if exist in options" do
+      transport = Faraday.new :hosts => [ { :host => 'foobar', :port => 1234} ],
+                              :options => { :scheme => 'https' }
+
+      assert_instance_of ::Faraday::Connection, transport.connections.first.connection
+      assert_equal 'https://foobar:1234/',       transport.connections.first.connection.url_prefix.to_s
+    end
+
+    should "override options scheme if passed explicitly" do
+      transport = Faraday.new :hosts => [ { :host => 'foobar', :port => 1234, :scheme => 'http'} ],
+                              :options => { :scheme => 'https' }
+
+      assert_instance_of ::Faraday::Connection, transport.connections.first.connection
+      assert_equal 'http://foobar:1234/',       transport.connections.first.connection.url_prefix.to_s
+    end
   end
 
 end


### PR DESCRIPTION
Added support for reload_connections/reload_on_failure when using basic auth (user/password) and https connections (i.e. when using Shield)