### PR TITLE
fixes travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,6 +34,7 @@ install:
   - test $TEST_SUITE == 'integration' && curl -s https://download.elasticsearch.org/elasticsearch/release/org/elasticsearch/distribution/tar/elasticsearch/2.0.0-rc1/elasticsearch-2.0.0-rc1.tar.gz | tar xz -C /tmp || true
 
 before_script:
+  - gem install bundler -v 1.11.2
   - rake setup
   - rake elasticsearch:update
   - rake bundle:clean


### PR DESCRIPTION
problem: travis build is broken with a strange error: NoMethodError: undefined method `spec' for nil:NilClass



solution: 
- take the latest bundler version (1.11.2)