### PR TITLE
URL-escape the document ID while percolating a document already indexed

### DIFF
--- a/elasticsearch-api/lib/elasticsearch/api/actions/percolate.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/percolate.rb
@@ -93,7 +93,7 @@ module Elasticsearch
         method = HTTP_GET
         path   = Utils.__pathify Utils.__escape(arguments[:index]),
                                  Utils.__escape(arguments[:type]),
-                                 arguments[:id],
+                                 Utils.__escape(arguments[:id]),
                                  '_percolate'
 
         params = Utils.__validate_and_extract_params arguments, valid_params

--- a/elasticsearch-api/test/unit/percolate_test.rb
+++ b/elasticsearch-api/test/unit/percolate_test.rb
@@ -40,6 +40,15 @@ module Elasticsearch
           subject.percolate :index => 'foo^bar', :type => 'bar/bam', :body => { :doc => { :foo => 'bar' } }
         end
 
+        should "URL-escape the parts (including document id)" do
+          subject.expects(:perform_request).with do |method, url, params, body|
+            assert_equal 'foo%5Ebar/bar%2Fbam/some%2Fid/_percolate', url
+            true
+          end.returns(FakeResponse.new)
+
+          subject.percolate :index => 'foo^bar', :type => 'bar/bam', :id => 'some/id'
+        end
+
       end
 
     end


### PR DESCRIPTION
The document ID can contain slashes or characters not allowed in a URI