### PR TITLE
Using definition.to_hash in the first README search example, to make it…

### DIFF
--- a/elasticsearch-dsl/README.md
+++ b/elasticsearch-dsl/README.md
@@ -46,7 +46,7 @@ definition.to_hash
 require 'elasticsearch'
 client = Elasticsearch::Client.new trace: true
 
-client.search body: definition
+client.search body: definition.to_hash
 # curl -X GET 'http://localhost:9200/test/_search?pretty' -d '{
 #   "query":{
 #     "match":{


### PR DESCRIPTION
… run without SearchParseException.