### PR TITLE
Fix warnings on elasticsearch transport

### DIFF
--- a/elasticsearch-transport/Gemfile
+++ b/elasticsearch-transport/Gemfile
@@ -3,14 +3,14 @@ source 'https://rubygems.org'
 # Specify your gem's dependencies in elasticsearch-transport.gemspec
 gemspec
 
-if File.exists? File.expand_path("../../elasticsearch-api/elasticsearch-api.gemspec", __FILE__)
+if File.exist? File.expand_path("../../elasticsearch-api/elasticsearch-api.gemspec", __FILE__)
   gem 'elasticsearch-api', :path => File.expand_path("../../elasticsearch-api", __FILE__), :require => false
 end
 
-if File.exists? File.expand_path("../../elasticsearch-extensions", __FILE__)
+if File.exist? File.expand_path("../../elasticsearch-extensions", __FILE__)
   gem 'elasticsearch-extensions', :path => File.expand_path("../../elasticsearch-extensions", __FILE__), :require => false
 end
 
-if File.exists? File.expand_path("../../elasticsearch/elasticsearch.gemspec", __FILE__)
+if File.exist? File.expand_path("../../elasticsearch/elasticsearch.gemspec", __FILE__)
   gem 'elasticsearch', :path => File.expand_path("../../elasticsearch", __FILE__), :require => false
 end

--- a/elasticsearch-transport/lib/elasticsearch/transport/transport/connections/connection.rb
+++ b/elasticsearch-transport/lib/elasticsearch/transport/transport/connections/connection.rb
@@ -29,6 +29,7 @@ module Elasticsearch
             @state_mutex = Mutex.new
 
             @options[:resurrect_timeout] ||= DEFAULT_RESURRECT_TIMEOUT
+            @dead = false
             @failures = 0
           end
 

--- a/elasticsearch-transport/lib/elasticsearch/transport/transport/connections/selector.rb
+++ b/elasticsearch-transport/lib/elasticsearch/transport/transport/connections/selector.rb
@@ -50,7 +50,7 @@ module Elasticsearch
             #
             def select(options={})
               # On Ruby 1.9, Array#rotate could be used instead
-              @current = @current.nil? ? 0 : @current+1
+              @current = !defined?(@current) || @current.nil? ? 0 : @current+1
               @current = 0 if @current >= connections.size
               connections[@current]
             end

--- a/elasticsearch-transport/lib/elasticsearch/transport/transport/http/curb.rb
+++ b/elasticsearch-transport/lib/elasticsearch/transport/transport/http/curb.rb
@@ -57,7 +57,7 @@ module Elasticsearch
                   client.password = host[:password]
                 end
 
-                client.instance_eval &@block if @block
+                client.instance_eval(&@block) if @block
 
                 Connections::Connection.new :host => host, :connection => client
               },


### PR DESCRIPTION
Simple changes to avoid boring warnings.

Running tests with `RUBYOPT=-w` before the changes to check those warning messages.