### PR TITLE
Use /tmp folder for logs by default

### DIFF
--- a/elasticsearch-extensions/lib/elasticsearch/extensions/test/cluster.rb
+++ b/elasticsearch-extensions/lib/elasticsearch/extensions/test/cluster.rb
@@ -84,7 +84,7 @@ module Elasticsearch
           arguments[:node_name]         ||= ENV.fetch('TEST_CLUSTER_NODE_NAME', 'node')
           arguments[:path_data]         ||= ENV.fetch('TEST_CLUSTER_DATA',      '/tmp/elasticsearch_test')
           arguments[:path_work]         ||= ENV.fetch('TEST_CLUSTER_TMP',       '/tmp')
-          arguments[:path_logs]         ||= ENV.fetch('TEST_CLUSTER_LOGS',      '/var/log/elasticsearch')
+          arguments[:path_logs]         ||= ENV.fetch('TEST_CLUSTER_LOGS',      '/tmp/log/elasticsearch')
           arguments[:es_params]         ||= ENV.fetch('TEST_CLUSTER_PARAMS',    '')
           arguments[:multicast_enabled] ||= ENV.fetch('TEST_CLUSTER_MULTICAST', 'true')
           arguments[:timeout]           ||= (ENV.fetch('TEST_CLUSTER_TIMEOUT', 30).to_i)


### PR DESCRIPTION
Running test cluster for integration tests was failing for me with the following errors:

```
java.io.FileNotFoundException: /var/log/elasticsearch/elasticsearch-test-eugenes-macbook-pro-2.local.log (Permission denied)
java.io.FileNotFoundException: /var/log/elasticsearch/elasticsearch-test-eugenes-macbook-pro-2.local_index_indexing_slowlog.log (Permission denied)
java.io.FileNotFoundException: /var/log/elasticsearch/elasticsearch-test-eugenes-macbook-pro-2.local_index_search_slowlog.log (Permission denied)
```

Unlike `/var`, `/tmp` is much more permissive, thus the following fixed the issue I was having:

```bash
TEST_CLUSTER_LOGS=/tmp/logs/elasticsearch rake test:cluster:start
```