### PR TITLE
Proper compatibility matrix between Elasticsearch 2.x and Ruby gem versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.0.0
+
+* Added deprecation notices to API methods and parameters not supported on Elasticsearch 2.x
+
 ## DSL:0.1.4
 
 * Added correct implementation of `Sort#empty?`

--- a/elasticsearch-api/lib/elasticsearch/api/actions/bulk.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/bulk.rb
@@ -75,6 +75,9 @@ module Elasticsearch
           :fields,
           :pipeline ]
 
+        unsupported_params = [ :fields, :pipeline ]
+        Utils.__report_unsupported_parameters(arguments, unsupported_params)
+
         method = HTTP_POST
         path   = Utils.__pathify Utils.__escape(arguments[:index]), Utils.__escape(type), '_bulk'
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/cat/aliases.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/cat/aliases.rb
@@ -48,6 +48,9 @@ module Elasticsearch
             :help,
             :v ]
 
+          unsupported_params = [ :format ]
+          Utils.__report_unsupported_parameters(arguments.keys, unsupported_params)
+
           name = arguments.delete(:name)
 
           method = HTTP_GET

--- a/elasticsearch-api/lib/elasticsearch/api/actions/cat/allocation.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/cat/allocation.rb
@@ -50,6 +50,9 @@ module Elasticsearch
             :help,
             :v ]
 
+          unsupported_params = [ :format ]
+          Utils.__report_unsupported_parameters(arguments.keys, unsupported_params)
+
           node_id = arguments.delete(:node_id)
 
           method = HTTP_GET

--- a/elasticsearch-api/lib/elasticsearch/api/actions/cat/count.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/cat/count.rb
@@ -44,6 +44,9 @@ module Elasticsearch
             :help,
             :v ]
 
+          unsupported_params = [ :format ]
+          Utils.__report_unsupported_parameters(arguments.keys, unsupported_params)
+
           index = arguments.delete(:index)
 
           method = HTTP_GET

--- a/elasticsearch-api/lib/elasticsearch/api/actions/cat/fielddata.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/cat/fielddata.rb
@@ -34,6 +34,9 @@ module Elasticsearch
             :v,
             :fields ]
 
+          unsupported_params = [ :format ]
+          Utils.__report_unsupported_parameters(arguments.keys, unsupported_params)
+
           fields = arguments.delete(:fields)
 
           method = HTTP_GET

--- a/elasticsearch-api/lib/elasticsearch/api/actions/cat/health.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/cat/health.rb
@@ -37,6 +37,9 @@ module Elasticsearch
             :ts,
             :v ]
 
+          unsupported_params = [ :format ]
+          Utils.__report_unsupported_parameters(arguments.keys, unsupported_params)
+
           method = HTTP_GET
           path   = "_cat/health"
           params = Utils.__validate_and_extract_params arguments, valid_params

--- a/elasticsearch-api/lib/elasticsearch/api/actions/cat/indices.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/cat/indices.rb
@@ -58,6 +58,9 @@ module Elasticsearch
             :pri,
             :v ]
 
+          unsupported_params = [ :format ]
+          Utils.__report_unsupported_parameters(arguments.keys, unsupported_params)
+
           index = arguments.delete(:index)
 
           method = HTTP_GET

--- a/elasticsearch-api/lib/elasticsearch/api/actions/cat/master.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/cat/master.rb
@@ -35,6 +35,9 @@ module Elasticsearch
             :help,
             :v ]
 
+          unsupported_params = [ :format ]
+          Utils.__report_unsupported_parameters(arguments.keys, unsupported_params)
+
           method = HTTP_GET
           path   = "_cat/master"
           params = Utils.__validate_and_extract_params arguments, valid_params

--- a/elasticsearch-api/lib/elasticsearch/api/actions/cat/nodeattrs.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/cat/nodeattrs.rb
@@ -20,7 +20,11 @@ module Elasticsearch
             :h,
             :help,
             :v ]
-          method = 'GET'
+
+          unsupported_params = [ :format ]
+          Utils.__report_unsupported_parameters(arguments.keys, unsupported_params)
+
+          method = HTTP_GET
           path   = "_cat/nodeattrs"
           params = Utils.__validate_and_extract_params arguments, valid_params
           body   = nil

--- a/elasticsearch-api/lib/elasticsearch/api/actions/cat/nodes.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/cat/nodes.rb
@@ -43,6 +43,9 @@ module Elasticsearch
             :help,
             :v ]
 
+          unsupported_params = [ :format ]
+          Utils.__report_unsupported_parameters(arguments.keys, unsupported_params)
+
           method = HTTP_GET
           path   = "_cat/nodes"
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/cat/pending_tasks.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/cat/pending_tasks.rb
@@ -35,6 +35,9 @@ module Elasticsearch
             :help,
             :v ]
 
+          unsupported_params = [ :format ]
+          Utils.__report_unsupported_parameters(arguments.keys, unsupported_params)
+
           method = HTTP_GET
           path   = "_cat/pending_tasks"
           params = Utils.__validate_and_extract_params arguments, valid_params

--- a/elasticsearch-api/lib/elasticsearch/api/actions/cat/plugins.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/cat/plugins.rb
@@ -21,7 +21,11 @@ module Elasticsearch
             :h,
             :help,
             :v ]
-          method = 'GET'
+
+          unsupported_params = [ :format ]
+          Utils.__report_unsupported_parameters(arguments.keys, unsupported_params)
+
+          method = HTTP_GET
           path   = "_cat/plugins"
           params = Utils.__validate_and_extract_params arguments, valid_params
           body   = nil

--- a/elasticsearch-api/lib/elasticsearch/api/actions/cat/recovery.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/cat/recovery.rb
@@ -54,6 +54,9 @@ module Elasticsearch
             :help,
             :v ]
 
+          unsupported_params = [ :format ]
+          Utils.__report_unsupported_parameters(arguments.keys, unsupported_params)
+
           index = arguments.delete(:index)
 
           method = HTTP_GET

--- a/elasticsearch-api/lib/elasticsearch/api/actions/cat/repositories.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/cat/repositories.rb
@@ -27,6 +27,9 @@ module Elasticsearch
             :help,
             :v ]
 
+          unsupported_params = [ :format ]
+          Utils.__report_unsupported_parameters(arguments.keys, unsupported_params)
+
           method = HTTP_GET
           path   = "_cat/repositories"
           params = Utils.__validate_and_extract_params arguments, valid_params

--- a/elasticsearch-api/lib/elasticsearch/api/actions/cat/segments.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/cat/segments.rb
@@ -23,7 +23,11 @@ module Elasticsearch
             :h,
             :help,
             :v ]
-          method = 'GET'
+
+          unsupported_params = [ :format ]
+          Utils.__report_unsupported_parameters(arguments.keys, unsupported_params)
+
+          method = HTTP_GET
           path   = "_cat/segments"
           params = Utils.__validate_and_extract_params arguments, valid_params
           body   = nil

--- a/elasticsearch-api/lib/elasticsearch/api/actions/cat/shards.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/cat/shards.rb
@@ -58,6 +58,9 @@ module Elasticsearch
             :help,
             :v ]
 
+          unsupported_params = [ :format ]
+          Utils.__report_unsupported_parameters(arguments.keys, unsupported_params)
+
           index = arguments.delete(:index)
 
           method = HTTP_GET

--- a/elasticsearch-api/lib/elasticsearch/api/actions/cat/snapshots.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/cat/snapshots.rb
@@ -29,6 +29,9 @@ module Elasticsearch
             :help,
             :v ]
 
+          unsupported_params = [ :format ]
+          Utils.__report_unsupported_parameters(arguments.keys, unsupported_params)
+
           repository = arguments.delete(:repository)
 
           method = HTTP_GET

--- a/elasticsearch-api/lib/elasticsearch/api/actions/cat/tasks.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/cat/tasks.rb
@@ -18,6 +18,8 @@ module Elasticsearch
         # @see http://www.elastic.co/guide/en/elasticsearch/reference/master/tasks.html
         #
         def tasks(arguments={})
+          Utils.__report_unsupported_method(__method__)
+
           valid_params = [
             :format,
             :node_id,
@@ -28,7 +30,9 @@ module Elasticsearch
             :h,
             :help,
             :v ]
-          method = 'GET'
+
+          method = HTTP_GET
+
           path   = "_cat/tasks"
           params = Utils.__validate_and_extract_params arguments, valid_params
           body   = nil

--- a/elasticsearch-api/lib/elasticsearch/api/actions/cat/thread_pool.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/cat/thread_pool.rb
@@ -45,6 +45,9 @@ module Elasticsearch
             :help,
             :v ]
 
+          unsupported_params = [ :format, :size ]
+          Utils.__report_unsupported_parameters(arguments.keys, unsupported_params)
+
           method = HTTP_GET
           path   = "_cat/thread_pool"
           params = Utils.__validate_and_extract_params arguments, valid_params

--- a/elasticsearch-api/lib/elasticsearch/api/actions/cluster/allocation_explain.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/cluster/allocation_explain.rb
@@ -11,9 +11,11 @@ module Elasticsearch
         # @see http://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-allocation-explain.html
         #
         def allocation_explain(arguments={})
-          valid_params = [
-            :include_yes_decisions ]
-          method = 'GET'
+          Utils.__report_unsupported_method(__method__)
+
+          valid_params = [ :include_yes_decisions ]
+
+          method = HTTP_GET
           path   = "_cluster/allocation/explain"
           params = Utils.__validate_and_extract_params arguments, valid_params
           body   = arguments[:body]

--- a/elasticsearch-api/lib/elasticsearch/api/actions/cluster/get_settings.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/cluster/get_settings.rb
@@ -21,6 +21,9 @@ module Elasticsearch
             :include_defaults
           ]
 
+          unsupported_params = [ :include_defaults ]
+          Utils.__report_unsupported_parameters(arguments.keys, unsupported_params)
+
           method = HTTP_GET
           path   = "_cluster/settings"
           params = Utils.__validate_and_extract_params arguments, valid_params

--- a/elasticsearch-api/lib/elasticsearch/api/actions/cluster/reroute.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/cluster/reroute.rb
@@ -34,6 +34,9 @@ module Elasticsearch
         def reroute(arguments={})
           valid_params = [ :dry_run, :explain, :metric, :master_timeout, :retry_failed, :timeout ]
 
+          unsupported_params = [ :retry_failed ]
+          Utils.__report_unsupported_parameters(arguments.keys, unsupported_params)
+
           method = HTTP_POST
           path   = "_cluster/reroute"
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/delete_by_query.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/delete_by_query.rb
@@ -43,6 +43,8 @@ module Elasticsearch
       # @see http://www.elasticsearch.org/guide/reference/api/delete-by-query/
       #
       def delete_by_query(arguments={})
+        Utils.__report_unsupported_method(__method__)
+
         raise ArgumentError, "Required argument 'index' missing" unless arguments[:index]
 
         valid_params = [

--- a/elasticsearch-api/lib/elasticsearch/api/actions/index.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/index.rb
@@ -89,6 +89,9 @@ module Elasticsearch
           :version,
           :version_type ]
 
+        unsupported_params = [ :pipeline ]
+        Utils.__report_unsupported_parameters(arguments, unsupported_params)
+
         method = arguments[:id] ? HTTP_PUT : HTTP_POST
         path   = Utils.__pathify Utils.__escape(arguments[:index]),
                                  Utils.__escape(arguments[:type]),

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/get.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/get.rb
@@ -35,6 +35,9 @@ module Elasticsearch
             :human,
             :include_defaults ]
 
+          unsupported_params = [ :include_defaults ]
+          Utils.__report_unsupported_parameters(arguments.keys, unsupported_params)
+
           method = HTTP_GET
 
           path   = Utils.__pathify Utils.__listify(arguments[:index]), Utils.__listify(arguments.delete(:feature))

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/get_settings.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/get_settings.rb
@@ -53,6 +53,9 @@ module Elasticsearch
             :local
           ]
 
+          unsupported_params = [ :include_defaults ]
+          Utils.__report_unsupported_parameters(arguments.keys, unsupported_params)
+
           method = HTTP_GET
           path   = Utils.__pathify Utils.__listify(arguments[:index]),
                                    Utils.__listify(arguments[:type]),

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/put_settings.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/put_settings.rb
@@ -59,6 +59,9 @@ module Elasticsearch
             :flat_settings
           ]
 
+          unsupported_params = [ :preserve_existing ]
+          Utils.__report_unsupported_parameters(arguments.keys, unsupported_params)
+
           method = HTTP_PUT
           path   = Utils.__pathify Utils.__listify(arguments[:index]), '_settings'
           params = Utils.__validate_and_extract_params arguments, valid_params

--- a/elasticsearch-api/lib/elasticsearch/api/actions/ingest/delete_pipeline.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/ingest/delete_pipeline.rb
@@ -12,11 +12,15 @@ module Elasticsearch
         # @see https://www.elastic.co/guide/en/elasticsearch/plugins/master/ingest.html
         #
         def delete_pipeline(arguments={})
+          Utils.__report_unsupported_method(__method__)
+
           raise ArgumentError, "Required argument 'id' missing" unless arguments[:id]
+
           valid_params = [
             :master_timeout,
             :timeout ]
-          method = 'DELETE'
+
+          method = HTTP_DELETE
           path   = Utils.__pathify "_ingest/pipeline", Utils.__escape(arguments[:id])
           params = Utils.__validate_and_extract_params arguments, valid_params
           body   = nil

--- a/elasticsearch-api/lib/elasticsearch/api/actions/ingest/get_pipeline.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/ingest/get_pipeline.rb
@@ -11,10 +11,14 @@ module Elasticsearch
         # @see https://www.elastic.co/guide/en/elasticsearch/plugins/master/ingest.html
         #
         def get_pipeline(arguments={})
+          Utils.__report_unsupported_method(__method__)
+
           raise ArgumentError, "Required argument 'id' missing" unless arguments[:id]
+
           valid_params = [
             :master_timeout ]
-          method = 'GET'
+
+          method = HTTP_GET
           path   = Utils.__pathify "_ingest/pipeline", Utils.__escape(arguments[:id])
           params = Utils.__validate_and_extract_params arguments, valid_params
           body   = nil

--- a/elasticsearch-api/lib/elasticsearch/api/actions/ingest/put_pipeline.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/ingest/put_pipeline.rb
@@ -13,12 +13,16 @@ module Elasticsearch
         # @see https://www.elastic.co/guide/en/elasticsearch/plugins/master/ingest.html
         #
         def put_pipeline(arguments={})
+          Utils.__report_unsupported_method(__method__)
+
           raise ArgumentError, "Required argument 'id' missing" unless arguments[:id]
           raise ArgumentError, "Required argument 'body' missing" unless arguments[:body]
+
           valid_params = [
             :master_timeout,
             :timeout ]
-          method = 'PUT'
+
+          method = HTTP_PUT
           path   = Utils.__pathify "_ingest/pipeline", Utils.__escape(arguments[:id])
 
           params = Utils.__validate_and_extract_params arguments, valid_params

--- a/elasticsearch-api/lib/elasticsearch/api/actions/ingest/simulate.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/ingest/simulate.rb
@@ -13,10 +13,13 @@ module Elasticsearch
         # @see https://www.elastic.co/guide/en/elasticsearch/reference/master/simulate-pipeline-api.html
         #
         def simulate(arguments={})
+          Utils.__report_unsupported_method(__method__)
+
           raise ArgumentError, "Required argument 'body' missing" unless arguments[:body]
-          valid_params = [
-            :verbose ]
-          method = 'GET'
+
+          valid_params = [ :verbose ]
+
+          method = HTTP_GET
           path   = Utils.__pathify "_ingest/pipeline", Utils.__escape(arguments[:id]), '_simulate'
           params = Utils.__validate_and_extract_params arguments, valid_params
           body   = arguments[:body]

--- a/elasticsearch-api/lib/elasticsearch/api/actions/tasks/list.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/tasks/list.rb
@@ -31,6 +31,9 @@ module Elasticsearch
             :group_by,
             :wait_for_completion ]
 
+          unsupported_params = [ :group_by ]
+          Utils.__report_unsupported_parameters(arguments.keys, unsupported_params)
+
           task_id = arguments.delete(:task_id)
 
           method = 'GET'

--- a/elasticsearch-api/lib/elasticsearch/api/actions/update_by_query.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/update_by_query.rb
@@ -111,6 +111,9 @@ module Elasticsearch
           :wait_for_completion,
           :requests_per_second ]
 
+        unsupported_params = [ :pipeline ]
+        Utils.__report_unsupported_parameters(arguments, unsupported_params)
+
         method = HTTP_POST
 
         path   = Utils.__pathify Utils.__listify(arguments[:index]),

--- a/elasticsearch-api/lib/elasticsearch/api/version.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/version.rb
@@ -1,5 +1,5 @@
 module Elasticsearch
   module API
-    VERSION = "2.0.0.pre"
+    VERSION = "2.0.0"
   end
 end

--- a/elasticsearch-api/lib/elasticsearch/api/version.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/version.rb
@@ -1,5 +1,5 @@
 module Elasticsearch
   module API
-    VERSION = "1.0.18"
+    VERSION = "2.0.0.pre"
   end
 end

--- a/elasticsearch-api/test/integration/yaml_test_runner.rb
+++ b/elasticsearch-api/test/integration/yaml_test_runner.rb
@@ -258,7 +258,8 @@ module Elasticsearch
 
         # Skip features
         elsif skip && skip['skip']['features']
-          if (skip['skip']['features'].split(',') & SKIP_FEATURES.split(',') ).size > 0
+          skip_features = skip['skip']['features'].respond_to?(:split) ? skip['skip']['features'].split(',') : skip['skip']['features']
+          if ( skip_features & SKIP_FEATURES.split(',') ).size > 0
             return skip['skip']['features']
           end
         end

--- a/elasticsearch-transport/lib/elasticsearch/transport/version.rb
+++ b/elasticsearch-transport/lib/elasticsearch/transport/version.rb
@@ -1,5 +1,5 @@
 module Elasticsearch
   module Transport
-    VERSION = "1.0.18"
+    VERSION = "2.0.0.pre"
   end
 end

--- a/elasticsearch-transport/lib/elasticsearch/transport/version.rb
+++ b/elasticsearch-transport/lib/elasticsearch/transport/version.rb
@@ -1,5 +1,5 @@
 module Elasticsearch
   module Transport
-    VERSION = "2.0.0.pre"
+    VERSION = "2.0.0"
   end
 end

--- a/elasticsearch/elasticsearch.gemspec
+++ b/elasticsearch/elasticsearch.gemspec
@@ -20,8 +20,8 @@ Gem::Specification.new do |s|
   s.extra_rdoc_files  = [ "README.md", "LICENSE.txt" ]
   s.rdoc_options      = [ "--charset=UTF-8" ]
 
-  s.add_dependency "elasticsearch-transport", '1.0.18'
-  s.add_dependency "elasticsearch-api",       '1.0.18'
+  s.add_dependency "elasticsearch-transport", '2.0.0.pre'
+  s.add_dependency "elasticsearch-api",       '2.0.0.pre'
 
   s.add_development_dependency "bundler", "> 1"
 

--- a/elasticsearch/elasticsearch.gemspec
+++ b/elasticsearch/elasticsearch.gemspec
@@ -20,8 +20,8 @@ Gem::Specification.new do |s|
   s.extra_rdoc_files  = [ "README.md", "LICENSE.txt" ]
   s.rdoc_options      = [ "--charset=UTF-8" ]
 
-  s.add_dependency "elasticsearch-transport", '2.0.0.pre'
-  s.add_dependency "elasticsearch-api",       '2.0.0.pre'
+  s.add_dependency "elasticsearch-transport", '2.0.0'
+  s.add_dependency "elasticsearch-api",       '2.0.0'
 
   s.add_development_dependency "bundler", "> 1"
 

--- a/elasticsearch/lib/elasticsearch/version.rb
+++ b/elasticsearch/lib/elasticsearch/version.rb
@@ -1,3 +1,3 @@
 module Elasticsearch
-  VERSION = "1.0.18"
+  VERSION = "2.0.0.pre"
 end

--- a/elasticsearch/lib/elasticsearch/version.rb
+++ b/elasticsearch/lib/elasticsearch/version.rb
@@ -1,3 +1,3 @@
 module Elasticsearch
-  VERSION = "2.0.0.pre"
+  VERSION = "2.0.0"
 end


### PR DESCRIPTION
This pull request builds upon work in #322, to deprecate API methods and parameters for Elasticsearch 2.x APIs.