### PR TITLE
Fix http method and path in delete_by_query

### DIFF
--- a/elasticsearch-api/lib/elasticsearch/api/actions/delete_by_query.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/delete_by_query.rb
@@ -60,10 +60,10 @@ module Elasticsearch
           :source,
           :timeout ]
 
-        method = HTTP_DELETE
+        method = HTTP_POST
         path   = Utils.__pathify Utils.__listify(arguments[:index]),
                                  Utils.__listify(arguments[:type]),
-                                 '/_query'
+                                 '/_delete_by_query'
 
         params = Utils.__validate_and_extract_params arguments, valid_params
         body   = arguments[:body]


### PR DESCRIPTION
https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-delete-by-query.html

delete_by_query method and path changed from elasticsearch 5.0.0