### PR TITLE
Travis: Switch build machine to trusty

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,8 @@
 
 sudo: false
 
+dist: trusty
+
 language: ruby
 
 cache: bundler

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,10 +29,10 @@ env:
 
 matrix:
   exclude:
-    - rvm: 2.3
+    - rvm: 2.3.3
       jdk: openjdk8
       env: TEST_SUITE=integration
-    - rvm: 2.2
+    - rvm: 2.2.6
       jdk: openjdk8
       env: TEST_SUITE=integration
 
@@ -44,7 +44,7 @@ install:
   - test $TEST_SUITE == 'integration' && curl -s https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-5.1.2.tar.gz | tar xz -C /tmp || true
 
 before_script:
-  - gem install bundler -v 1.11.2
+  - gem install bundler
   - rake setup
   - rake elasticsearch:update
   - rake bundle:clean

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,9 +16,9 @@ branches:
     - travis
 
 rvm:
-  - 2.4
-  - 2.3
-  - 2.2
+  - 2.4.0
+  - 2.3.3
+  - 2.2.6
 
 jdk:
   - openjdk8


### PR DESCRIPTION
This PR changes Travis machine from `precise` to `trusty`. This "fixes the build" (now, the build failures seem to be about more mundane, specific things).

Previously, the build was not able to pass this section:

```
$ jdk_switcher use openjdk8
Switching to OpenJDK8 (java-1.8.0-openjdk-amd64), JAVA_HOME will be set to /usr/lib/jvm/java-8-openjdk-amd64

```