### PR TITLE
allow percolate_format for mpercolate queries

### DIFF
--- a/elasticsearch-api/lib/elasticsearch/api/actions/mpercolate.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/mpercolate.rb
@@ -34,7 +34,8 @@ module Elasticsearch
         valid_params = [
           :ignore_unavailable,
           :allow_no_indices,
-          :expand_wildcards ]
+          :expand_wildcards,
+          :percolate_format ]
 
         method = HTTP_GET
         path   = "_mpercolate"


### PR DESCRIPTION
`mpercolate` does not support `percolate_format` per-action specification but will respond as expected when passed as a url parameter.  For example:

Does not respect percolate_format: `GET /_mpercolate`
```
{"percolate" : {"index" : "twitter", "type" : "tweet", "id" : "1", "percolate_format": "ids"}}
{}
```

Does: `GET /_mpercolate?percolate_format=ids`
```
{"percolate" : {"index" : "twitter", "type" : "tweet", "id" : "1"}}
{}
```

This change allows for the second form.