### PR TITLE
[EXT] Fix value of pid When close connection normaly

### DIFF
--- a/elasticsearch-extensions/lib/elasticsearch/extensions/test/cluster.rb
+++ b/elasticsearch-extensions/lib/elasticsearch/extensions/test/cluster.rb
@@ -459,6 +459,7 @@ module Elasticsearch
                   wout.close unless wout.closed?
                   output = rout.read unless rout.closed?
                   rout.close unless rout.closed?
+                  pid = nil
                 end
               rescue Timeout::Error
                 # ...else, the old `-v` syntax


### PR DESCRIPTION
When try to closing connection was successful completion,  I think that it is better to set it to nil as pid disappears. If it is not set to nil, inconsistency will occur [here](https://github.com/elastic/elasticsearch-ruby/blob/master/elasticsearch-extensions/lib/elasticsearch/extensions/test/cluster.rb#L468).

Please give advise.