### PR TITLE
moves ci + code climate badges to top

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
 # Elasticsearch
+[![Build Status](https://travis-ci.org/elastic/elasticsearch-ruby.svg?branch=master)](https://travis-ci.org/elastic/elasticsearch-ruby) [![Code Climate](https://codeclimate.com/github/elastic/elasticsearch-ruby/badges/gpa.svg)](https://codeclimate.com/github/elastic/elasticsearch-ruby)
+
 
 This repository contains Ruby integrations for [Elasticsearch](http://elasticsearch.org):
 
@@ -88,8 +90,6 @@ Keep in mind, that for optimal performance, you should use a HTTP library which 
 * [Test Suite](https://github.com/elasticsearch/elasticsearch-ruby/blob/master/elasticsearch-extensions/test)
 
 ## Development
-
-[![Build Status](https://travis-ci.org/elastic/elasticsearch-ruby.svg?branch=master)](https://travis-ci.org/elastic/elasticsearch-ruby) [![Code Climate](https://codeclimate.com/github/elastic/elasticsearch-ruby/badges/gpa.svg)](https://codeclimate.com/github/elastic/elasticsearch-ruby)
 
 To work on the code, clone and bootstrap the project first:
 


### PR DESCRIPTION
problem: the state of the travis build is not immediately visible when you open the project on github


solution: 
- move the travisci + code climate badges to top, so it keeps you motivated to fix the build rather sooner ;)