### PR TITLE
Add missing options to Bool Query

### DIFF
--- a/elasticsearch-dsl/lib/elasticsearch/dsl/search/queries/bool.rb
+++ b/elasticsearch-dsl/lib/elasticsearch/dsl/search/queries/bool.rb
@@ -36,6 +36,9 @@ module Elasticsearch
         class Bool
           include BaseComponent
 
+          option_method :minimum_should_match
+          option_method :boost
+
           def must(*args, &block)
             @hash[name][:must] ||= []
             value = Query.new(*args, &block).to_hash

--- a/elasticsearch-dsl/test/unit/queries/bool_test.rb
+++ b/elasticsearch-dsl/test/unit/queries/bool_test.rb
@@ -27,6 +27,25 @@ module Elasticsearch
             assert_equal( { bool: {must: [ {match: { foo: 'bar' }} ] } }, subject.to_hash )
           end
 
+          should "have option methods" do
+            subject = Bool.new do
+              should   { term tag: 'wow' }
+              should   { term tag: 'elasticsearch' }
+
+              minimum_should_match 1
+              boost 1.0
+            end
+
+            assert_equal( { bool:
+                            { 
+                              minimum_should_match: 1,
+                              boost: 1.0,
+                              should:     [ {term: { tag: 'wow' }}, {term: { tag: 'elasticsearch' }} ]
+                            }
+                          },
+                          subject.to_hash )            
+          end
+
           should "take a block with multiple methods" do
             subject = Bool.new do
               must     { match foo: 'bar' }


### PR DESCRIPTION
Add missing options `minimum_should_match`, `boost` to [Bool Query](https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-bool-query.html)
