### PR TITLE
Correct name of option for number of nodes

### DIFF
--- a/elasticsearch-extensions/README.md
+++ b/elasticsearch-extensions/README.md
@@ -136,10 +136,10 @@ Start the cluster on specific port, with a specific Elasticsearch version, numbe
     require 'elasticsearch/extensions/test/cluster'
 
     Elasticsearch::Extensions::Test::Cluster.start \
-      cluster_name: "my-testing-cluster",
-      command:      "/usr/local/Cellar/elasticsearch/0.90.10/bin/elasticsearch",
-      port:         9350,
-      nodes:        3
+      cluster_name:    "my-testing-cluster",
+      command:         "/usr/local/Cellar/elasticsearch/0.90.10/bin/elasticsearch",
+      port:            9350,
+      number_of_nodes: 3
 
     # Starting 3 Elasticsearch nodes.....................
     # --------------------------------------------------------------------------------

--- a/elasticsearch-extensions/lib/elasticsearch/extensions/test/cluster.rb
+++ b/elasticsearch-extensions/lib/elasticsearch/extensions/test/cluster.rb
@@ -172,7 +172,7 @@ module Elasticsearch
           # Create a new instance of the Cluster class
           #
           # @option arguments [String]  :cluster_name Cluster name (default: `elasticsearch_test`)
-          # @option arguments [Integer] :nodes        Number of desired nodes (default: 2)
+          # @option arguments [Integer] :number_of_nodes Number of desired nodes (default: 2)
           # @option arguments [String]  :command      Elasticsearch command (default: `elasticsearch`)
           # @option arguments [String]  :port         Starting port number; will be auto-incremented (default: 9250)
           # @option arguments [String]  :node_name    The node name (will be appended with a number)
@@ -222,7 +222,7 @@ module Elasticsearch
           # @example Start a cluster with a custom configuration
           #      Elasticsearch::Extensions::Test::Cluster::Cluster.new(
           #        cluster_name: 'my-cluster',
-          #        nodes: 3,
+          #        number_of_nodes: 3,
           #        node_name: 'my-node',
           #        port: 9350
           #      ).start


### PR DESCRIPTION
Why:

* Both the readme and the class level docs refer to what I assume is the
  old name of the option to configure the number of nodes in the test
  cluster

This change addresses the need by:

* Changing the documentation to the new names