### PR TITLE
Add bytes as a valid parameter to _cat/{shards,segments}

### DIFF
--- a/elasticsearch-api/lib/elasticsearch/api/actions/cat/segments.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/cat/segments.rb
@@ -10,6 +10,7 @@ module Elasticsearch
         #     puts client.cat.segments
         #
         # @option arguments [List] :index A comma-separated list of index names to limit the returned information
+        # @option arguments [String] :bytes The unit in which to display byte values (options: b, k, m, g)
         # @option arguments [List] :h Comma-separated list of column names to display
         # @option arguments [Boolean] :help Return help information
         # @option arguments [Boolean] :v Verbose mode. Display column headers
@@ -18,6 +19,7 @@ module Elasticsearch
         #
         def segments(arguments={})
           valid_params = [
+            :bytes,
             :h,
             :help,
             :v ]

--- a/elasticsearch-api/lib/elasticsearch/api/actions/cat/shards.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/cat/shards.rb
@@ -21,6 +21,10 @@ module Elasticsearch
         #
         #     puts client.cat.shards v: true
         #
+        # @example Display shard size in choice of units
+        #
+        #     puts client.cat.shards bytes: 'b'
+        #
         # @example Display only specific columns in the output (see the `help` parameter)
         #
         #     puts client.cat.shards h: ['node', 'index', 'shard', 'prirep', 'docs', 'store', 'merges.total']
@@ -49,6 +53,7 @@ module Elasticsearch
           valid_params = [
             :local,
             :master_timeout,
+            :bytes,
             :h,
             :help,
             :v ]


### PR DESCRIPTION
Bytes is a valid parameter for a selection of the _cat commands but it looks like it was accidently excluded from two of them.

This commit adds them in.