### PR TITLE
[CLIENT] Faraday configuration block support

### DIFF
--- a/elasticsearch-transport/README.md
+++ b/elasticsearch-transport/README.md
@@ -289,6 +289,16 @@ To configure the _Faraday_ instance, pass a configuration block to the transport
     #
     client = Elasticsearch::Client.new transport: transport
 
+And you can also configure the _Faraday_ instance directly by using block:
+
+    require 'typhoeus'
+    require 'typhoeus/adapters/faraday'
+
+    client = Elasticsearch::Client.new(host: 'localhost', port: '9200') do |f|
+      f.response :logger
+      f.adapter  :typhoeus
+    end
+
 To pass options to the
 [`Faraday::Connection`](https://github.com/lostisland/faraday/blob/master/lib/faraday/connection.rb)
 constructor, use the `transport_options` key:

--- a/elasticsearch-transport/lib/elasticsearch/transport.rb
+++ b/elasticsearch-transport/lib/elasticsearch/transport.rb
@@ -22,8 +22,8 @@ module Elasticsearch
 
     # A convenience wrapper for {::Elasticsearch::Transport::Client#initialize}.
     #
-    def new(arguments={})
-      Elasticsearch::Transport::Client.new(arguments)
+    def new(arguments={}, &block)
+      Elasticsearch::Transport::Client.new(arguments, &block)
     end
     extend self
   end

--- a/elasticsearch-transport/lib/elasticsearch/transport/client.rb
+++ b/elasticsearch-transport/lib/elasticsearch/transport/client.rb
@@ -79,6 +79,8 @@ module Elasticsearch
       # @option arguments [String] :send_get_body_as Specify the HTTP method to use for GET requests with a body.
       #                                              (Default: GET)
       #
+      # @yield [faraday] Gives `Faraday::Connection` instance. You can configure it directly in this block.
+      #
       def initialize(arguments={}, &block)
         hosts = arguments[:hosts] || \
                 arguments[:host]  || \

--- a/elasticsearch-transport/lib/elasticsearch/transport/client.rb
+++ b/elasticsearch-transport/lib/elasticsearch/transport/client.rb
@@ -79,7 +79,7 @@ module Elasticsearch
       # @option arguments [String] :send_get_body_as Specify the HTTP method to use for GET requests with a body.
       #                                              (Default: GET)
       #
-      def initialize(arguments={})
+      def initialize(arguments={}, &block)
         hosts = arguments[:hosts] || \
                 arguments[:host]  || \
                 arguments[:url]   || \
@@ -103,7 +103,11 @@ module Elasticsearch
         @transport       = arguments[:transport] || begin
           if transport_class == Transport::HTTP::Faraday
             transport_class.new(:hosts => __extract_hosts(hosts, arguments), :options => arguments) do |faraday|
-              faraday.adapter(arguments[:adapter] || __auto_detect_adapter)
+              if block
+                block.call faraday
+              else
+                faraday.adapter(arguments[:adapter] || __auto_detect_adapter)
+              end
             end
           else
             transport_class.new(:hosts => __extract_hosts(hosts, arguments), :options => arguments)


### PR DESCRIPTION
For using Amazon Elasticsearch Service in secure way, we need to use [faraday_middleware-aws-signers-v4](https://github.com/winebarrel/faraday_middleware-aws-signers-v4) for signing requests.

As discussed in #232 , I think block approach is better too.
I implemented the approach to pass faraday configuration block to `Elasticsearch::Client.new` directory.
It seems to be more simple than passing proc object approach.

```ruby
require 'faraday_middleware/aws_signers_v4'

Elasticsearch::Model.client = Elasticsearch::Client.new(host: 'xxx', port: 'yyyy') do |client|
  client.request :aws_signers_v4,
    credentials: Aws::SharedCredentials.new,
    service_name: 'es',
    region: 'ap-northeast-1'
  client.adapter Faraday.default_adapter
end
```

How do you think about it?