### PR TITLE
Add bytes as a valid parameter to client.cat.shards

### DIFF
--- a/elasticsearch-api/lib/elasticsearch/api/actions/cat/shards.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/cat/shards.rb
@@ -21,6 +21,10 @@ module Elasticsearch
         #
         #     puts client.cat.shards v: true
         #
+        # @example Display shard size in choice of units
+        #
+        #     puts client.cat.shards bytes: 'b'
+        #
         # @example Display only specific columns in the output (see the `help` parameter)
         #
         #     puts client.cat.shards h: ['node', 'index', 'shard', 'prirep', 'docs', 'store', 'merges.total']
@@ -49,6 +53,7 @@ module Elasticsearch
           valid_params = [
             :local,
             :master_timeout,
+            :bytes,
             :h,
             :help,
             :v ]


### PR DESCRIPTION
The documentation states that this is a valid parameter, but it is not allowed as one in the code, also there was no example, so I have added it.

Close #236 