### PR TITLE
Fix warnings on elasticsearch api

### DIFF
--- a/elasticsearch-api/Gemfile
+++ b/elasticsearch-api/Gemfile
@@ -3,14 +3,14 @@ source 'https://rubygems.org'
 # Specify your gem's dependencies in elasticsearch-api.gemspec
 gemspec
 
-if File.exists? File.expand_path("../../elasticsearch/elasticsearch.gemspec", __FILE__)
+if File.exist? File.expand_path("../../elasticsearch/elasticsearch.gemspec", __FILE__)
   gem 'elasticsearch', :path => File.expand_path("../../elasticsearch", __FILE__), :require => false
 end
 
-if File.exists? File.expand_path("../../elasticsearch-transport", __FILE__)
+if File.exist? File.expand_path("../../elasticsearch-transport", __FILE__)
   gem 'elasticsearch-transport', :path => File.expand_path("../../elasticsearch-transport", __FILE__), :require => true
 end
 
-if File.exists? File.expand_path("../../elasticsearch-extensions", __FILE__)
+if File.exist? File.expand_path("../../elasticsearch-extensions", __FILE__)
   gem 'elasticsearch-extensions', :path => File.expand_path("../../elasticsearch-extensions", __FILE__), :require => false
 end

--- a/elasticsearch-api/Rakefile
+++ b/elasticsearch-api/Rakefile
@@ -71,7 +71,7 @@ namespace :test do
       es_version_info = client.info['version']
       build_hash      = es_version_info['build_hash']
       cluster_running = true
-    rescue Faraday::Error::ConnectionFailed => e
+    rescue Faraday::Error::ConnectionFailed
       STDERR.puts "[!] Test cluster not running?"
       cluster_running = false
     end


### PR DESCRIPTION
Simple changes to avoid boring warnings.

Running tests with RUBYOPT=-w before the changes to check those warning messages.
