### PR TITLE
Update elasticsearch-extensions docs

### DIFF
--- a/elasticsearch-extensions/README.md
+++ b/elasticsearch-extensions/README.md
@@ -136,10 +136,10 @@ Start the cluster on specific port, with a specific Elasticsearch version, numbe
     require 'elasticsearch/extensions/test/cluster'
 
     Elasticsearch::Extensions::Test::Cluster.start \
-      cluster_name: "my-testing-cluster",
-      command:      "/usr/local/Cellar/elasticsearch/0.90.10/bin/elasticsearch",
-      port:         9350,
-      nodes:        3
+      cluster_name:    "my-testing-cluster",
+      command:         "/usr/local/Cellar/elasticsearch/0.90.10/bin/elasticsearch",
+      port:            9350,
+      number_of_nodes: 3
 
     # Starting 3 Elasticsearch nodes.....................
     # --------------------------------------------------------------------------------
@@ -171,6 +171,18 @@ You can control the cluster configuration with environment variables as well:
 
 To prevent deleting data and configurations when the cluster is started, for example in a development environment,
 use the `clear_cluster: false` option or the `TEST_CLUSTER_CLEAR=false` environment variable.
+
+To check if cluster is running:
+
+    require 'elasticsearch/extensions/test/cluster'
+
+    # Identical arguments with Elasticsearch::Extensions::Test::Cluster.start needed.
+    Elasticsearch::Extensions::Test::Cluster.running? \
+      cluster_name:    "my-testing-cluster",
+      command:         "/usr/local/Cellar/elasticsearch/0.90.10/bin/elasticsearch",
+      port:            9350,
+      number_of_nodes: 3
+
 
 [Full documentation](http://rubydoc.info/gems/elasticsearch-extensions/Elasticsearch/Extensions/Test/Cluster)
 

--- a/elasticsearch-extensions/lib/elasticsearch/extensions/test/cluster.rb
+++ b/elasticsearch-extensions/lib/elasticsearch/extensions/test/cluster.rb
@@ -171,7 +171,7 @@ module Elasticsearch
           # Create a new instance of the Cluster class
           #
           # @option arguments [String]  :cluster_name Cluster name (default: `elasticsearch_test`)
-          # @option arguments [Integer] :nodes        Number of desired nodes (default: 2)
+          # @option arguments [Integer] :number_of_nodes Number of desired nodes (default: 2)
           # @option arguments [String]  :command      Elasticsearch command (default: `elasticsearch`)
           # @option arguments [String]  :port         Starting port number; will be auto-incremented (default: 9250)
           # @option arguments [String]  :node_name    The node name (will be appended with a number)
@@ -221,7 +221,7 @@ module Elasticsearch
           # @example Start a cluster with a custom configuration
           #      Elasticsearch::Extensions::Test::Cluster::Cluster.new(
           #        cluster_name: 'my-cluster',
-          #        nodes: 3,
+          #        number_of_nodes: 3,
           #        node_name: 'my-node',
           #        port: 9350
           #      ).start


### PR DESCRIPTION
Resolve https://github.com/elastic/elasticsearch-ruby/issues/334
- Argument `:nodes` renamed to `:number_of_nodes` in `Elasticsearch::Extensions::Test::Cluster`
- Add docs for `Elasticsearch::Extensions::Test::Cluster.running?`
