### PR TITLE
ensure Manticore initializer passes arguments to base class

### DIFF
--- a/elasticsearch-transport/lib/elasticsearch/transport/transport/http/manticore.rb
+++ b/elasticsearch-transport/lib/elasticsearch/transport/transport/http/manticore.rb
@@ -47,7 +47,7 @@ module Elasticsearch
 
           def initialize(arguments={}, &block)
             @manticore = build_client(arguments[:options] || {})
-            super()
+            super(arguments, &block)
           end
 
           # Should just be run once at startup


### PR DESCRIPTION
not calling super with the proper arguments doesn't setup auxiliary variables like `hosts`, and `options`.