### PR TITLE
Security bugfix: Change Faraday path to be without user and password

### DIFF
--- a/elasticsearch-transport/lib/elasticsearch/transport/transport/base.rb
+++ b/elasticsearch-transport/lib/elasticsearch/transport/transport/base.rb
@@ -252,7 +252,7 @@ module Elasticsearch
               params = connection.connection.params.merge(params.to_hash)
             end
 
-            url        = connection.full_url(path, params)
+            url        = connection.full_path(path, params)
 
             response   = block.call(connection, url)
 

--- a/elasticsearch-transport/lib/elasticsearch/transport/transport/http/curb.rb
+++ b/elasticsearch-transport/lib/elasticsearch/transport/transport/http/curb.rb
@@ -17,7 +17,7 @@ module Elasticsearch
           #
           def perform_request(method, path, params={}, body=nil)
             super do |connection,url|
-              connection.connection.url = url
+              connection.connection.url += url
 
               case method
                 when 'HEAD'

--- a/elasticsearch-transport/test/unit/transport_base_test.rb
+++ b/elasticsearch-transport/test/unit/transport_base_test.rb
@@ -354,7 +354,7 @@ class Elasticsearch::Transport::Transport::BaseTest < Test::Unit::TestCase
     setup do
       @transport = DummyTransportPerformer.new :options => { :logger => Logger.new('/dev/null') }
 
-      fake_connection = stub :full_url => 'localhost:9200/_search?size=1',
+      fake_connection = stub :full_path => 'localhost:9200/_search?size=1',
                              :host     => 'localhost',
                              :connection => stub_everything,
                              :failures => 0,
@@ -378,7 +378,7 @@ class Elasticsearch::Transport::Transport::BaseTest < Test::Unit::TestCase
     end
 
     should "sanitize password in the URL" do
-      fake_connection = stub :full_url => 'http://user:password@localhost:9200/_search?size=1',
+      fake_connection = stub :full_path => 'http://user:password@localhost:9200/_search?size=1',
                              :host     => 'localhost',
                              :connection => stub_everything,
                              :failures => 0,
@@ -421,7 +421,7 @@ class Elasticsearch::Transport::Transport::BaseTest < Test::Unit::TestCase
     setup do
       @transport = DummyTransportPerformer.new :options => { :tracer => Logger.new('/dev/null') }
 
-      fake_connection = stub :full_url => 'localhost:9200/_search?size=1',
+      fake_connection = stub :full_path => 'localhost:9200/_search?size=1',
                              :host     => 'localhost',
                              :connection => stub_everything,
                              :failures => 0,


### PR DESCRIPTION
There is no need to send the full path to the Faraday connection - it already has the host from the connection initializer.
We had issues with Ethon logging the user and password in plaintext - this fix removes that from the logs.
