### PR TITLE
Allow access to calling context from search block

### DIFF
--- a/elasticsearch-dsl/lib/elasticsearch/dsl/search.rb
+++ b/elasticsearch-dsl/lib/elasticsearch/dsl/search.rb
@@ -39,7 +39,7 @@ module Elasticsearch
 
         def initialize(*args, &block)
           @options = Options.new *args
-          instance_eval(&block) if block
+          block.arity < 1 ? self.instance_eval(&block) : block.call(self) if block
         end
 
         # DSL method for building or accessing the `query` part of a search definition


### PR DESCRIPTION
In #291 access to the calling scope was mentioned so that you could use helper methods in the query definition.

_Turns out_ this functionality is already present in a basic form.  If you pass an argument to most blocks, it will execute the block in the calling context, whereas if you do it with arity == 0 - it will `instance_eval` it. 

I'm not sure how desirable this is, since it would seem to me that you'd want access to your calling context FAR more frequently than you would want access to the the AST builder - but since that's potentially a pretty big change, we can support hanging on to our calling context via the arity hack in the search block.

I checked the other base components, and they all seem to support this with the exception of the `search` method.  Search never executes a passed in block with an argument, so it should be safe to change this.