### PR TITLE
Keep track of defined option methods, identify aggregations class easily.

### DIFF
--- a/elasticsearch-dsl/lib/elasticsearch/dsl/search.rb
+++ b/elasticsearch-dsl/lib/elasticsearch/dsl/search.rb
@@ -116,7 +116,7 @@ module Elasticsearch
         # @return [self]
         #
         def aggregation(*args, &block)
-          @aggregations ||= {}
+          @aggregations ||= AggregationsCollection.new
 
           if block
             @aggregations.update args.first => Aggregation.new(*args, &block)

--- a/elasticsearch-dsl/lib/elasticsearch/dsl/search/aggregation.rb
+++ b/elasticsearch-dsl/lib/elasticsearch/dsl/search/aggregation.rb
@@ -6,6 +6,12 @@ module Elasticsearch
       #
       module Aggregations;end
 
+      class AggregationsCollection < Hash
+        def to_hash
+          @hash ||= Hash[map { |k,v| [k, v.to_hash] }]
+        end
+      end
+
       # Wraps the `aggregations` part of a search definition
       #
       # @see http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/search-aggregations.html

--- a/elasticsearch-dsl/lib/elasticsearch/dsl/search/base_aggregation_component.rb
+++ b/elasticsearch-dsl/lib/elasticsearch/dsl/search/base_aggregation_component.rb
@@ -33,7 +33,7 @@ module Elasticsearch
           # @return [self]
           #
           def aggregation(*args, &block)
-            @aggregations ||= {}
+            @aggregations ||= AggregationsCollection.new
             @aggregations.update args.first => Aggregation.new(*args, &block)
             self
           end
@@ -50,8 +50,7 @@ module Elasticsearch
             @hash = { name => @args } unless @hash && @hash[name] && ! @hash[name].empty?
 
             if @aggregations
-              @hash[:aggregations] = {}
-              @aggregations.map { |name, value| @hash[:aggregations][name] = value.to_hash }
+              @hash[:aggregations] = @aggregations.to_hash
             end
             @hash
           end

--- a/elasticsearch-dsl/lib/elasticsearch/dsl/search/base_component.rb
+++ b/elasticsearch-dsl/lib/elasticsearch/dsl/search/base_component.rb
@@ -43,6 +43,7 @@ module Elasticsearch
             #       # => {:mycustomquery=>{:foo=>{:custom=>"TEST"}}}
             #
             def option_method(name, block=nil)
+              option_methods << name
               if block
                 self.__send__ :define_method, name, &block
               else
@@ -101,6 +102,10 @@ module Elasticsearch
           #
           def name=(value)
             @name = value.to_sym
+          end
+
+          def option_methods
+            @option_methods ||= []
           end
         end
 

--- a/elasticsearch-dsl/test/unit/search_base_component_test.rb
+++ b/elasticsearch-dsl/test/unit/search_base_component_test.rb
@@ -64,6 +64,16 @@ module Elasticsearch
           assert_equal({ dummy_component_with_option_method: { foo: { bar: 'BAM' } } }, subject.to_hash)
         end
 
+        should "keep track of option methods" do
+          class DummyComponentWithCustomOptionMethod
+            include Elasticsearch::DSL::Search::BaseComponent
+            option_method :foo
+          end
+
+          subject = DummyComponentWithCustomOptionMethod
+          assert_true(subject.option_methods.include?(:foo))
+        end
+
         should "have an option method without args" do
           class DummyComponentWithOptionMethod
             include Elasticsearch::DSL::Search::BaseComponent


### PR DESCRIPTION
I've been working on a "SearchMerger" - which allows you to to "merge" Elasticsearch queries intelligently.  Obviously, doing something like this requires a lot of access to the internals of the Query DSL, and these two items were causing me grief.
- Keeping track of what methods were "options" on a Query Node and what could potentially contain other query nodes.  Since some of them have the same name, this got to be pretty hairy - a straight forward solution is just to keep an ongoing list of every method defined with the `option_method` macro.
- Distinguishing a searches aggregations from various other Hashes.  Every query node has it's own class but the collection of Aggregations, which was previously just a Hash.  It's still just a Hash, but now it has it's own class, so it's easy to know when you've got one.  😄 
