### PR TITLE
Proper compatibility matrix between Elasticsearch 1.x and Ruby gem versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 1.1.0
+
+### API
+
+* Added deprecation notices to API methods and arguments not supported on Elasticsearch 1.x
+
 ## DSL:0.1.4
 
 * Added correct implementation of `Sort#empty?`

--- a/elasticsearch-api/lib/elasticsearch/api/actions/bulk.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/bulk.rb
@@ -64,7 +64,7 @@ module Elasticsearch
       def bulk(arguments={})
         arguments = arguments.clone
 
-        type      = arguments.delete(:type)
+        type = arguments.delete(:type)
 
         valid_params = [
           :consistency,
@@ -74,6 +74,9 @@ module Elasticsearch
           :timeout,
           :fields,
           :pipeline ]
+
+        unsupported_params = [ :fields, :pipeline ]
+        Utils.__report_unsupported_parameters(arguments, unsupported_params)
 
         method = HTTP_POST
         path   = Utils.__pathify Utils.__escape(arguments[:index]), Utils.__escape(type), '_bulk'

--- a/elasticsearch-api/lib/elasticsearch/api/actions/cat/aliases.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/cat/aliases.rb
@@ -48,6 +48,9 @@ module Elasticsearch
             :help,
             :v ]
 
+          unsupported_params = [ :format ]
+          Utils.__report_unsupported_parameters(arguments.keys, unsupported_params)
+
           name = arguments.delete(:name)
 
           method = HTTP_GET

--- a/elasticsearch-api/lib/elasticsearch/api/actions/cat/allocation.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/cat/allocation.rb
@@ -50,6 +50,9 @@ module Elasticsearch
             :help,
             :v ]
 
+          unsupported_params = [ :format ]
+          Utils.__report_unsupported_parameters(arguments.keys, unsupported_params)
+
           node_id = arguments.delete(:node_id)
 
           method = HTTP_GET

--- a/elasticsearch-api/lib/elasticsearch/api/actions/cat/count.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/cat/count.rb
@@ -44,6 +44,9 @@ module Elasticsearch
             :help,
             :v ]
 
+          unsupported_params = [ :format ]
+          Utils.__report_unsupported_parameters(arguments.keys, unsupported_params)
+
           index = arguments.delete(:index)
 
           method = HTTP_GET

--- a/elasticsearch-api/lib/elasticsearch/api/actions/cat/fielddata.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/cat/fielddata.rb
@@ -34,6 +34,9 @@ module Elasticsearch
             :v,
             :fields ]
 
+          unsupported_params = [ :format ]
+          Utils.__report_unsupported_parameters(arguments.keys, unsupported_params)
+
           fields = arguments.delete(:fields)
 
           method = HTTP_GET

--- a/elasticsearch-api/lib/elasticsearch/api/actions/cat/health.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/cat/health.rb
@@ -37,6 +37,9 @@ module Elasticsearch
             :ts,
             :v ]
 
+          unsupported_params = [ :format ]
+          Utils.__report_unsupported_parameters(arguments.keys, unsupported_params)
+
           method = HTTP_GET
           path   = "_cat/health"
           params = Utils.__validate_and_extract_params arguments, valid_params

--- a/elasticsearch-api/lib/elasticsearch/api/actions/cat/indices.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/cat/indices.rb
@@ -58,6 +58,9 @@ module Elasticsearch
             :pri,
             :v ]
 
+          unsupported_params = [ :format ]
+          Utils.__report_unsupported_parameters(arguments.keys, unsupported_params)
+
           index = arguments.delete(:index)
 
           method = HTTP_GET

--- a/elasticsearch-api/lib/elasticsearch/api/actions/cat/master.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/cat/master.rb
@@ -35,6 +35,9 @@ module Elasticsearch
             :help,
             :v ]
 
+          unsupported_params = [ :format ]
+          Utils.__report_unsupported_parameters(arguments.keys, unsupported_params)
+
           method = HTTP_GET
           path   = "_cat/master"
           params = Utils.__validate_and_extract_params arguments, valid_params

--- a/elasticsearch-api/lib/elasticsearch/api/actions/cat/nodeattrs.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/cat/nodeattrs.rb
@@ -14,12 +14,15 @@ module Elasticsearch
         # @see http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-nodeattrs.html
         #
         def nodeattrs(arguments={})
+          Utils.__report_unsupported_method(__method__)
+
           valid_params = [
             :local,
             :master_timeout,
             :h,
             :help,
             :v ]
+
           method = 'GET'
           path   = "_cat/nodeattrs"
           params = Utils.__validate_and_extract_params arguments, valid_params

--- a/elasticsearch-api/lib/elasticsearch/api/actions/cat/nodes.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/cat/nodes.rb
@@ -43,6 +43,9 @@ module Elasticsearch
             :help,
             :v ]
 
+          unsupported_params = [ :format ]
+          Utils.__report_unsupported_parameters(arguments.keys, unsupported_params)
+
           method = HTTP_GET
           path   = "_cat/nodes"
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/cat/pending_tasks.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/cat/pending_tasks.rb
@@ -35,6 +35,9 @@ module Elasticsearch
             :help,
             :v ]
 
+          unsupported_params = [ :format ]
+          Utils.__report_unsupported_parameters(arguments.keys, unsupported_params)
+
           method = HTTP_GET
           path   = "_cat/pending_tasks"
           params = Utils.__validate_and_extract_params arguments, valid_params

--- a/elasticsearch-api/lib/elasticsearch/api/actions/cat/plugins.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/cat/plugins.rb
@@ -21,6 +21,10 @@ module Elasticsearch
             :h,
             :help,
             :v ]
+
+          unsupported_params = [ :format ]
+          Utils.__report_unsupported_parameters(arguments.keys, unsupported_params)
+
           method = 'GET'
           path   = "_cat/plugins"
           params = Utils.__validate_and_extract_params arguments, valid_params

--- a/elasticsearch-api/lib/elasticsearch/api/actions/cat/recovery.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/cat/recovery.rb
@@ -54,6 +54,9 @@ module Elasticsearch
             :help,
             :v ]
 
+          unsupported_params = [ :format ]
+          Utils.__report_unsupported_parameters(arguments.keys, unsupported_params)
+
           index = arguments.delete(:index)
 
           method = HTTP_GET

--- a/elasticsearch-api/lib/elasticsearch/api/actions/cat/repositories.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/cat/repositories.rb
@@ -21,6 +21,8 @@ module Elasticsearch
         # @see https://www.elastic.co/guide/en/elasticsearch/reference/current/cat-repositories.html
         #
         def repositories(arguments={})
+          Utils.__report_unsupported_method(__method__)
+
           valid_params = [
             :master_timeout,
             :h,

--- a/elasticsearch-api/lib/elasticsearch/api/actions/cat/segments.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/cat/segments.rb
@@ -23,6 +23,10 @@ module Elasticsearch
             :h,
             :help,
             :v ]
+
+          unsupported_params = [ :format ]
+          Utils.__report_unsupported_parameters(arguments.keys, unsupported_params)
+
           method = 'GET'
           path   = "_cat/segments"
           params = Utils.__validate_and_extract_params arguments, valid_params

--- a/elasticsearch-api/lib/elasticsearch/api/actions/cat/shards.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/cat/shards.rb
@@ -58,6 +58,9 @@ module Elasticsearch
             :help,
             :v ]
 
+          unsupported_params = [ :format ]
+          Utils.__report_unsupported_parameters(arguments.keys, unsupported_params)
+
           index = arguments.delete(:index)
 
           method = HTTP_GET

--- a/elasticsearch-api/lib/elasticsearch/api/actions/cat/snapshots.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/cat/snapshots.rb
@@ -21,6 +21,8 @@ module Elasticsearch
         # @see https://www.elastic.co/guide/en/elasticsearch/reference/current/cat-snapshots.html
         #
         def snapshots(arguments={})
+          Utils.__report_unsupported_method(__method__)
+
           raise ArgumentError, "Required argument 'repository' missing" unless arguments[:repository]
 
           valid_params = [

--- a/elasticsearch-api/lib/elasticsearch/api/actions/cat/tasks.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/cat/tasks.rb
@@ -18,6 +18,8 @@ module Elasticsearch
         # @see http://www.elastic.co/guide/en/elasticsearch/reference/master/tasks.html
         #
         def tasks(arguments={})
+          Utils.__report_unsupported_method(__method__)
+
           valid_params = [
             :format,
             :node_id,

--- a/elasticsearch-api/lib/elasticsearch/api/actions/cat/thread_pool.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/cat/thread_pool.rb
@@ -45,6 +45,9 @@ module Elasticsearch
             :help,
             :v ]
 
+          unsupported_params = [ :format, :size ]
+          Utils.__report_unsupported_parameters(arguments.keys, unsupported_params)
+
           method = HTTP_GET
           path   = "_cat/thread_pool"
           params = Utils.__validate_and_extract_params arguments, valid_params

--- a/elasticsearch-api/lib/elasticsearch/api/actions/cluster/allocation_explain.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/cluster/allocation_explain.rb
@@ -11,6 +11,8 @@ module Elasticsearch
         # @see http://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-allocation-explain.html
         #
         def allocation_explain(arguments={})
+          Utils.__report_unsupported_method(__method__)
+
           valid_params = [
             :include_yes_decisions ]
           method = 'GET'

--- a/elasticsearch-api/lib/elasticsearch/api/actions/cluster/get_settings.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/cluster/get_settings.rb
@@ -21,6 +21,9 @@ module Elasticsearch
             :include_defaults
           ]
 
+          unsupported_params = [ :include_defaults ]
+          Utils.__report_unsupported_parameters(arguments.keys, unsupported_params)
+
           method = HTTP_GET
           path   = "_cluster/settings"
           params = Utils.__validate_and_extract_params arguments, valid_params

--- a/elasticsearch-api/lib/elasticsearch/api/actions/cluster/reroute.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/cluster/reroute.rb
@@ -34,6 +34,9 @@ module Elasticsearch
         def reroute(arguments={})
           valid_params = [ :dry_run, :explain, :metric, :master_timeout, :retry_failed, :timeout ]
 
+          unsupported_params = [ :retry_failed ]
+          Utils.__report_unsupported_parameters(arguments.keys, unsupported_params)
+
           method = HTTP_POST
           path   = "_cluster/reroute"
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/index.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/index.rb
@@ -89,6 +89,9 @@ module Elasticsearch
           :version,
           :version_type ]
 
+        unsupported_params = [ :pipeline ]
+        Utils.__report_unsupported_parameters(arguments.keys, unsupported_params)
+
         method = arguments[:id] ? HTTP_PUT : HTTP_POST
         path   = Utils.__pathify Utils.__escape(arguments[:index]),
                                  Utils.__escape(arguments[:type]),

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/analyze.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/analyze.rb
@@ -64,6 +64,9 @@ module Elasticsearch
             :token_filters,
             :format ]
 
+          unsupported_params = [ :explain, :attributes ]
+          Utils.__report_unsupported_parameters(arguments.keys, unsupported_params)
+
           method = HTTP_GET
           path   = Utils.__pathify Utils.__listify(arguments[:index]), '_analyze'
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/create.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/create.rb
@@ -75,6 +75,9 @@ module Elasticsearch
             :update_all_types
           ]
 
+          unsupported_params = [ :update_all_types ]
+          Utils.__report_unsupported_parameters(arguments.keys, unsupported_params)
+
           method = HTTP_PUT
           path   = Utils.__pathify Utils.__escape(arguments[:index])
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/forcemerge.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/forcemerge.rb
@@ -42,6 +42,8 @@ module Elasticsearch
         # @see http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-forcemerge.html
         #
         def forcemerge(arguments={})
+          Utils.__report_unsupported_method(__method__)
+
           valid_params = [
             :max_num_segments,
             :only_expunge_deletes,

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/put_mapping.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/put_mapping.rb
@@ -62,6 +62,9 @@ module Elasticsearch
             :timeout
           ]
 
+          unsupported_params = [ :update_all_types ]
+          Utils.__report_unsupported_parameters(arguments.keys, unsupported_params)
+
           method = HTTP_PUT
           path   = Utils.__pathify Utils.__listify(arguments[:index]), '_mapping', Utils.__escape(arguments[:type])
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/put_settings.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/put_settings.rb
@@ -59,6 +59,9 @@ module Elasticsearch
             :flat_settings
           ]
 
+          unsupported_params = [ :update_all_types ]
+          Utils.__report_unsupported_parameters(arguments.keys, unsupported_params)
+
           method = HTTP_PUT
           path   = Utils.__pathify Utils.__listify(arguments[:index]), '_settings'
           params = Utils.__validate_and_extract_params arguments, valid_params

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/segments.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/segments.rb
@@ -32,6 +32,9 @@ module Elasticsearch
             :verbose
           ]
 
+          unsupported_params = [ :verbose ]
+          Utils.__report_unsupported_parameters(arguments.keys, unsupported_params)
+
           method = HTTP_GET
           path   = Utils.__pathify Utils.__listify(arguments[:index]), '_segments'
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/ingest/delete_pipeline.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/ingest/delete_pipeline.rb
@@ -12,6 +12,8 @@ module Elasticsearch
         # @see https://www.elastic.co/guide/en/elasticsearch/plugins/master/ingest.html
         #
         def delete_pipeline(arguments={})
+          Utils.__report_unsupported_method(__method__)
+
           raise ArgumentError, "Required argument 'id' missing" unless arguments[:id]
           valid_params = [
             :master_timeout,

--- a/elasticsearch-api/lib/elasticsearch/api/actions/ingest/get_pipeline.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/ingest/get_pipeline.rb
@@ -11,6 +11,8 @@ module Elasticsearch
         # @see https://www.elastic.co/guide/en/elasticsearch/plugins/master/ingest.html
         #
         def get_pipeline(arguments={})
+          Utils.__report_unsupported_method(__method__)
+
           raise ArgumentError, "Required argument 'id' missing" unless arguments[:id]
           valid_params = [
             :master_timeout ]

--- a/elasticsearch-api/lib/elasticsearch/api/actions/ingest/put_pipeline.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/ingest/put_pipeline.rb
@@ -13,6 +13,8 @@ module Elasticsearch
         # @see https://www.elastic.co/guide/en/elasticsearch/plugins/master/ingest.html
         #
         def put_pipeline(arguments={})
+          Utils.__report_unsupported_method(__method__)
+
           raise ArgumentError, "Required argument 'id' missing" unless arguments[:id]
           raise ArgumentError, "Required argument 'body' missing" unless arguments[:body]
           valid_params = [

--- a/elasticsearch-api/lib/elasticsearch/api/actions/ingest/simulate.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/ingest/simulate.rb
@@ -13,6 +13,8 @@ module Elasticsearch
         # @see https://www.elastic.co/guide/en/elasticsearch/reference/master/simulate-pipeline-api.html
         #
         def simulate(arguments={})
+          Utils.__report_unsupported_method(__method__)
+
           raise ArgumentError, "Required argument 'body' missing" unless arguments[:body]
           valid_params = [
             :verbose ]

--- a/elasticsearch-api/lib/elasticsearch/api/actions/nodes/hot_threads.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/nodes/hot_threads.rb
@@ -34,6 +34,9 @@ module Elasticsearch
             :type,
             :timeout ]
 
+          unsupported_params = [ :timeout ]
+          Utils.__report_unsupported_parameters(arguments.keys, unsupported_params)
+
           method = HTTP_GET
           path   = Utils.__pathify '_nodes', Utils.__listify(arguments[:node_id]), 'hot_threads'
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/nodes/info.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/nodes/info.rb
@@ -53,10 +53,12 @@ module Elasticsearch
             :process,
             :settings,
             :thread_pool,
-            :transport,
-            :timeout ]
+            :transport ]
 
           valid_params = [ :timeout ]
+
+          unsupported_params = [ :timeout ]
+          Utils.__report_unsupported_parameters(arguments.keys, unsupported_params)
 
           method = HTTP_GET
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/nodes/stats.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/nodes/stats.rb
@@ -57,6 +57,9 @@ module Elasticsearch
             :types,
             :timeout ]
 
+          unsupported_params = [ :timeout ]
+          Utils.__report_unsupported_parameters(arguments.keys, unsupported_params)
+
           method = HTTP_GET
 
           path   = Utils.__pathify '_nodes',

--- a/elasticsearch-api/lib/elasticsearch/api/actions/percolate.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/percolate.rb
@@ -90,6 +90,9 @@ module Elasticsearch
           :version,
           :version_type ]
 
+        unsupported_params = [ :percolate_format ]
+        Utils.__report_unsupported_parameters(arguments.keys, unsupported_params)
+
         method = HTTP_GET
         path   = Utils.__pathify Utils.__escape(arguments[:index]),
                                  Utils.__escape(arguments[:type]),

--- a/elasticsearch-api/lib/elasticsearch/api/actions/reindex.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/reindex.rb
@@ -50,6 +50,8 @@ module Elasticsearch
       # @see https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-reindex.html
       #
       def reindex(arguments={})
+        Utils.__report_unsupported_method(__method__)
+
         raise ArgumentError, "Required argument 'body' missing" unless arguments[:body]
         valid_params = [
           :refresh,
@@ -57,7 +59,8 @@ module Elasticsearch
           :consistency,
           :wait_for_completion,
           :requests_per_second ]
-        method = 'POST'
+
+        method = HTTP_POST
         path   = "_reindex"
         params = Utils.__validate_and_extract_params arguments, valid_params
         body   = arguments[:body]

--- a/elasticsearch-api/lib/elasticsearch/api/actions/render_search_template.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/render_search_template.rb
@@ -10,10 +10,11 @@ module Elasticsearch
       # @see http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/search-template.html
       #
       def render_search_template(arguments={})
-        valid_params = [
-          :id
-        ]
-        method = 'GET'
+        Utils.__report_unsupported_method(__method__)
+
+        valid_params = [ :id ]
+
+        method = HTTP_GET
         path   = "_render/template"
         params = Utils.__validate_and_extract_params arguments, valid_params
         body   = arguments[:body]

--- a/elasticsearch-api/lib/elasticsearch/api/actions/search.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/search.rb
@@ -156,6 +156,9 @@ module Elasticsearch
           :timeout,
           :version ]
 
+        unsupported_params = [ :terminate_after ]
+        Utils.__report_unsupported_parameters(arguments.keys, unsupported_params)
+
         method = HTTP_GET
         path   = Utils.__pathify( Utils.__listify(arguments[:index]), Utils.__listify(arguments[:type]), UNDERSCORE_SEARCH )
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/tasks/cancel.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/tasks/cancel.rb
@@ -18,6 +18,8 @@ module Elasticsearch
         # @see http://www.elastic.co/guide/en/elasticsearch/reference/master/tasks-cancel.html
         #
         def cancel(arguments={})
+          Utils.__report_unsupported_method(__method__)
+
           valid_params = [
             :node_id,
             :actions,
@@ -26,8 +28,7 @@ module Elasticsearch
 
           task_id = arguments.delete(:task_id)
 
-          method = 'POST'
-          path   = "_tasks"
+          method = HTTP_POST
           path   = Utils.__pathify( '_tasks', Utils.__escape(task_id), '_cancel' )
           params = Utils.__validate_and_extract_params arguments, valid_params
           body   = nil

--- a/elasticsearch-api/lib/elasticsearch/api/actions/tasks/list.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/tasks/list.rb
@@ -22,6 +22,8 @@ module Elasticsearch
         # @see http://www.elastic.co/guide/en/elasticsearch/reference/master/tasks-list.html
         #
         def list(arguments={})
+          Utils.__report_unsupported_method(__method__)
+
           valid_params = [
             :node_id,
             :actions,
@@ -33,8 +35,7 @@ module Elasticsearch
 
           task_id = arguments.delete(:task_id)
 
-          method = 'GET'
-          path   = "_tasks"
+          method = HTTP_GET
           path   = Utils.__pathify( '_tasks', Utils.__escape(task_id) )
           params = Utils.__validate_and_extract_params arguments, valid_params
           body   = nil

--- a/elasticsearch-api/lib/elasticsearch/api/actions/termvectors.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/termvectors.rb
@@ -58,6 +58,8 @@ module Elasticsearch
       # @see http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/docs-termvectors.html
       #
       def termvectors(arguments={})
+        Utils.__report_unsupported_method(__method__)
+
         raise ArgumentError, "Required argument 'index' missing" unless arguments[:index]
         raise ArgumentError, "Required argument 'type' missing" unless arguments[:type]
 

--- a/elasticsearch-api/lib/elasticsearch/api/version.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/version.rb
@@ -1,5 +1,5 @@
 module Elasticsearch
   module API
-    VERSION = "1.1.pre"
+    VERSION = "1.1.0"
   end
 end

--- a/elasticsearch-api/lib/elasticsearch/api/version.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/version.rb
@@ -1,5 +1,5 @@
 module Elasticsearch
   module API
-    VERSION = "1.0.18"
+    VERSION = "1.1.pre"
   end
 end

--- a/elasticsearch-api/test/integration/yaml_test_runner.rb
+++ b/elasticsearch-api/test/integration/yaml_test_runner.rb
@@ -258,7 +258,8 @@ module Elasticsearch
 
         # Skip features
         elsif skip && skip['skip']['features']
-          if (skip['skip']['features'].split(',') & SKIP_FEATURES.split(',') ).size > 0
+          skip_features = skip['skip']['features'].respond_to?(:split) ? skip['skip']['features'].split(',') : skip['skip']['features']
+          if ( skip_features & SKIP_FEATURES.split(',') ).size > 0
             return skip['skip']['features']
           end
         end

--- a/elasticsearch-transport/lib/elasticsearch/transport/version.rb
+++ b/elasticsearch-transport/lib/elasticsearch/transport/version.rb
@@ -1,5 +1,5 @@
 module Elasticsearch
   module Transport
-    VERSION = "1.0.18"
+    VERSION = "1.1.pre"
   end
 end

--- a/elasticsearch-transport/lib/elasticsearch/transport/version.rb
+++ b/elasticsearch-transport/lib/elasticsearch/transport/version.rb
@@ -1,5 +1,5 @@
 module Elasticsearch
   module Transport
-    VERSION = "1.1.pre"
+    VERSION = "1.1.0"
   end
 end

--- a/elasticsearch/elasticsearch.gemspec
+++ b/elasticsearch/elasticsearch.gemspec
@@ -20,8 +20,8 @@ Gem::Specification.new do |s|
   s.extra_rdoc_files  = [ "README.md", "LICENSE.txt" ]
   s.rdoc_options      = [ "--charset=UTF-8" ]
 
-  s.add_dependency "elasticsearch-transport", '1.1.pre'
-  s.add_dependency "elasticsearch-api",       '1.1.pre'
+  s.add_dependency "elasticsearch-transport", '1.1.0'
+  s.add_dependency "elasticsearch-api",       '1.1.0'
 
   s.add_development_dependency "bundler", "> 1"
 

--- a/elasticsearch/elasticsearch.gemspec
+++ b/elasticsearch/elasticsearch.gemspec
@@ -20,8 +20,8 @@ Gem::Specification.new do |s|
   s.extra_rdoc_files  = [ "README.md", "LICENSE.txt" ]
   s.rdoc_options      = [ "--charset=UTF-8" ]
 
-  s.add_dependency "elasticsearch-transport", '1.0.18'
-  s.add_dependency "elasticsearch-api",       '1.0.18'
+  s.add_dependency "elasticsearch-transport", '1.1.pre'
+  s.add_dependency "elasticsearch-api",       '1.1.pre'
 
   s.add_development_dependency "bundler", "> 1"
 

--- a/elasticsearch/lib/elasticsearch/version.rb
+++ b/elasticsearch/lib/elasticsearch/version.rb
@@ -1,3 +1,3 @@
 module Elasticsearch
-  VERSION = "1.0.18"
+  VERSION = "1.1.pre"
 end

--- a/elasticsearch/lib/elasticsearch/version.rb
+++ b/elasticsearch/lib/elasticsearch/version.rb
@@ -1,3 +1,3 @@
 module Elasticsearch
-  VERSION = "1.1.pre"
+  VERSION = "1.1.0"
 end


### PR DESCRIPTION
The current support for Elasticsearch APIs in the `elasticsearch-api` library is sub-optimal and non-transparent.

The master branch and `1.x` versions of the library support Elasticsearch APIs from 1.x, through 2.x, up to upcoming 5.0, effectively only "accumulating" features, without properly matching the corresponding version. While this does not present any significant problems to users, it is technically incorrect and dangerous in the longer run.

The change of the next major Elasticsearch version to `5.0`, i.e. skipping over two versions, gives us a chance to correct the situation, and have very clear, transparent compatibility matrix:

| Ruby          |   | Elasticsearch |
|:-------------:|:-:| :-----------: |
| 0.90          | → | 0.90          |
| 1.x           | → | 1.x           |
| 2.x           | → | 2.x           |
| 5.x           | → | 5.x           |
| master        | → | master        |

However, since the current `1.0.x` versions support Elasticsearch APIs from 1.0 till 5.0, this plan breaks semantic versioning, because we have to deprecate certain APIs (methods and their parameters) in a `1.1` release. While I take semantic versioning extremely seriously, I think that paying this price now and _once_ enables us to achieve a much larger goal: predictable and simple compatibility matrix.

(Technically, we could release version 2.0 to support ES 1.0, 3.0 to support ES 2.0, and 5.0 to support ES 5.0, but that would presumably look even more insane to any outsider than the current situation.)

The `1.x` branch which forms the basis of this pull request contains the necessary deprecation notices, by comparing the diff of the Elasticsearch's [REST API specification](https://github.com/elastic/elasticsearch/tree/master/rest-api-spec) between the current master (which is supported on the Rubygem's master) and the `1.x` branch.

I'll leave the pull request open for a couple of days, so we can have a discussion about the plan, and will release the `1.1` version of the Rubygem early next week, so people are aware of the plan when they upgrade the Rubygem in their applications (I have released a [`1.1.pre`](https://rubygems.org/gems/elasticsearch/versions/1.1.pre) version to Rubygems). I intend to release a `1.2` version which will _remove_ the deprecated methods and parameters a week or two after that. Hopefully the broader scope of the minor version numbers (`.0`, `.1`, `.2`) will soften the blow of breaking semantic version a little bit. I'll open another pull request with a similar change for Elasticsearch 2.0 APIs.

Any feedback about the plan is highly appreciated!