### PR TITLE
close_connections during rebuild

### DIFF
--- a/elasticsearch-transport/lib/elasticsearch/transport/transport/base.rb
+++ b/elasticsearch-transport/lib/elasticsearch/transport/transport/base.rb
@@ -96,17 +96,16 @@ module Elasticsearch
         def __rebuild_connections(arguments={})
           @hosts       = arguments[:hosts]    || []
           @options     = arguments[:options]  || {}
-          old_connections = @connections # set aside old connections
+          __close_connections # close old connections
           @connections = __build_connections
-          __close_connections(old_connections) # close old connections
         end
 
         # Closes the connections collection.
         #
         # @api private
         #
-        def __close_connections(connections)
-          # to be implemented by the transport
+        def __close_connections
+          @connections.each {|c| c.dead! }
         end
 
         # Log request and response information.

--- a/elasticsearch-transport/lib/elasticsearch/transport/transport/base.rb
+++ b/elasticsearch-transport/lib/elasticsearch/transport/transport/base.rb
@@ -96,7 +96,17 @@ module Elasticsearch
         def __rebuild_connections(arguments={})
           @hosts       = arguments[:hosts]    || []
           @options     = arguments[:options]  || {}
+          old_connections = @connections # set aside old connections
           @connections = __build_connections
+          __close_connections(old_connections) # close old connections
+        end
+
+        # Closes the connections collection.
+        #
+        # @api private
+        #
+        def __close_connections(connections)
+          # to be implemented by the transport
         end
 
         # Log request and response information.

--- a/elasticsearch-transport/test/unit/transport_base_test.rb
+++ b/elasticsearch-transport/test/unit/transport_base_test.rb
@@ -485,6 +485,17 @@ class Elasticsearch::Transport::Transport::BaseTest < Test::Unit::TestCase
     end
   end
 
+  context "closing connections" do
+    setup do
+      @transport = DummyTransport.new
+    end
+
+    should "close connections" do
+      @transport.__close_connections
+      assert_equal @transport.connections, []
+    end
+  end
+
   context "resurrecting connections" do
     setup do
       @transport = DummyTransportPerformer.new

--- a/elasticsearch-transport/test/unit/transport_base_test.rb
+++ b/elasticsearch-transport/test/unit/transport_base_test.rb
@@ -473,6 +473,11 @@ class Elasticsearch::Transport::Transport::BaseTest < Test::Unit::TestCase
       @transport = DummyTransport.new
     end
 
+    should "close connections" do
+      @transport.expects(:__close_connections)
+      @transport.__rebuild_connections :hosts => ['foo']
+    end
+
     should "should replace the connections" do
       assert_equal [], @transport.connections
       @transport.__rebuild_connections :hosts => ['foo', 'bar']


### PR DESCRIPTION
allows transport implementations to define `__close_connections` that is called during `__rebuild_connections`
[edit] By default this only marks all connections as dead.

sets up the necessary code path to fix #241 