### PR TITLE
Add index to allowed params for cluster health check

### DIFF
--- a/elasticsearch-api/lib/elasticsearch/api/actions/cluster/health.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/cluster/health.rb
@@ -31,6 +31,7 @@ module Elasticsearch
         #
         def health(arguments={})
           valid_params = [
+            :index,
             :level,
             :local,
             :master_timeout,


### PR DESCRIPTION
Although it is in the method documentation, the `index` param was not listed in the allowed arguments and got therefore filtered out.
This PR just adds `:index` to the valid params of the `health` method.