### PR TITLE
problem: elasticsearch-dsl tests fail on MRI 2.2.3

### DIFF
--- a/elasticsearch-dsl/elasticsearch-dsl.gemspec
+++ b/elasticsearch-dsl/elasticsearch-dsl.gemspec
@@ -37,7 +37,8 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'yard'
   s.add_development_dependency 'cane'
   s.add_development_dependency 'pry'
-  if defined?(RUBY_VERSION) && RUBY_VERSION > '2.2'
-    s.add_development_dependency "test-unit", '~> 2'
-  end
+
+  # if defined?(RUBY_VERSION) && RUBY_VERSION > '2.2'
+  #   s.add_development_dependency "test-unit", '~> 2'
+  # end
 end

--- a/elasticsearch-dsl/elasticsearch-dsl.gemspec
+++ b/elasticsearch-dsl/elasticsearch-dsl.gemspec
@@ -37,4 +37,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'yard'
   s.add_development_dependency 'cane'
   s.add_development_dependency 'pry'
+  if defined?(RUBY_VERSION) && RUBY_VERSION > '2.2'
+    s.add_development_dependency "test-unit", '~> 2'
+  end
 end


### PR DESCRIPTION
solution: 
- add missing test-unit gem for ruby > 2.2, like done for other sibling gems