### PR TITLE
Fix bad indentation and unused variables

### DIFF
--- a/elasticsearch-api/lib/elasticsearch/api/utils.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/utils.rb
@@ -235,7 +235,7 @@ module Elasticsearch
         end
 
         unless messages.empty?
-          if terminal = STDERR.tty?
+          if STDERR.tty?
             STDERR.puts messages.map { |m| "\e[31;1m#{m}\e[0m" }.join("\n")
           else
             STDERR.puts messages.join("\n")
@@ -251,11 +251,11 @@ module Elasticsearch
 
         message += ". This method is not supported in the version you're using: #{Elasticsearch::API::VERSION}, and will be removed in the next release."
 
-        if terminal = STDERR.tty?
-            STDERR.puts "\e[31;1m#{message}\e[0m"
-          else
-            STDERR.puts message
-          end
+        if STDERR.tty?
+          STDERR.puts "\e[31;1m#{message}\e[0m"
+        else
+          STDERR.puts message
+        end
       end
 
       extend self


### PR DESCRIPTION
This fixes interpreter warnings when run with the "-W" option:
- elasticsearch-api-2.0.0/lib/elasticsearch/api/utils.rb:238: warning: assigned but unused variable - terminal
- elasticsearch-api-2.0.0/lib/elasticsearch/api/utils.rb:258: warning: mismatched indentations at 'end' with 'if' at 254
- elasticsearch-api-2.0.0/lib/elasticsearch/api/utils.rb:254: warning: assigned but unused variable - terminal
