### PR TITLE
Remove "patron" hint from the AWS guide

### DIFF
--- a/elasticsearch-transport/README.md
+++ b/elasticsearch-transport/README.md
@@ -295,7 +295,6 @@ To configure the _Faraday_ instance directly, use a block:
 You can use any standard Faraday middleware and plugins in the configuration block,
 for example sign the requests for the [AWS Elasticsearch service](https://aws.amazon.com/elasticsearch-service/):
 
-    require 'patron'
     require 'faraday_middleware/aws_signers_v4'
 
     client = Elasticsearch::Client.new url: 'https://search-my-cluster-abc123....es.amazonaws.com' do |f|


### PR DESCRIPTION
because using Patron is not a prerequisite when using this workflow, and might in fact mislead
the user to installing Patron and adding it to his/her Gemfile just because this is mentioned in the documentation.