### PR TITLE
Sort responds to empty? correctly

### DIFF
--- a/elasticsearch-dsl/lib/elasticsearch/dsl/search/sort.rb
+++ b/elasticsearch-dsl/lib/elasticsearch/dsl/search/sort.rb
@@ -36,9 +36,11 @@ module Elasticsearch
         #
         def to_hash
           if @block
-            call
+            call unless @block_called
+            @block_called = true
           else
-            @value << @args if @args
+            last_index = @value.length == 0 ? 0 : -1
+            @value[last_index] = @args if @args
           end
 
           @hash = @value.flatten

--- a/elasticsearch-dsl/lib/elasticsearch/dsl/search/sort.rb
+++ b/elasticsearch-dsl/lib/elasticsearch/dsl/search/sort.rb
@@ -44,6 +44,10 @@ module Elasticsearch
           @hash = @value.flatten
           @hash
         end
+
+        def empty?
+          @value.empty? && @args.empty?
+        end
       end
     end
   end

--- a/elasticsearch-dsl/test/unit/search_sort_test.rb
+++ b/elasticsearch-dsl/test/unit/search_sort_test.rb
@@ -36,6 +36,21 @@ module Elasticsearch
           end
         end
 
+        context "to_hash is indempotent" do
+          should 'when defined by args' do
+            subject = Elasticsearch::DSL::Search::Sort.new foo: { order: 'desc' }
+            assert_equal(subject.to_hash, subject.to_hash)
+          end
+
+          should 'when defined by a block' do
+            subject = Elasticsearch::DSL::Search::Sort.new do
+              by :foo
+            end
+
+            assert_equal(subject.to_hash, subject.to_hash)
+          end
+        end
+
 
         should "add fields with the DSL method" do
           subject = Elasticsearch::DSL::Search::Sort.new do

--- a/elasticsearch-dsl/test/unit/search_sort_test.rb
+++ b/elasticsearch-dsl/test/unit/search_sort_test.rb
@@ -22,6 +22,21 @@ module Elasticsearch
           assert_equal( [ { foo: { order: 'desc', mode: 'avg' } } ], subject.to_hash )
         end
 
+        context "when the search is empty" do
+          should "respond with true to empty?" do
+            subject = Elasticsearch::DSL::Search::Sort.new
+            assert_equal subject.empty?, true
+          end
+        end
+
+        context "when search is not empty" do
+          should "respond with false to empty?" do
+            subject = Elasticsearch::DSL::Search::Sort.new foo: { order: 'desc' }
+            assert_equal subject.empty?, false
+          end
+        end
+
+
         should "add fields with the DSL method" do
           subject = Elasticsearch::DSL::Search::Sort.new do
             by :foo


### PR DESCRIPTION
The Sort component respond to `empty?` but raises an error when it is called.