### PR TITLE
[extensions] Rescue failures in process cleanup when checking ES version

### DIFF
--- a/elasticsearch-extensions/lib/elasticsearch/extensions/test/cluster.rb
+++ b/elasticsearch-extensions/lib/elasticsearch/extensions/test/cluster.rb
@@ -452,7 +452,10 @@ module Elasticsearch
                 STDERR.puts "Running [#{arguments[:command]} -v] to determine version" if ENV['DEBUG']
                 output = `#{arguments[:command]} -v`
               ensure
-                Process.kill('INT', pid) if pid
+                # Most likely the process has terminated already
+                if pid
+                  Process.kill('INT', pid) rescue Errno::ESRCH
+                end
                 wout.close unless wout.closed?
                 rout.close unless rout.closed?
               end


### PR DESCRIPTION
Prevents an exception in the (common) case where es started and successfully reported the version within the timeout period.