### PR TITLE
Combine multiple query filters (fixes #367)

### DIFF
--- a/elasticsearch-dsl/lib/elasticsearch/dsl/search/queries/bool.rb
+++ b/elasticsearch-dsl/lib/elasticsearch/dsl/search/queries/bool.rb
@@ -58,9 +58,9 @@ module Elasticsearch
           end
 
           def filter(*args, &block)
-            @filter ||= []
+            @hash[name][:filter] ||= []
             value = Filter.new(*args, &block).to_hash
-            @filter.push(value).flatten! unless @filter.include?(value)
+            @hash[name][:filter].push(value).flatten! unless @hash[name][:filter].include?(value)
             self
           end
 
@@ -71,11 +71,6 @@ module Elasticsearch
               call
             else
               @hash[name] = @args unless @args.nil? || @args.empty?
-            end
-
-            if @filter
-              _filter = @filter.respond_to?(:to_hash) ? @filter.to_hash : @filter
-              @hash[name].update(filter: _filter)
             end
 
             @hash

--- a/elasticsearch-dsl/lib/elasticsearch/dsl/search/queries/bool.rb
+++ b/elasticsearch-dsl/lib/elasticsearch/dsl/search/queries/bool.rb
@@ -58,7 +58,9 @@ module Elasticsearch
           end
 
           def filter(*args, &block)
-            @filter = block ? Filter.new(*args, &block) : args.first
+            @filter ||= []
+            value = Filter.new(*args, &block).to_hash
+            @filter.push(value).flatten! unless @filter.include?(value)
             self
           end
 

--- a/elasticsearch-dsl/test/unit/queries/bool_test.rb
+++ b/elasticsearch-dsl/test/unit/queries/bool_test.rb
@@ -32,12 +32,14 @@ module Elasticsearch
               must     { match foo: 'bar' }
               must_not { match moo: 'bam' }
               should   { match xoo: 'bax' }
+              filter   { term  zoo: 'baz'}
             end
 
             assert_equal( { bool:
                             { must:     [ {match: { foo: 'bar' }} ],
                               must_not: [ {match: { moo: 'bam' }} ],
-                              should:   [ {match: { xoo: 'bax' }} ]
+                              should:   [ {match: { xoo: 'bax' }} ],
+                              filter:   [ {term:  { zoo: 'baz' }}]
                             }
                           },
                           subject.to_hash )
@@ -92,13 +94,23 @@ module Elasticsearch
                           subject.to_hash )
           end
 
-          should "allow adding a filter" do
+          should "combine chained filters" do
             subject = Bool.new
-            subject.filter do
-              term foo: 'bar'
-            end
+            subject.
+              filter {
+                term foo: "bar"
+              }
+            subject.filter {
+                term zoo: "baz"
+              }
 
-            assert_equal( { bool: { filter: { term: { foo: "bar" } } } }, subject.to_hash)
+            assert_equal( { bool:
+                            { filter: [
+                              { term: { foo: "bar"}},
+                              { term: { zoo: "baz"}}
+                            ] }
+                          },
+                          subject.to_hash)
           end
 
           should "be chainable" do


### PR DESCRIPTION
Replaces PR #368 

Adjusts original fix by @tangopium so that it's more inline with how other blocks are handled and adds tests. I removed the special handling for filters in `to_hash` since it didn't seem to solve any particular issue and made it difficult to have multiple filters. Please let me know if I was mistaken.
