### PR TITLE
Manticore close connections

### DIFF
--- a/elasticsearch-transport/lib/elasticsearch/transport/transport/base.rb
+++ b/elasticsearch-transport/lib/elasticsearch/transport/transport/base.rb
@@ -96,7 +96,16 @@ module Elasticsearch
         def __rebuild_connections(arguments={})
           @hosts       = arguments[:hosts]    || []
           @options     = arguments[:options]  || {}
+          __close_connections
           @connections = __build_connections
+        end
+
+        # Closes the connections collection.
+        #
+        # @api private
+        #
+        def __close_connections
+          # to be implemented by specific transports
         end
 
         # Log request and response information.

--- a/elasticsearch-transport/lib/elasticsearch/transport/transport/http/manticore.rb
+++ b/elasticsearch-transport/lib/elasticsearch/transport/transport/http/manticore.rb
@@ -105,6 +105,16 @@ module Elasticsearch
               :selector => options[:selector]
           end
 
+          # Closes all connections by marking them as dead
+          # and closing the underlying HttpClient instances
+          #
+          # @return [Connections::Collection]
+          #
+          def __close_connections
+            @connections.each {|c| c.dead! }
+            @connections.all.each {|c| c.connection.close }
+          end
+
           # Returns an array of implementation specific connection errors.
           #
           # @return [Array]

--- a/elasticsearch-transport/test/unit/transport_base_test.rb
+++ b/elasticsearch-transport/test/unit/transport_base_test.rb
@@ -473,6 +473,11 @@ class Elasticsearch::Transport::Transport::BaseTest < Test::Unit::TestCase
       @transport = DummyTransport.new
     end
 
+    should "close connections" do
+      @transport.expects(:__close_connections)
+      @transport.__rebuild_connections :hosts => ['foo']
+    end
+
     should "should replace the connections" do
       assert_equal [], @transport.connections
       @transport.__rebuild_connections :hosts => ['foo', 'bar']

--- a/elasticsearch-transport/test/unit/transport_manticore_test.rb
+++ b/elasticsearch-transport/test/unit/transport_manticore_test.rb
@@ -26,6 +26,19 @@ else
         assert_instance_of ::Manticore::Client,   @transport.connections.first.connection
       end
 
+      should "implement __close_connections" do
+        assert_equal 1, @transport.connections.size
+        @transport.__close_connections
+        assert_equal 0, @transport.connections.size
+      end
+
+      should "prevent requests after __close_connections" do
+        @transport.__close_connections
+        assert_raises ::Manticore::ClientStoppedException do
+          @transport.perform_request 'GET', '/'
+        end
+      end
+
       should "perform the request" do
         @transport.connections.first.connection.expects(:get).returns(stub_everything)
         @transport.perform_request 'GET', '/'


### PR DESCRIPTION
includes #245 and adds specific implementation for manticore by calling Manticore::Client#close (which is proposed in https://github.com/cheald/manticore/pull/39