### PR TITLE
Add 'rewrite' option to Elasticsearch API for validate_query

### DIFF
--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/validate_query.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/validate_query.rb
@@ -13,9 +13,12 @@ module Elasticsearch
         #
         #     client.indices.validate_query index: 'myindex', q: '[[[ BOOM! ]]]', explain: true
         #
-        # @example Validate a DSL query (with explanation)
+        # @example Validate a DSL query (with explanation and rewrite). With rewrite set to true, the 
+        #                                explanation is more detailed showing the actual Lucene query that will 
+        #                                be executed.
         #
         #     client.indices.validate_query index: 'myindex',
+        #                                   rewrite: true,
         #                                   explain: true,
         #                                   body: {
         #                                     filtered: {

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/validate_query.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/validate_query.rb
@@ -67,6 +67,7 @@ module Elasticsearch
         #
         def validate_query(arguments={})
           valid_params = [
+            :rewrite,
             :explain,
             :ignore_unavailable,
             :allow_no_indices,


### PR DESCRIPTION
With rewrite set to true, the explanation is more detailed showing the actual Lucene query that will be executed.
