### PR TITLE
[CLIENT] ensure get_connection doesn't reload returned connections

### DIFF
--- a/elasticsearch-transport/lib/elasticsearch/transport/transport/base.rb
+++ b/elasticsearch-transport/lib/elasticsearch/transport/transport/base.rb
@@ -64,11 +64,9 @@ module Elasticsearch
         def get_connection(options={})
           resurrect_dead_connections! if Time.now > @last_request_at + @resurrect_after
 
-          connection = connections.get_connection(options)
           @counter_mtx.synchronize { @counter += 1 }
-
           reload_connections!         if reload_connections && counter % reload_after == 0
-          connection
+          connections.get_connection(options)
         end
 
         # Reloads and replaces the connection collection based on cluster information.


### PR DESCRIPTION
currently get_connections asks the connection collection for a
connection and then, under certain conditions, executes reload_connections
which can close the retrieved connection if the used transport implements
the __close_connections method

This patch reorders the get_connection code so that the connection
retrieval happens as late as possible (after reload_connections)