### PR TITLE
It should be request_cache instead of query_cache

### DIFF
--- a/elasticsearch-api/lib/elasticsearch/api/actions/search.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/search.rb
@@ -133,7 +133,7 @@ module Elasticsearch
           :lowercase_expanded_terms,
           :preference,
           :q,
-          :query_cache,
+          :request_cache,
           :routing,
           :scroll,
           :search_type,


### PR DESCRIPTION
https://www.elastic.co/guide/en/elasticsearch/reference/current/shard-request-cache.html

I can't find the doc about the parameter `query_cache`. Instead, I found that the examples from elasticsearch is using `request_cache`.