### PR TITLE
[CLIENT] remove manticore close_connection implementation

### DIFF
--- a/elasticsearch-transport/lib/elasticsearch/transport/transport/http/manticore.rb
+++ b/elasticsearch-transport/lib/elasticsearch/transport/transport/http/manticore.rb
@@ -119,8 +119,9 @@ module Elasticsearch
           # @return [Connections::Collection]
           #
           def __close_connections
-            @connections.each {|c| c.dead! }
-            @connections.all.each {|c| c.connection.close }
+            # this transport uses a single, long lived instance of
+            # Manticore::Client that controls the connection pool
+            # so we don't need to close the client
           end
 
           # Returns an array of implementation specific connection errors.

--- a/elasticsearch-transport/test/unit/transport_manticore_test.rb
+++ b/elasticsearch-transport/test/unit/transport_manticore_test.rb
@@ -26,19 +26,6 @@ else
         assert_instance_of ::Manticore::Client,   @transport.connections.first.connection
       end
 
-      should "implement __close_connections" do
-        assert_equal 1, @transport.connections.size
-        @transport.__close_connections
-        assert_equal 0, @transport.connections.size
-      end
-
-      should "prevent requests after __close_connections" do
-        @transport.__close_connections
-        assert_raises ::Manticore::ClientStoppedException do
-          @transport.perform_request 'GET', '/'
-        end
-      end
-
       should "perform the request" do
         @transport.connections.first.connection.expects(:get).returns(stub_everything)
         @transport.perform_request 'GET', '/'


### PR DESCRIPTION
Since manticore is now a single instance of Manticore::Client and it is
capable of handling the connection pool, it is shared across the
connection collection. This means that we can no longer close it,
otherwise the transport will never execute requests again.