### PR TITLE
lock json at 1.8.3 when RUBY_VERSION < 2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,6 +25,7 @@ if defined?(RUBY_VERSION) && RUBY_VERSION > '1.9'
   gem "require-prof" unless defined?(JRUBY_VERSION) || defined?(Rubinius)
   gem "simplecov"
   gem "simplecov-rcov"
+  gem "json", '~> 1.8.3' if RUBY_VERSION < '2'
   gem "cane"
 end
 

--- a/elasticsearch-api/elasticsearch-api.gemspec
+++ b/elasticsearch-api/elasticsearch-api.gemspec
@@ -53,7 +53,7 @@ Gem::Specification.new do |s|
   # Prevent unit test failures on Ruby 1.8
   if defined?(RUBY_VERSION) && RUBY_VERSION < '1.9'
     s.add_development_dependency "test-unit", '~> 2'
-    s.add_development_dependency "json"
+    s.add_development_dependency "json", '~> 1.8.3'
   end
 
   if defined?(RUBY_VERSION) && RUBY_VERSION > '1.9'
@@ -62,6 +62,7 @@ Gem::Specification.new do |s|
     s.add_development_dependency "escape_utils" unless defined? JRUBY_VERSION
     s.add_development_dependency "simplecov"
     s.add_development_dependency "simplecov-rcov"
+    s.add_development_dependency "json", '~> 1.8.3' if RUBY_VERSION < '2'
     s.add_development_dependency "cane"
     s.add_development_dependency "require-prof" unless defined?(JRUBY_VERSION) || defined?(Rubinius)
   end

--- a/elasticsearch-extensions/elasticsearch-extensions.gemspec
+++ b/elasticsearch-extensions/elasticsearch-extensions.gemspec
@@ -47,12 +47,13 @@ Gem::Specification.new do |s|
   s.add_development_dependency "ci_reporter", "~> 1.9"
 
   if defined?(RUBY_VERSION) && RUBY_VERSION < '1.9'
-    s.add_development_dependency "json"
+    s.add_development_dependency "json", '~> 1.8.3'
   end
 
   if defined?(RUBY_VERSION) && RUBY_VERSION > '1.9'
     s.add_development_dependency "simplecov"
     s.add_development_dependency "simplecov-rcov"
+    s.add_development_dependency "json", '~> 1.8.3' if RUBY_VERSION < '2'
     s.add_development_dependency "cane"
   end
 

--- a/elasticsearch-transport/elasticsearch-transport.gemspec
+++ b/elasticsearch-transport/elasticsearch-transport.gemspec
@@ -58,7 +58,7 @@ Gem::Specification.new do |s|
   # Prevent unit test failures on Ruby 1.8
   if defined?(RUBY_VERSION) && RUBY_VERSION < '1.9'
     s.add_development_dependency "test-unit", '~> 2'
-    s.add_development_dependency "json"
+    s.add_development_dependency "json", '~> 1.8.3'
   end
 
   if defined?(RUBY_VERSION) && RUBY_VERSION > '1.9'
@@ -67,6 +67,7 @@ Gem::Specification.new do |s|
     s.add_development_dependency "require-prof" unless defined?(JRUBY_VERSION) || defined?(Rubinius)
     s.add_development_dependency "simplecov"
     s.add_development_dependency "simplecov-rcov"
+    s.add_development_dependency "json", '~> 1.8.3' if RUBY_VERSION < '2'
     s.add_development_dependency "cane"
   end
 

--- a/elasticsearch/elasticsearch.gemspec
+++ b/elasticsearch/elasticsearch.gemspec
@@ -46,7 +46,7 @@ Gem::Specification.new do |s|
   # Prevent unit test failures on Ruby 1.8
   if defined?(RUBY_VERSION) && RUBY_VERSION < '1.9'
     s.add_development_dependency "test-unit", '~> 2'
-    s.add_development_dependency "json"
+    s.add_development_dependency "json", '~> 1.8.3'
   end
 
   if defined?(RUBY_VERSION) && RUBY_VERSION > '1.9'
@@ -55,6 +55,7 @@ Gem::Specification.new do |s|
     s.add_development_dependency "require-prof" unless defined?(JRUBY_VERSION) || defined?(Rubinius)
     s.add_development_dependency "simplecov"
     s.add_development_dependency "simplecov-rcov"
+    s.add_development_dependency "json", '~> 1.8.3' if RUBY_VERSION < '2'
     s.add_development_dependency "cane"
   end
 


### PR DESCRIPTION
The current `json` gem at `v2.0.2` requires `'ruby', ~> '2.0'`.
This PR locks `json` at version `1.8.3` when `RUBY_VERSON < '2'`.
`json` is a dependency of `simplecov`.
