### PR TITLE
do not escape fields in search

### DIFF
--- a/elasticsearch-api/lib/elasticsearch/api/actions/search.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/search.rb
@@ -158,8 +158,8 @@ module Elasticsearch
 
         body   = arguments[:body]
 
-        params[:fields] = Utils.__listify(params[:fields]) if params[:fields]
-        params[:fielddata_fields] = Utils.__listify(params[:fielddata_fields]) if params[:fielddata_fields]
+        params[:fields] = Utils.__listify(params[:fields], :escape => false) if params[:fields]
+        params[:fielddata_fields] = Utils.__listify(params[:fielddata_fields], :escape => false) if params[:fielddata_fields]
 
         # FIX: Unescape the `filter_path` parameter due to __listify default behavior. Investigate.
         params[:filter_path] =  defined?(EscapeUtils) ? EscapeUtils.unescape_url(params[:filter_path]) : CGI.unescape(params[:filter_path]) if params[:filter_path]


### PR DESCRIPTION
If you provide a fields list and one of the fields hat a space in the name, the space gets escaped to a plus '+' sign. And then it will again be escaped by the transport layer to a %2B (which is an url-encoded '+') instead of %20. So i think we should not escape the fields because they will be escaped by the transport layer.
I am not sure if there are other places in the code with the same double encoding problem, we just found it in the search but did not check other methods.

What do you think?