### PR TITLE
Threadsafe Manticore

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ branches:
     - travis
 
 rvm:
+  - 1.8.7
   - 1.9.3
   - 2.1
   - 2.2

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,11 +12,12 @@ branches:
     - travis
 
 rvm:
-  - 1.8.7
-  - 1.9.3
-  - 2.1
-  - 2.2
   - jruby-1.7.23
+#  - 1.8.7
+#  - 1.9.3
+#  - 2.1
+#  - 2.2
+
 
 env:
   - TEST_SUITE=unit
@@ -35,7 +36,7 @@ before_script:
   - gem install bundler -v 1.11.2
   - rake setup
   - rake elasticsearch:update
-  - echo elasticsearch-* elasticsearch | xargs -n1 -IFF sh -c 'echo processing bundle for FF && cd FF && bundle && cd ..'
+  - echo elasticsearch-* elasticsearch | xargs -n1 -IFF bash -c 'echo processing bundle for FF && cd FF && bundle && cd ..'
 
 script:
   - SERVER=start TEST_CLUSTER_LOGS=/tmp/log TEST_BUILD_REF=tags/v$ES_VERSION TEST_CLUSTER_COMMAND=/tmp/elasticsearch-$ES_VERSION/bin/elasticsearch rake test:$TEST_SUITE

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,6 @@ sudo: false
 
 language: ruby
 
-cache: bundler
-
 branches:
   only:
     - master
@@ -18,7 +16,7 @@ rvm:
   - 1.9.3
   - 2.1
   - 2.2
-  - jruby-1.7.24
+  - jruby-1.7.23
 
 env:
   - TEST_SUITE=unit

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,13 +14,10 @@ branches:
     - travis
 
 rvm:
-  - 1.8.7
   - 1.9.3
   - 2.1
   - 2.2
-
-jdk:
-  - openjdk7
+  - jruby-1.7.24
 
 env:
   - TEST_SUITE=unit

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,8 +35,7 @@ before_script:
   - gem install bundler -v 1.11.2
   - rake setup
   - rake elasticsearch:update
-  - rake bundle:clean
-  - rake bundle:install
+  - echo elasticsearch-* elasticsearch | xargs -n1 -IFF sh -c 'echo processing bundle for FF && cd FF && bundle && cd ..'
 
 script:
   - SERVER=start TEST_CLUSTER_LOGS=/tmp/log TEST_BUILD_REF=tags/v$ES_VERSION TEST_CLUSTER_COMMAND=/tmp/elasticsearch-$ES_VERSION/bin/elasticsearch rake test:$TEST_SUITE

--- a/elasticsearch-extensions/Gemfile
+++ b/elasticsearch-extensions/Gemfile
@@ -3,18 +3,8 @@ source 'https://rubygems.org'
 # Specify your gem's dependencies in elasticsearch-extensions.gemspec
 gemspec
 
-if File.exists? File.expand_path("../../elasticsearch-api/elasticsearch-api.gemspec", __FILE__)
-  gem 'elasticsearch-api', :path => File.expand_path("../../elasticsearch-api", __FILE__), :require => false
-end
+gem 'elasticsearch-api', :path => "../elasticsearch-api", :require => false
+gem 'elasticsearch-transport', :path => "../elasticsearch-transport", :require => false
+gem 'elasticsearch-extensions', :path => "../elasticsearch-extensions", :require => false
 
-if File.exists? File.expand_path("../../elasticsearch-transport/elasticsearch-transport.gemspec", __FILE__)
-  gem 'elasticsearch-transport', :path => File.expand_path("../../elasticsearch-transport", __FILE__), :require => false
-end
-
-if File.exists? File.expand_path("../../elasticsearch-extensions", __FILE__)
-  gem 'elasticsearch-extensions', :path => File.expand_path("../../elasticsearch-extensions", __FILE__), :require => false
-end
-
-if File.exists? File.expand_path("../../elasticsearch/elasticsearch.gemspec", __FILE__)
-  gem 'elasticsearch', :path => File.expand_path("../../elasticsearch/", __FILE__)
-end
+gem 'elasticsearch', :path => "../elasticsearch/"

--- a/elasticsearch-extensions/elasticsearch-extensions.gemspec
+++ b/elasticsearch-extensions/elasticsearch-extensions.gemspec
@@ -56,6 +56,6 @@ Gem::Specification.new do |s|
   end
 
   # Gems for testing integrations
-  s.add_development_dependency "patron"
-  s.add_development_dependency "oj"
+  s.add_development_dependency "patron" unless defined?(JRUBY_VERSION) || defined?(Rubinius)
+  s.add_development_dependency "oj" unless defined?(JRUBY_VERSION) || defined?(Rubinius)
 end

--- a/elasticsearch-transport/lib/elasticsearch/transport/client.rb
+++ b/elasticsearch-transport/lib/elasticsearch/transport/client.rb
@@ -128,6 +128,11 @@ module Elasticsearch
         transport.perform_request method, path, params, body
       end
 
+      # Shuts down the client
+      def close
+        @transport.__close_connections
+      end
+
       # Normalizes and returns hosts configuration.
       #
       # Arrayifies the `hosts_config` argument and extracts `host` and `port` info from strings.

--- a/elasticsearch-transport/lib/elasticsearch/transport/transport/connections/connection.rb
+++ b/elasticsearch-transport/lib/elasticsearch/transport/transport/connections/connection.rb
@@ -114,7 +114,7 @@ module Elasticsearch
           #
           def resurrectable?
             @state_mutex.synchronize {
-              Time.now > @dead_since + ( @options[:resurrect_timeout] * 2 ** (@failures-1) )
+              Time.now >= @dead_since + ( @options[:resurrect_timeout] * 2 ** (@failures-1) )
             }
           end
 

--- a/elasticsearch-transport/lib/elasticsearch/transport/transport/errors.rb
+++ b/elasticsearch-transport/lib/elasticsearch/transport/transport/errors.rb
@@ -12,7 +12,26 @@ module Elasticsearch
 
       # Elasticsearch server error (HTTP status 5xx)
       #
-      class ServerError < Error; end
+      class ServerError < Error;
+        attr_reader :response
+
+        def initialize(response)
+          @response = response
+        end
+      end
+
+      class HostUnreachableError < Error;
+        attr_reader :original_error, :url
+
+        def initialize(original_error, url)
+          @original_error = original_error
+          @url = url
+        end
+
+        def message
+          "[#{original_error.class}] #{original_error.message}"
+        end
+      end
 
       module Errors; end
 

--- a/elasticsearch-transport/lib/elasticsearch/transport/transport/http/manticore.rb
+++ b/elasticsearch-transport/lib/elasticsearch/transport/transport/http/manticore.rb
@@ -1,4 +1,7 @@
 require 'manticore'
+require "elasticsearch/transport/transport/http/manticore/pool"
+require "elasticsearch/transport/transport/http/manticore/adapter"
+require "elasticsearch/transport/transport/http/manticore/manticore_sniffer"
 
 module Elasticsearch
   module Transport
@@ -43,97 +46,159 @@ module Elasticsearch
         # @see Transport::Base
         #
         class Manticore
+          attr_reader :pool, :adapter, :options
           include Base
 
           def initialize(arguments={}, &block)
-            @manticore = build_client(arguments[:options] || {})
-            super(arguments, &block)
+            @options = arguments[:options] || {}
+            @logger = options[:logger]
+            @adapter = Adapter.new(logger, options)
+            @healthcheck_path = options[:healthcheck_path] || "/"
+            normalized_hosts = (arguments[:hosts] || []).map {|h| normalize_host(h)}
+            @pool = Manticore::Pool.new(logger, @adapter, @healthcheck_path, normalized_hosts)
+            @protocol    = options[:protocol] || DEFAULT_PROTOCOL
+            @serializer = options[:serializer] || ( options[:serializer_class] ? options[:serializer_class].new(self) : DEFAULT_SERIALIZER_CLASS.new(self) )
+            @max_retries     = options[:retry_on_failure].is_a?(Fixnum)   ? options[:retry_on_failure]   : DEFAULT_MAX_RETRIES
+            @retry_on_status = Array(options[:retry_on_status]).map { |d| d.to_i }
+
+            setup_sniffing!
           end
 
-          # Should just be run once at startup
-          def build_client(options={})
-            client_options = options[:transport_options] || {}
-            client_options[:ssl] = options[:ssl] || {}
-
-            @manticore = ::Manticore::Client.new(client_options)
-          end
-
-          # Performs the request by invoking {Transport::Base#perform_request} with a block.
-          #
-          # @return [Response]
-          # @see    Transport::Base#perform_request
-          #
-          def perform_request(method, path, params={}, body=nil)
-            super do |connection, url|
-              params[:body] = __convert_to_json(body) if body
-              params = params.merge @request_options
-              case method
-              when "GET"
-                resp = connection.connection.get(url, params)
-              when "HEAD"
-                resp = connection.connection.head(url, params)
-              when "PUT"
-                resp = connection.connection.put(url, params)
-              when "POST"
-                resp = connection.connection.post(url, params)
-              when "DELETE"
-                resp = connection.connection.delete(url, params)
+          def normalize_host(host)
+            case host
+            when URI
+              host
+            when String
+              URI.parse(host)
+            when Hash
+              host = host.clone
+              host[:scheme] ||= (host[:scheme] || host[:protocol] || "http").to_s
+              if host[:scheme] == 'http'
+                URI::HTTP.build(host)
+              elsif scheme == 'https'
+                URI::HTTPS.build(host)
               else
-                raise ArgumentError.new "Method #{method} not supported"
+                raise ArgumentError, "Unrecognized scheme for host #{host}"
               end
-              Response.new resp.code, resp.read_body, resp.headers
+            else
+              raise ArgumentError, "Host parameter #{host} is not valid! Try something like 'http://localhost:9200'!"
             end
           end
 
-          # Builds and returns a collection of connections.
-          # Each connection is a Manticore::Client
-          #
-          # @return [Connections::Collection]
-          #
-          def __build_connections
-            @request_options = {}
-
-            if options.key?(:headers)
-              @request_options[:headers] = options[:headers]
+          def setup_sniffing!
+            if options[:sniffing] || options[:reload_connections]
+              # We don't support sniffers that aren't threadsafe with timers here!
+              sniffer_class = options[:sniffer_class] ? options[:sniffer_class] : ::Elasticsearch::Transport::Transport::HTTP::Manticore::ManticoreSniffer
+              raise ArgumentError, "Sniffer class #{sniffer_class} must be a ManticoreSniffer!" if sniffer_class.nil? || !sniffer_class.ancestors.include?(::Elasticsearch::Transport::Transport::HTTP::Manticore::ManticoreSniffer)
+              @sniffer = sniffer_class.new(self, logger)
+              @sniffer.sniff_every(options[:sniffer_delay] || 5) do |urls|
+                logger.info("Will update internal host pool with #{urls.inspect}")
+                @pool.update_urls(urls)
+              end
             end
-
-            Connections::Collection.new \
-              :connections => hosts.map { |host|
-                host[:protocol]   = host[:scheme] || DEFAULT_PROTOCOL
-                host[:port]     ||= DEFAULT_PORT
-
-                host.delete(:user)     # auth is not supported here.
-                host.delete(:password) # use the headers
-
-                Connections::Connection.new \
-                  :host => host,
-                  :connection => @manticore
-              },
-              :selector_class => options[:selector_class],
-              :selector => options[:selector]
           end
 
-          # Closes all connections by marking them as dead
-          # and closing the underlying HttpClient instances
-          #
-          # @return [Connections::Collection]
-          #
+          # Sniff (if enabled) to get the newest list of hosts
+          # then attempt to resurrect any dead URLs
+          def reload_connections!
+            if options[:sniffing]
+              @pool.update_urls(@sniffer.hosts)
+            end
+            @pool.resurrect_dead!
+          end
+
+          def perform_request(method, path, params={}, body=nil)
+            body = __convert_to_json(body) if body
+            url, response = with_request_retries do
+              url, response = @pool.perform_request(method, path, params, body)
+              # Raise an exception so we can catch it for `retry_on_status`
+              __raise_transport_error(response) if response.status.to_i >= 300 && @retry_on_status.include?(response.status.to_i)
+              [url, response]
+            end
+
+            enrich_response(method, url, path, params, body, response)
+          end
+
+          # This takes a host string to aid in debug logging
+          def with_request_retries
+            tries = 0
+            begin
+              tries += 1
+              yield
+            rescue ::Elasticsearch::Transport::Transport::ServerError => e
+              if @retry_on_status.include?(e.response.status)
+                logger.warn "[#{e.class}] Attempt #{tries} to get response from #{url}" if logger
+                logger.debug "[#{e.class}] Attempt #{tries} to get response from #{url}" if logger
+                if tries <= max_retries
+                  retry
+                else
+                  logger.error "[#{e.class}] Cannot get response from #{url} after #{tries} tries" if logger
+                  raise e
+                end
+              else
+                raise e
+              end
+            rescue ::Elasticsearch::Transport::Transport::HostUnreachableError => e
+              logger.error "[#{e.class}] #{e.message} #{e.url}" if logger
+
+              if @options[:retry_on_failure]
+                logger.warn "[#{e.class}] Attempt #{tries} connecting to #{connection.host.inspect}" if logger
+                if tries <= max_retries
+                  if @options[:reload_on_failure] && pool.alive_urls_count == 0
+                    logger.warn "[#{e.class}] Reloading connections (attempt #{tries} of #{max_retries})" if logger
+                    reload_connections!
+                  end
+
+                  retry
+                else
+                  logger.fatal "[#{e.class}] Cannot connect to #{connection.host.inspect} after #{tries} tries" if logger
+                  raise e
+                end
+              end
+            rescue Exception => e
+              logger.fatal "[#{e.class}] #{e.message} ()" if logger
+              raise e
+            end
+          end
+
           def __close_connections
-            # The Manticore adapter uses a single long-lived instance
-            # of Manticore::Client, so we don't close the connections.
+            if @sniffer
+              logger.info("Closing sniffer...") if logger
+              @sniffer.close
+            end
+            logger.info("Sniffer closed.") if logger
+            logger.info("Closing pool") if logger
+            @pool.close # closes adapter as well
+            logger.info("Pool closed") if logger
           end
 
-          # Returns an array of implementation specific connection errors.
-          #
-          # @return [Array]
-          #
+          def enrich_response(method, url, path, params, body, response)
+            start = Time.now if logger || tracer
+
+            duration = Time.now-start if logger || tracer
+
+            if response.status.to_i >= 300
+              __log    method, path, params, body, url, response, nil, 'N/A', duration if logger
+              __trace  method, path, params, body, url, response, nil, 'N/A', duration if tracer
+              __log_failed response if logger
+              __raise_transport_error response
+            end
+
+            json = __deserialize_response(response)
+            if json
+              took     = (json['took'] ? sprintf('%.3fs', json['took']/1000.0) : 'n/a') rescue 'n/a' if logger || tracer
+
+              __log   method, path, params, body, url, response, json, took, duration if logger
+              __trace method, path, params, body, url, response, json, took, duration if tracer
+            end
+
+            # If the response wasn't JSON we just return it as a string
+            data = json || response.body
+            ::Elasticsearch::Transport::Transport::Response.new response.status, data, response.headers
+          end
+
           def host_unreachable_exceptions
-            [
-              ::Manticore::Timeout,
-              ::Manticore::SocketException,
-              ::Manticore::ClientProtocolException,
-              ::Manticore::ResolutionFailure
-            ]
+            [::Manticore::Timeout,::Manticore::SocketException, ::Manticore::ClientProtocolException, ::Manticore::ResolutionFailure]
           end
         end
       end

--- a/elasticsearch-transport/lib/elasticsearch/transport/transport/http/manticore/adapter.rb
+++ b/elasticsearch-transport/lib/elasticsearch/transport/transport/http/manticore/adapter.rb
@@ -1,0 +1,61 @@
+module Elasticsearch
+  module Transport
+    module Transport
+      module HTTP
+        class Manticore
+          # While the Manticore Pool only supports Manticore today, one day other adapters
+          # may use it. This class provides an abstraction around the actual HTTP client for
+          # the pool.
+          class Adapter
+            attr_reader :manticore, :logger
+
+            def initialize(logger, options)
+              @logger = logger
+              build_client(options || {})
+              sniffer_options = [logger, options[:sniffer_timeout], options[:randomize_hosts]]
+            end
+
+            # Should just be run once at startup
+            def build_client(options={})
+              client_options = options[:transport_options] || {}
+              client_options[:ssl] = options[:ssl] || {}
+
+              @request_options = options[:headers] ? {:headers => options[:headers]} : {}
+              @manticore = ::Manticore::Client.new(client_options)
+            end
+
+            # Performs the request by invoking {Transport::Base#perform_request} with a block.
+            #
+            # @return [Response]
+            # @see    Transport::Base#perform_request
+            #
+            def perform_request(url, method, path, params={}, body=nil)
+              params = params.merge @request_options
+              params[:body] = body if body
+              url_and_path = (url + path).to_s # Convert URI object to string
+              case method
+              when "GET"
+                resp = @manticore.get(url_and_path, params)
+              when "HEAD"
+                resp = @manticore.head(url_and_path, params)
+              when "PUT"
+                resp = @manticore.put(url_and_path, params)
+              when "POST"
+                resp = @manticore.post(url_and_path, params)
+              when "DELETE"
+                resp = @manticore.delete(url_and_path, params)
+              else
+                raise ArgumentError.new "Method #{method} not supported"
+              end
+              Response.new resp.code, resp.read_body, resp.headers
+            end
+
+            def close
+              @manticore.close
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/elasticsearch-transport/lib/elasticsearch/transport/transport/http/manticore/manticore_sniffer.rb
+++ b/elasticsearch-transport/lib/elasticsearch/transport/transport/http/manticore/manticore_sniffer.rb
@@ -1,0 +1,64 @@
+module Elasticsearch
+  module Transport
+    module Transport
+      module HTTP
+        class Manticore
+          # Handles node discovery ("sniffing")
+          #
+          class ManticoreSniffer < ::Elasticsearch::Transport::Transport::Sniffer
+            attr_reader   :transport
+            attr_accessor :timeout
+
+            # @param transport [Object] A transport instance
+            #
+            def initialize(*args)
+              @timeout = 1 # in seconds
+              @state_mutex = Mutex.new
+              @stopping = false
+              super
+            end
+
+            def sniff_every(interval_seconds, &block)
+              logger.info("Will sniff every #{interval_seconds} seconds for new Elasticsearch hosts!")
+              @state_mutex.synchronize do
+                return if @sniffer_thread
+                @sniffer_thread = Thread.new do
+                  last_sniff = Time.now
+                  until @state_mutex.synchronize { @stopping }
+                    sleep 1
+                    begin
+
+                      if (Time.now - last_sniff) > interval_seconds
+                        if !!block
+                          begin
+                            block.call(hosts)
+                          rescue Exception => e
+                            @logger.warn("Error invoking Elasticsearch sniffing block! [#{e.class}] #{e.message} #{e.backtrace.join("\n")}")
+                          end
+                        end
+                        last_sniff = Time.now
+                      end
+                    rescue Exception => e
+                      logger.warn("Error while sniffing Elasticsearch Nodes! [#{e.class.name}][#{e.message}][#{e.backtrace.join("\n")}]") if logger
+                    end
+                  end
+                end
+              end
+            end
+
+            def hosts
+              nodes = transport.perform_request('GET', '_nodes/http', :request_timeout => timeout).body
+              urls = hosts_from_nodes(nodes).map {|n| "#{transport.protocol}://#{n["http_address"]}"}
+              urls
+            end
+
+            def close
+              @state_mutex.synchronize { @stopping = true }
+              @sniffer_thread.join if @sniffer_thread
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/elasticsearch-transport/lib/elasticsearch/transport/transport/http/manticore/pool.rb
+++ b/elasticsearch-transport/lib/elasticsearch/transport/transport/http/manticore/pool.rb
@@ -1,0 +1,205 @@
+module Elasticsearch
+  module Transport
+    module Transport
+      module HTTP
+        class Manticore
+          class Pool
+            class NoConnectionAvailableError < Error; end
+
+            attr_reader :logger
+
+            def initialize(logger, adapter, healthcheck_path="/", urls=[], resurrect_interval=5, host_unreachable_exceptions=[])
+              @logger = logger
+              @state_mutex = Mutex.new
+              @url_info = {}
+              @adapter = adapter
+              @healthcheck_path = healthcheck_path
+              @stopping = false
+              @resurrect_interval = resurrect_interval
+              @resurrectionist = start_resurrectionist
+              @host_unreachable_exceptions = host_unreachable_exceptions
+              update_urls(urls)
+            end
+
+            def close
+              logger.debug  "Stopping resurrectionist" if logger
+              stop_resurrectionist
+              logger.debug  "Waiting for in use manticore connections" if logger
+              wait_for_in_use_connections
+              logger.debug("Closing adapter #{@adapter}") if logger
+              @adapter.close
+            end
+
+            def wait_for_in_use_connections
+              until in_use_connections.empty?
+                logger.info "Blocked on shutdown to in use connections #{@state_mutex.synchronize {@url_info}}" if logger
+                sleep 1
+              end
+            end
+
+            def in_use_connections
+              @state_mutex.synchronize { @url_info.values.select {|v| v[:in_use] > 0 } }
+            end
+
+            def alive_urls_count
+              @state_mutex.synchronize { @url_info.values.select {|v| !v[:dead] }.count }
+            end
+
+            def start_resurrectionist
+              Thread.new do
+                last_resurrect = Time.now
+                until @state_mutex.synchronize { @stopping } do
+                  if Time.now-last_resurrect >= @resurrect_interval
+                    last_resurrect = Time.now
+                    resurrect_dead!
+                  end
+                end
+              end
+            end
+
+            def resurrect_dead!
+              # Try to keep locking granularity low such that we don't affect IO...
+              @state_mutex.synchronize { @url_info.select {|url,meta| meta[:dead] } }.each do |url,meta|
+                begin
+                  @logger.info("Checking url #{url} with path #{@healthcheck_path} to see if node resurrected")
+                  perform_request_to_url(url, "GET", @healthcheck_path)
+                  # If no exception was raised it must have succeeded!
+                  logger.warn("Resurrected connection to dead ES instance at #{url}")
+                  @state_mutex.synchronize { meta[:dead] = false }
+                rescue ::Elasticsearch::Transport::Transport::HostUnreachableError => e
+                  logger.debug("Attempted to resurrect connection to dead ES instance at #{url}, got an error [#{e.class}] #{e.message}")
+                end
+              end
+            end
+
+            def stop_resurrectionist
+              @state_mutex.synchronize { @stopping = true }
+              @resurrectionist.join # Wait for thread to stop
+            end
+
+            def perform_request(method, path, params={}, body=nil)
+              with_connection do |url|
+                [url, perform_request_to_url(url, method, path, params, body)]
+              end
+            end
+
+            def perform_request_to_url(url, method, path, params={}, body=nil)
+              @adapter.perform_request(url, method, path, params, body)
+            rescue *@host_unreachable_exceptions => e
+              logger.error "[#{e.class}] #{e.message} #{url}" if logger
+              raise ::Elasticsearch::Transport::Transport::HostUnreachableError.new(e, url), "Could not reach host #{e.class}: #{e.message}"
+            end
+
+            def update_urls(new_urls)
+              # Normalize URLs
+              new_urls = new_urls.map {|u| u.is_a?(URI) ? u : URI.parse(u) }
+
+              @state_mutex.synchronize do
+                # Add new connections
+                new_urls.each do |url|
+                  # URI objects don't have real hash equality! So, since this isn't perf sensitive we do a linear scan
+                  unless @url_info.keys.include?(url)
+                    logger.info("Elasticsearch pool adding node @ URL #{url}") if logger
+                    add_url(url)
+                  end
+                end
+
+                # Delete connections not in the new list
+                @url_info.each do |url,_|
+                  unless new_urls.include?(url)
+                    logger.info("Elasticsearch pool removing node @ URL #{url}") if logger
+                    remove_url(url)
+                  end
+                end
+              end
+            end
+
+            def size
+              @state_mutex.synchronize { @url_info.size }
+            end
+
+            def add_url(url)
+              @url_info[url] ||= empty_url_meta
+            end
+
+            def remove_url(url)
+              @url_info.delete(url)
+            end
+
+            def empty_url_meta
+              {
+                :in_use => 0,
+                :dead => false
+              }
+            end
+
+            def with_connection
+              url, url_meta = get_connection
+
+              # Custom error class used here so that users may retry attempts if they receive this error
+              # should they choose to
+              raise NoConnectionAvailableError, "No Available connections" unless url
+              yield url
+            rescue ::Elasticsearch::Transport::Transport::HostUnreachableError => e
+              mark_dead(url, e)
+              raise e
+            ensure
+              return_connection(url)
+            end
+
+            def mark_dead(url, error)
+              @state_mutex.synchronize do
+                url_meta = @url_info[url]
+                logger.warn("Marking url #{url} as dead. Last error: [#{error.class}] #{error.message}")
+                url_meta[:dead] = true
+                url_meta[:last_error] = error
+              end
+            end
+
+            def url_meta(url)
+              @state_mutex.synchronize do
+                @url_info[url]
+              end
+            end
+
+            def get_connection
+              @state_mutex.synchronize do
+                # The goal here is to pick a random connection from the least-in-use connections
+                # We want some randomness so that we don't hit the same node over and over, but
+                # we also want more 'fair' behavior in the event of high concurrency
+                eligible_set = nil
+                lowest_value_seen = nil
+                @url_info.each do |url,meta|
+                  meta_in_use = meta[:in_use]
+                  next if meta[:dead]
+
+                  if lowest_value_seen.nil? || meta_in_use < lowest_value_seen
+                    lowest_value_seen = meta_in_use
+                    eligible_set = [[url, meta]]
+                  elsif lowest_value_seen == meta_in_use
+                    eligible_set << [url, meta]
+                  end
+                end
+
+                return nil if eligible_set.nil?
+
+                pick, pick_meta = eligible_set.sample
+                pick_meta[:in_use] += 1
+
+                [pick, pick_meta]
+              end
+            end
+
+            def return_connection(url)
+              @state_mutex.synchronize do
+                if @url_info[url] # Guard against the condition where the connection has already been deleted
+                  @url_info[url][:in_use] -= 1
+                end
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/elasticsearch-transport/lib/elasticsearch/transport/transport/sniffer.rb
+++ b/elasticsearch-transport/lib/elasticsearch/transport/transport/sniffer.rb
@@ -8,14 +8,15 @@ module Elasticsearch
         ES1_RE_URL  = /\[([^\/]*)?\/?([^:]*):([0-9]+)\]/
         ES2_RE_URL  = /([^\/]*)?\/?([^:]*):([0-9]+)/
 
-        attr_reader   :transport
+        attr_reader   :transport, :logger
         attr_accessor :timeout
 
         # @param transport [Object] A transport instance
         #
-        def initialize(transport)
+        def initialize(transport, logger=nil)
           @transport = transport
           @timeout   = transport.options[:sniffer_timeout] || 1
+          @logger = logger
         end
 
         # Retrieves the node list from the Elasticsearch's
@@ -30,19 +31,23 @@ module Elasticsearch
         def hosts
           Timeout::timeout(timeout, SnifferTimeoutError) do
             nodes = transport.perform_request('GET', '_nodes/http').body
-            hosts = nodes['nodes'].map do |id,info|
-              addr_str = info["#{transport.protocol}_address"].to_s
-              matches = addr_str.match(ES1_RE_URL) || addr_str.match(ES2_RE_URL)
-              if matches
-                host = matches[1].empty? ? matches[2] : matches[1]
-                port = matches[3]
-                info.merge :host => host, :port => port, :id => id
-              end
-            end.compact
-
-            hosts.shuffle! if transport.options[:randomize_hosts]
-            hosts
+            hosts_from_nodes(nodes)
           end
+        end
+
+        def hosts_from_nodes(nodes)
+          hosts = nodes['nodes'].map do |id,info|
+            addr_str = info["#{transport.protocol}_address"].to_s
+            matches = addr_str.match(ES1_RE_URL) || addr_str.match(ES2_RE_URL)
+            if matches
+              host = matches[1].empty? ? matches[2] : matches[1]
+              port = matches[3]
+              info.merge :host => host, :port => port, :id => id
+            end
+          end.compact
+
+          hosts.shuffle! if transport.options[:randomize_hosts]
+          hosts
         end
       end
     end

--- a/elasticsearch-transport/test/unit/manticore_sniffer_test.rb
+++ b/elasticsearch-transport/test/unit/manticore_sniffer_test.rb
@@ -1,0 +1,68 @@
+require 'test_helper'
+
+unless JRUBY
+  version = ( defined?(RUBY_ENGINE) ? RUBY_ENGINE : 'Ruby' ) + ' ' + RUBY_VERSION
+  puts "SKIP: '#{File.basename(__FILE__)}' only supported on JRuby (you're running #{version})"
+else
+  class Elasticsearch::Transport::Transport::ManticoreSnifferTest < Test::Unit::TestCase
+    require 'elasticsearch/transport/transport/http/manticore/manticore_sniffer'
+    require 'manticore'
+
+    class ManticoreDummyTransport < Elasticsearch::Transport::Transport::HTTP::Manticore
+      def initialize(json=nil)
+        @json ||= <<-JSON
+        {
+          "ok" : true,
+          "cluster_name" : "elasticsearch_test",
+          "nodes" : {
+            "N1" : {
+              "name" : "Node 1",
+              "transport_address" : "inet[/192.168.1.23:9300]",
+              "hostname" : "testhost1",
+              "version" : "0.20.6",
+              "http_address" : "inet[/192.168.1.23:9200]",
+              "thrift_address" : "/192.168.1.23:9500",
+              "memcached_address" : "inet[/192.168.1.23:11211]"
+            }
+          }
+        }
+        JSON
+        @options = {}
+      end
+
+      def perform_request(method, path, options)
+        Elasticsearch::Transport::Transport::Response.new 200, MultiJson.load(@json)
+      end
+
+      def protocol
+        "http"
+      end
+    end
+
+    context "Manticore Sniffer" do
+      setup do
+        @logger = Logger.new(STDERR)
+        @logger.level = Logger::WARN
+        @transport = ManticoreDummyTransport.new
+        @transport.expects(:options).returns({:sniffer_timeout => 1}).at_least_once
+        @sniffer   = Elasticsearch::Transport::Transport::HTTP::Manticore::ManticoreSniffer.new @transport, @logger
+      end
+
+      should "be initialized with a transport instance" do
+        assert_equal @transport, @sniffer.transport
+      end
+
+      should "sniff every N seconds" do
+        count = 0
+        @sniffer.sniff_every(1) do |result|
+          count += 1
+        end
+        sleep 5
+        # Timing issues can make this inaccurate, 3 to 5 is close enough
+        assert((3..5).include?(count), "Expcted 5 or 4 invocations. Got #{count}")
+      end
+
+    end
+
+  end
+end

--- a/elasticsearch-transport/test/unit/transport_base_test.rb
+++ b/elasticsearch-transport/test/unit/transport_base_test.rb
@@ -367,7 +367,7 @@ class Elasticsearch::Transport::Transport::BaseTest < Test::Unit::TestCase
 
     should "log the request and response" do
       @transport.logger.expects(:info).  with do |line|
-        line =~ %r|POST localhost\:9200/_search\?size=1 \[status\:200, request:.*s, query:n/a\]|
+        line =~ %r|POST localhost\:9200/_search\?size=1 \[status\:200, request:[0-9\.]+s, query:n/a\]|
       end
       @transport.logger.expects(:debug). with '> {"foo":"bar"}'
       @transport.logger.expects(:debug). with '< {"foo":"bar"}'
@@ -565,7 +565,7 @@ class Elasticsearch::Transport::Transport::BaseTest < Test::Unit::TestCase
 
   context "errors" do
     should "raise highest-level Error exception for any ServerError" do
-      assert_kind_of Elasticsearch::Transport::Transport::Error, Elasticsearch::Transport::Transport::ServerError.new
+      assert_kind_of Elasticsearch::Transport::Transport::Error, Elasticsearch::Transport::Transport::ServerError.new(mock("foo"))
     end
   end
 end

--- a/elasticsearch-transport/test/unit/transport_manticore_pool_test.rb
+++ b/elasticsearch-transport/test/unit/transport_manticore_pool_test.rb
@@ -1,0 +1,69 @@
+require 'test_helper'
+
+unless JRUBY
+  version = ( defined?(RUBY_ENGINE) ? RUBY_ENGINE : 'Ruby' ) + ' ' + RUBY_VERSION
+  puts "SKIP: '#{File.basename(__FILE__)}' only supported on JRuby (you're running #{version})"
+else
+  require 'elasticsearch/transport/transport/http/manticore/pool'
+  require 'manticore'
+
+  class Elasticsearch::Transport::Transport::HTTP::ManticorePoolTest < Test::Unit::TestCase
+    include Elasticsearch::Transport::Transport::HTTP
+
+    context "Manticore transport" do
+      setup do
+        @logger = Logger.new(StringIO.new)
+        @adapter = mock()
+        @healthcheck_path = "/healthcheck"
+        @urls = ["http://localhost:9200", "http://localhost:9201", "http://localhost:9202"]
+        @url_uris = @urls.map {|u| URI.parse(u) }
+        @resurrect_interval = 3
+        @pool = ::Elasticsearch::Transport::Transport::HTTP::Manticore::Pool.new(@logger, @adapter, @healthcheck_path, @urls, @resurrect_interval)
+      end
+
+      teardown do
+        @adapter.expects(:close)
+        @pool.close
+      end
+
+      should "close cleanly" do
+        @adapter.expects(:close)
+        @pool.close
+      end
+
+      context "#with_connection" do
+        should "correctly get an URL from the list of open URLs" do
+          @pool.with_connection do |c|
+            assert(@url_uris.include?(c))
+          end
+        end
+
+        should "minimize the number of connections to a given URL" do
+          connected_urls = []
+          (@urls.size*2).times do
+            c,meta = @pool.get_connection
+            connected_urls << c
+          end
+          connected_urls.each {|u| @pool.return_connection(u) }
+          @urls.each do |url|
+            assert_equal(2, connected_urls.select {|u| u == URI.parse(url)}.size)
+          end
+        end
+
+        should "resurrect dead connections" do
+          u,m = @pool.get_connection
+
+          # The resurrectionist will call this to check on the backend
+          @adapter.expects(:perform_request).with(u, 'GET', @healthcheck_path, {}, nil).returns(::Elasticsearch::Transport::Transport::Response.new(200, "", {}))
+
+          @pool.return_connection(u)
+          @pool.mark_dead(u, Exception.new)
+          assert(@pool.url_meta(u)[:dead])
+          sleep @resurrect_interval + 1
+          assert(!@pool.url_meta(u)[:dead])
+        end
+
+      end
+    end
+  end
+end

--- a/elasticsearch-transport/test/unit/transport_manticore_test.rb
+++ b/elasticsearch-transport/test/unit/transport_manticore_test.rb
@@ -19,45 +19,39 @@ else
         assert_instance_of Array, @transport.host_unreachable_exceptions
       end
 
-      should "implement __build_connections" do
-        assert_equal 1, @transport.hosts.size
-        assert_equal 1, @transport.connections.size
-
-        assert_instance_of ::Manticore::Client,   @transport.connections.first.connection
-      end
-
-      should "not close connections in __close_connections" do
-        assert_equal 1, @transport.connections.size
+      should "prevent requests after __close_connections" do
         @transport.__close_connections
-        assert_equal 1, @transport.connections.size
+        assert_raises ::Manticore::ClientStoppedException do
+          @transport.perform_request 'GET', '/'
+        end
       end
 
       should "perform the request" do
-        @transport.connections.first.connection.expects(:get).returns(stub_everything)
+        @transport.adapter.manticore.expects(:get).returns(stub_everything)
         @transport.perform_request 'GET', '/'
       end
 
       should "set body for GET request" do
-        @transport.connections.first.connection.expects(:get).
-          with('http://127.0.0.1:8080//', {:body => '{"foo":"bar"}'}).returns(stub_everything)
+        @transport.adapter.manticore.expects(:get).
+          with('http://127.0.0.1:8080/', {:body => '{"foo":"bar"}'}).returns(stub_everything)
         @transport.perform_request 'GET', '/', {}, '{"foo":"bar"}'
       end
 
       should "set body for PUT request" do
-        @transport.connections.first.connection.expects(:put).
-          with('http://127.0.0.1:8080//', {:body => '{"foo":"bar"}'}).returns(stub_everything)
+        @transport.adapter.manticore.expects(:put).
+          with('http://127.0.0.1:8080/', {:body => '{"foo":"bar"}'}).returns(stub_everything)
         @transport.perform_request 'PUT', '/', {}, {:foo => 'bar'}
       end
 
       should "serialize the request body" do
-        @transport.connections.first.connection.expects(:post).
-          with('http://127.0.0.1:8080//', {:body => '{"foo":"bar"}'}).returns(stub_everything)
+        @transport.adapter.manticore.expects(:post).
+          with('http://127.0.0.1:8080/', {:body => '{"foo":"bar"}'}).returns(stub_everything)
         @transport.perform_request 'POST', '/', {}, {'foo' => 'bar'}
       end
 
       should "not serialize a String request body" do
-        @transport.connections.first.connection.expects(:post).
-          with('http://127.0.0.1:8080//', {:body => '{"foo":"bar"}'}).returns(stub_everything)
+        @transport.adapter.manticore.expects(:post).
+          with('http://127.0.0.1:8080/', {:body => '{"foo":"bar"}'}).returns(stub_everything)
         @transport.serializer.expects(:dump).never
         @transport.perform_request 'POST', '/', {}, '{"foo":"bar"}'
       end
@@ -69,18 +63,23 @@ else
 
         transport = Manticore.new :hosts => [ { :host => 'localhost', :port => 8080 } ], :options => options
 
-        transport.connections.first.connection.stub("http://localhost:8080//", :body => "\"\"", :headers => {"content-type" => "application/json"}, :code => 200 )
+        resp = mock()
+        resp.stubs(:code).returns(200)
+        resp.stubs(:read_body).returns(nil)
+        resp.stubs(:headers).returns({})
+        transport.adapter.manticore.expects(:get).with("http://localhost:8080/", :headers => {"content-type" => "application/json"}).returns(resp)
+
 
         response = transport.perform_request 'GET', '/', {}
         assert_equal response.status, 200
       end
 
       should "handle HTTP methods" do
-        @transport.connections.first.connection.expects(:delete).with('http://127.0.0.1:8080//', {}).returns(stub_everything)
-        @transport.connections.first.connection.expects(:head).with('http://127.0.0.1:8080//', {}).returns(stub_everything)
-        @transport.connections.first.connection.expects(:get).with('http://127.0.0.1:8080//', {}).returns(stub_everything)
-        @transport.connections.first.connection.expects(:put).with('http://127.0.0.1:8080//', {}).returns(stub_everything)
-        @transport.connections.first.connection.expects(:post).with('http://127.0.0.1:8080//', {}).returns(stub_everything)
+        @transport.adapter.manticore.expects(:delete).with('http://127.0.0.1:8080/', {}).returns(stub_everything)
+        @transport.adapter.manticore.expects(:head).with('http://127.0.0.1:8080/', {}).returns(stub_everything)
+        @transport.adapter.manticore.expects(:get).with('http://127.0.0.1:8080/', {}).returns(stub_everything)
+        @transport.adapter.manticore.expects(:put).with('http://127.0.0.1:8080/', {}).returns(stub_everything)
+        @transport.adapter.manticore.expects(:post).with('http://127.0.0.1:8080/', {}).returns(stub_everything)
 
         %w| HEAD GET PUT POST DELETE |.each { |method| @transport.perform_request method, '/' }
 
@@ -90,8 +89,8 @@ else
       should "allow to set options for Manticore" do
         options = { :headers => {"User-Agent" => "myapp-0.0" }}
         transport = Manticore.new :hosts => [ { :host => 'foobar', :port => 1234 } ], :options => options
-        transport.connections.first.connection.expects(:get).
-          with('http://foobar:1234//', options).returns(stub_everything)
+        transport.adapter.manticore.expects(:get).
+          with('http://foobar:1234/', options).returns(stub_everything)
 
         transport.perform_request 'GET', '/', {}
       end
@@ -106,7 +105,7 @@ else
         }
 
         ::Manticore::Client.expects(:new).with(options)
-        transport = Manticore.new :hosts => [ { :host => 'foobar', :port => 1234 } ], :options => options
+        Manticore.new :hosts => [ { :host => 'foobar', :port => 1234 } ], :options => options
       end
 
       should "pass :transport_options to Manticore::Client" do
@@ -115,10 +114,68 @@ else
         }
 
         ::Manticore::Client.expects(:new).with(:potatoes => 1, :ssl => {})
-        transport = Manticore.new :hosts => [ { :host => 'foobar', :port => 1234 } ], :options => options
+        Manticore.new :hosts => [ { :host => 'foobar', :port => 1234 } ], :options => options
+      end
+
+      context "#with_request_retries" do
+        setup do
+          @retry_count = 3
+          @retry_on_status = 429
+          @transport = Manticore.new :hosts => [{:host => 'foobar'}],
+                                     :options => {
+                                       :retry_on_failure => @retry_count,
+                                       :retry_on_status => [429],
+                                       :reload_on_failure => true
+                                     }
+        end
+
+        should "only retry 'tries' times when ServerError exceptions are encountered then raises" do
+          count = 0
+          resp = ::Elasticsearch::Transport::Transport::Response.new(429, nil, {})
+          e = ::Elasticsearch::Transport::Transport::ServerError.new(resp)
+          assert_raises e.class do
+            @transport.with_request_retries do
+              count += 1
+              raise e
+            end
+          end
+
+          # Add one for the orig request
+          assert_equal(@retry_count+1, count)
+        end
+
+        should "only retry  'tries' times if the host is unreachable" do
+          count = 0
+          original_error = ::Manticore::Timeout.new
+          e = ::Elasticsearch::Transport::Transport::HostUnreachableError.new(original_error, "http://localhost:9200")
+          assert_raises e.class do
+            @transport.with_request_retries do
+              count += 1
+              raise e
+            end
+          end
+
+          # Add one for the orig request
+          assert_equal(@retry_count+1, count)
+        end
+
+        should "reload connections if host is unreachable and all hosts are dead" do
+          pool = mock()
+          pool.expects(:alive_urls_count).returns(0).at_least_once
+          @transport.expects(:pool).returns(pool).at_least_once
+          @transport.expects(:reload_connections!).times(@retry_count)
+
+          count = 0
+          original_error = ::Manticore::Timeout.new
+          e = ::Elasticsearch::Transport::Transport::HostUnreachableError.new(original_error, "http://localhost:9200")
+          assert_raises e.class do
+            @transport.with_request_retries do
+              count += 1
+              raise e
+            end
+          end
+        end
       end
     end
-
   end
-
 end

--- a/elasticsearch-transport/test/unit/transport_manticore_test.rb
+++ b/elasticsearch-transport/test/unit/transport_manticore_test.rb
@@ -90,7 +90,7 @@ else
         options = { :headers => {"User-Agent" => "myapp-0.0" }}
         transport = Manticore.new :hosts => [ { :host => 'foobar', :port => 1234 } ], :options => options
         transport.adapter.manticore.expects(:get).
-          with('http://foobar:1234/', options).returns(stub_everything)
+          with('http://foobar:1234/', :headers => options[:headers]).returns(stub_everything)
 
         transport.perform_request 'GET', '/', {}
       end
@@ -104,7 +104,7 @@ else
           }
         }
 
-        ::Manticore::Client.expects(:new).with(options)
+        ::Manticore::Client.expects(:new).with(:ssl => {:truststore => 'test.jks', :truststore_password => 'test', :verify => false})
         Manticore.new :hosts => [ { :host => 'foobar', :port => 1234 } ], :options => options
       end
 

--- a/elasticsearch-watcher/Gemfile
+++ b/elasticsearch-watcher/Gemfile
@@ -2,3 +2,6 @@ source 'https://rubygems.org'
 
 # Specify your gem's dependencies in elasticsearch-watcher.gemspec
 gemspec
+
+gem 'elasticsearch', :path => '../elasticsearch'
+gem 'elasticsearch-extensions', :path => '../elasticsearch-extensions'


### PR DESCRIPTION
Continues work from https://github.com/elastic/elasticsearch-ruby/pull/284 making Manticore connections threadsafe. Renamed the branch because this only touches Manticore.