### PR TITLE
Don't modify arguments

### DIFF
--- a/elasticsearch-extensions/lib/elasticsearch/extensions/test/cluster.rb
+++ b/elasticsearch-extensions/lib/elasticsearch/extensions/test/cluster.rb
@@ -188,7 +188,7 @@ module Elasticsearch
           # @see Cluster#start
           #
           def initialize(arguments={})
-            @arguments = arguments
+            @arguments = arguments.dup
 
             @arguments[:command]           ||= ENV.fetch('TEST_CLUSTER_COMMAND',   'elasticsearch')
             @arguments[:port]              ||= ENV.fetch('TEST_CLUSTER_PORT',      9250).to_i

--- a/elasticsearch-extensions/test/test/cluster/unit/cluster_test.rb
+++ b/elasticsearch-extensions/test/test/cluster/unit/cluster_test.rb
@@ -38,6 +38,12 @@ class Elasticsearch::Extensions::TestClusterTest < Test::Unit::TestCase
         assert_equal 9400, c.arguments[:port]
       end
 
+      should "not modify the arguments" do
+        args = { port: 9400 }.freeze
+
+        assert_nothing_raised { Cluster::Cluster.new args }
+      end
+
       should "take parameters from environment variables" do
         ENV['TEST_CLUSTER_PORT'] = '9400'
 


### PR DESCRIPTION
Because `@arguments[:foo] ||= ...` modifies `@arguments` (which is the same `arguments` hash object).

This change ensures that we're not modifying any external objects that are passed in to `Cluster.new` either directly or indirectly via `running?`, etc.