### PR TITLE
Update API code / specs generation tooling

### DIFF
--- a/elasticsearch-api/utils/thor/generate_api.rb
+++ b/elasticsearch-api/utils/thor/generate_api.rb
@@ -37,7 +37,7 @@ module Elasticsearch
         path  += '/' unless path =~ /\/$/ # Add trailing slash if missing
         prefix = "core/src/main/java/org/elasticsearch/rest/action"
 
-        java_rest_files = Dir["#{path}#{prefix}/**/*.java"]
+        java_rest_files = Dir["#{path}#{prefix}/**/Rest*Action.java"]
 
         map = {}
 

--- a/elasticsearch-api/utils/thor/generate_api.rb
+++ b/elasticsearch-api/utils/thor/generate_api.rb
@@ -14,7 +14,7 @@ module Elasticsearch
       # controller.registerHandler(RestRequest.Method.GET, "/_cluster/health", this);
       PATTERN_REST = /.*controller.registerHandler\(.*(?<method>GET|POST|PUT|DELETE|HEAD|OPTIONS|PATCH)\s*,\s*"(?<url>.*)"\s*,\s*.+\);/
       # request.param("index"), request.paramAsBoolean("docs", indicesStatsRequest.docs()), etc
-      PATTERN_URL_PARAMS = /.*request\.(param.*)\("(.*)"/
+      PATTERN_URL_PARAMS = /request\.(param[A-Za-z_]*?)\("(.+)"/
       # controller.registerHandler(GET, "/{index}/_refresh", this)
       PATTERN_URL_PARTS  = /\{(?<part>[a-zA-Z0-9\_\-]+)\}/
       # request.hasContent()

--- a/elasticsearch-api/utils/thor/generate_api.rb
+++ b/elasticsearch-api/utils/thor/generate_api.rb
@@ -35,7 +35,7 @@ module Elasticsearch
       #
       def __parse_java_source(path)
         path  += '/' unless path =~ /\/$/ # Add trailing slash if missing
-        prefix = "src/main/java/org/elasticsearch/rest/action"
+        prefix = "core/src/main/java/org/elasticsearch/rest/action"
 
         java_rest_files = Dir["#{path}#{prefix}/**/*.java"]
 

--- a/elasticsearch-api/utils/thor/generate_api.rb
+++ b/elasticsearch-api/utils/thor/generate_api.rb
@@ -44,7 +44,7 @@ module Elasticsearch
         java_rest_files.sort.each do |file|
           content = File.read(file)
           parts   = file.gsub(path+prefix, '').split('/')
-          name    = parts[0, parts.size-1].reject { |p| p =~ /^\s*$/ }.join('.')
+          name    = parts[-1].scan(/Rest(.+?)[A-Z]*Action\.java/).first.first.downcase + '_' + parts[-2]
 
           # Remove the `admin` namespace
           name.gsub! /admin\./, ''

--- a/elasticsearch-api/utils/thor/generate_api.rb
+++ b/elasticsearch-api/utils/thor/generate_api.rb
@@ -166,7 +166,7 @@ module Elasticsearch
             }
           }
 
-          json = JSON.pretty_generate(spec, indent: '  ', array_nl: '', object_nl: "\n", space: ' ', space_before: ' ')
+          json = JSON.pretty_generate(spec, indent: '  ', object_nl: "\n", space: ' ', space_before: ' ')
 
           # Fix JSON array formatting
           json.gsub!(/\[\s+/, '[')

--- a/elasticsearch-api/utils/thor/generate_source.rb
+++ b/elasticsearch-api/utils/thor/generate_source.rb
@@ -34,7 +34,7 @@ module Elasticsearch
       method_option :language,  default: 'ruby',                                          desc: 'Programming language'
       method_option :force,     type: :boolean, default: false,                           desc: 'Overwrite the output'
       method_option :verbose,   type: :boolean, default: false,                           desc: 'Output more information'
-      method_option :input,     default: File.expand_path('../../../../tmp/elasticsearch/rest-api-spec/api/**/*.json', __FILE__), desc: 'Path to directory with JSON API specs'
+      method_option :input,     default: File.expand_path('../../../../tmp/elasticsearch/rest-api-spec/src/main/resources/rest-api-spec/**/*.json', __FILE__), desc: 'Path to directory with JSON API specs'
       method_option :output,    default: File.expand_path('../../../tmp/out', __FILE__),        desc: 'Path to output directory'
 
       def generate(*files)

--- a/elasticsearch-api/utils/thor/templates/ruby/method.erb
+++ b/elasticsearch-api/utils/thor/templates/ruby/method.erb
@@ -37,6 +37,7 @@ module Elasticsearch
 <%# Method, path, params, body  -%>
       <%= '  '*@namespace_depth %>  valid_params = [
       <%= '  '*(@namespace_depth+2) %><%= @spec['url']['params'].keys.map { |k| ":#{k}" }.join(",\n#{'  '*(@namespace_depth+5)}") %> ]
+      <%=  "\n" -%>
       <%= '  '*@namespace_depth %>  method = <%= 'HTTP_' + @spec['methods'].first %>
       <%- unless @spec['url']['parts'].empty?  -%>
       <%= '  '*@namespace_depth %>  path   = "<%= @spec['url']['path'].split('/').compact.reject {|p| p =~ /^\s*$/}.map do |p|

--- a/elasticsearch-api/utils/thor/templates/ruby/method.erb
+++ b/elasticsearch-api/utils/thor/templates/ruby/method.erb
@@ -37,7 +37,7 @@ module Elasticsearch
 <%# Method, path, params, body  -%>
       <%= '  '*@namespace_depth %>  valid_params = [
       <%= '  '*(@namespace_depth+2) %><%= @spec['url']['params'].keys.map { |k| ":#{k}" }.join(",\n#{'  '*(@namespace_depth+5)}") %> ]
-      <%= '  '*@namespace_depth %>  method = '<%= @spec['methods'].first %>'
+      <%= '  '*@namespace_depth %>  method = <%= 'HTTP_' + @spec['methods'].first %>
       <%- unless @spec['url']['parts'].empty?  -%>
       <%= '  '*@namespace_depth %>  path   = "<%= @spec['url']['path'].split('/').compact.reject {|p| p =~ /^\s*$/}.map do |p|
         p =~ /\{/ ? "\#\{arguments[:#{p.tr('{}', '')}]\}" : p


### PR DESCRIPTION
While initially trying to run thor tasks to generate API specs / code, the code was failing for me (it seems like the code hasn't been up-to-date with changes in `elastic/elasticsearch` for quite a while), so I fixed bunch blocking stuff first and went on updating a few other places.

This PR should be considered a proposal, and is in a WIP state right now.

What's done so far:
- [x] fixed path to elasticsearch source (3d29e64)
- [x] point to correct directory inside elasticsearch folder (6b5fac5)
- [x] use constants, e.g. HTTP_POST instead of 'POST' string (dc88789)
- [x] output JSON array in a more pleasant way (af5cd0b)
- [x] include types while parsing java source code (bc26b7b)
- [x] skip walking over unnecessary files (007c76e)
- [ ] "render" required for parts that are strictly equired ([example](https://github.com/elastic/elasticsearch/blob/148265bd164cd5a614cd020fb480d5974f523d81/rest-api-spec/src/main/resources/rest-api-spec/api/snapshot.delete.json#L11))
- [ ] new file naming: making sure files are not overriding each other (cc1cf59)
- [ ] find a way to include existing (or pull from other source + generate on the fly) descriptions for params, as all of them are being written manually ([example](https://github.com/elastic/elasticsearch/blob/master/rest-api-spec/src/main/resources/rest-api-spec/api/cat.indices.json#L11))
- [ ] remove warning about rest_client being deprecated, when running tor:

  ```
WARNING: The rest_client gem is deprecated and will be removed from RubyGems. Please use rest-client gem instead.
  ```

I'm still unsure about the last item (renaming). I would like to keep things named as they are right now, but seems files in rest-json-spec in elastic/elasticsearch repo are not named consistently which makes it harder to find one/few simple rules to name the files. But I'm still trying some ideas.