### PR TITLE
Prevent cluster clearing done right

### DIFF
--- a/elasticsearch-extensions/README.md
+++ b/elasticsearch-extensions/README.md
@@ -90,6 +90,19 @@ You can control the cluster configuration with environment variables as well:
     TEST_CLUSTER_NAME=my_testing_cluster \
     ruby -r elasticsearch -e "require 'elasticsearch/extensions/test/cluster'; Elasticsearch::Extensions::Test::Cluster.start"
 
+When the cluster is started its content is wiped out by default. While this is good for test environment, one may
+want to keep data across restarts if using the test cluster in development. To control this behavior there is a
+setting that can be passed via options or environment, e.g.
+
+    # Using ruby
+    require 'elasticsearch/extensions/test/cluster'
+    Elasticsearch::Extensions::Test::Cluster.start clear_cluster: false
+
+    # Using ENV (only literal false is accepted here)
+    TEST_CLUSTER_CLEAR=false \
+    ruby -r elasticsearch -e "require 'elasticsearch/extensions/test/cluster'; Elasticsearch::Extensions::Test::Cluster.start"
+
+
 [Full documentation](http://rubydoc.info/gems/elasticsearch-extensions/Elasticsearch/Extensions/Test/Cluster)
 
 ### Test::StartupShutdown

--- a/elasticsearch-extensions/lib/elasticsearch/extensions/test/cluster.rb
+++ b/elasticsearch-extensions/lib/elasticsearch/extensions/test/cluster.rb
@@ -54,7 +54,7 @@ module Elasticsearch
         # @option arguments [Boolean] :multicast_enabled Whether multicast is enabled (default: true)
         # @option arguments [Integer] :timeout      Timeout when starting the cluster (default: 30)
         # @option arguments [String]  :network_host The host that nodes will bind on and publish to
-        # @option arguments [Boolean] :clear        Wipe out cluster content on startup (default: true)
+        # @option arguments [Boolean] :clear_cluster Wipe out cluster content on startup (default: true)
         #
         # You can also use environment variables to set these options.
         #
@@ -89,7 +89,9 @@ module Elasticsearch
           arguments[:multicast_enabled] ||= ENV.fetch('TEST_CLUSTER_MULTICAST', 'true')
           arguments[:timeout]           ||= (ENV.fetch('TEST_CLUSTER_TIMEOUT', 30).to_i)
           arguments[:network_host]      ||= @@network_host
-          arguments[:clear]             ||= true
+          # Flag to clear the cluster. May be passed directly with args or via ENV variables.
+          clear_cluster = !!arguments[:clear_cluster] || (ENV.fetch('TEST_CLUSTER_CLEAR', 'true') != 'false')
+
 
           # Make sure `cluster_name` is not dangerous
           if arguments[:cluster_name] =~ /^[\/\\]?$/
@@ -103,7 +105,7 @@ module Elasticsearch
           end
 
           # Wipe out data for this cluster name if requested
-          FileUtils.rm_rf "#{arguments[:path_data]}/#{arguments[:cluster_name]}" if arguments[:clear]
+          FileUtils.rm_rf "#{arguments[:path_data]}/#{arguments[:cluster_name]}" if clear_cluster
 
           print "Starting ".ansi(:faint) +
                 @@number_of_nodes.to_s.ansi(:bold, :faint) +


### PR DESCRIPTION
What I did in #194 was a noop :scream: 

```ruby
arguments[:clear] ||= true # This is always true, d'oh!
```

This is the right implementation for that.