### PR TITLE
Support for older versions of multi_json

### DIFF
--- a/elasticsearch-api/lib/elasticsearch/api.rb
+++ b/elasticsearch-api/lib/elasticsearch/api.rb
@@ -10,7 +10,34 @@ Dir[ File.expand_path('../api/namespace/**/*.rb', __FILE__) ].each { |f| require
 
 module Elasticsearch
   module API
-    DEFAULT_SERIALIZER = MultiJson
+
+    # A wrapper around MultiJson to handle older versions of the gem.
+    # Inspired by a similar class in elasticsearch-transport/lib/elasticsearch/transport/transport/serializer/multi_json.rb
+    module MultiJson
+      # De-serialize a Hash from JSON string
+      #
+      def load(string, options={})
+        if Gem.loaded_specs['multi_json'].version < Gem::Version.create('1.3.0')
+          ::MultiJson.decode(string, options)
+        else
+          ::MultiJson.load(string, options)
+        end
+      end
+      module_function :load
+
+      # Serialize a Hash to JSON string
+      #
+      def dump(object, options={})
+        if Gem.loaded_specs['multi_json'].version < Gem::Version.create('1.3.0')
+          ::MultiJson.encode(object, options)
+        else
+          ::MultiJson.dump(object, options)
+        end
+      end
+      module_function :dump
+    end
+
+    DEFAULT_SERIALIZER = Elasticsearch::API::MultiJson
 
     COMMON_PARAMS = [
       :ignore,                        # Client specific parameters

--- a/elasticsearch-api/test/unit/api_test.rb
+++ b/elasticsearch-api/test/unit/api_test.rb
@@ -18,7 +18,7 @@ module Elasticsearch
         end
 
         should "have default serializer" do
-          assert_equal MultiJson, Elasticsearch::API.serializer
+          assert_equal Elasticsearch::API::MultiJson, Elasticsearch::API.serializer
         end
 
       end

--- a/elasticsearch-api/test/unit/serializer_test.rb
+++ b/elasticsearch-api/test/unit/serializer_test.rb
@@ -1,0 +1,28 @@
+require 'test_helper'
+
+module Elasticsearch
+  module Test
+    class SerializerTest < ::Test::Unit::TestCase
+      context "Serializer" do
+
+        should "use MultiJson's dump/load methods when multi_json >= 1.3.0 is installed" do
+          Gem.stubs(:loaded_specs).returns({'multi_json' => Gem::Specification.new('multi_json', '1.13.2')})
+          ::MultiJson.expects(:load)
+          ::MultiJson.expects(:dump)
+          Elasticsearch::API.serializer.load('{}')
+          Elasticsearch::API.serializer.dump({})
+        end
+
+        should "use MultiJson's encode/decode when multi_json < 1.3.0 is installed" do
+          Gem.stubs(:loaded_specs).returns({'multi_json' => Gem::Specification.new('multi_json', '1.2.0')})
+          ::MultiJson.expects(:decode)
+          ::MultiJson.expects(:encode)
+          Elasticsearch::API.serializer.load('{}')
+          Elasticsearch::API.serializer.dump({})
+        end
+
+      end
+    end
+  end
+end
+

--- a/elasticsearch-transport/lib/elasticsearch/transport/transport/serializer/multi_json.rb
+++ b/elasticsearch-transport/lib/elasticsearch/transport/transport/serializer/multi_json.rb
@@ -21,13 +21,21 @@ module Elasticsearch
           # De-serialize a Hash from JSON string
           #
           def load(string, options={})
-            ::MultiJson.load(string, options)
+            if Gem.loaded_specs['multi_json'].version < Gem::Version.create('1.3.0')
+              ::MultiJson.decode(string, options)
+            else
+              ::MultiJson.load(string, options)
+            end
           end
 
           # Serialize a Hash to JSON string
           #
           def dump(object, options={})
-            ::MultiJson.dump(object, options)
+            if Gem.loaded_specs['multi_json'].version < Gem::Version.create('1.3.0')
+              ::MultiJson.encode(object, options)
+            else
+              ::MultiJson.dump(object, options)
+            end
           end
         end
       end

--- a/elasticsearch-transport/test/unit/serializer_test.rb
+++ b/elasticsearch-transport/test/unit/serializer_test.rb
@@ -4,9 +4,18 @@ class Elasticsearch::Transport::Transport::SerializerTest < Test::Unit::TestCase
 
   context "Serializer" do
 
-    should "use MultiJson by default" do
+    should "use MultiJson's dump/load methods when multi_json >= 1.3.0 is installed" do
+      Gem.stubs(:loaded_specs).returns({'multi_json' => Gem::Specification.new('multi_json', '1.13.2')})
       ::MultiJson.expects(:load)
       ::MultiJson.expects(:dump)
+      Elasticsearch::Transport::Transport::Serializer::MultiJson.new.load('{}')
+      Elasticsearch::Transport::Transport::Serializer::MultiJson.new.dump({})
+    end
+
+    should "use MultiJson's encode/decode when multi_json < 1.3.0 is installed" do
+      Gem.stubs(:loaded_specs).returns({'multi_json' => Gem::Specification.new('multi_json', '1.2.0')})
+      ::MultiJson.expects(:decode)
+      ::MultiJson.expects(:encode)
       Elasticsearch::Transport::Transport::Serializer::MultiJson.new.load('{}')
       Elasticsearch::Transport::Transport::Serializer::MultiJson.new.dump({})
     end


### PR DESCRIPTION
Allow the multi_json serializer wrapper in elasticsearch-transport to use versions of multi_json that don't have an implementation of dump/load. 

dump/load were [introduced in v 1.3.0](https://github.com/intridea/multi_json/blob/master/CHANGELOG.md#130). Prior versions only have decode/encode methods.

This implementation checks to see which version of multi_json is loaded, and calls the appropriate serialization/deserialization methods.