### PR TITLE
Fixed elasticsearch-transport bug

### DIFF
--- a/elasticsearch-transport/lib/elasticsearch/transport/transport/base.rb
+++ b/elasticsearch-transport/lib/elasticsearch/transport/transport/base.rb
@@ -34,6 +34,7 @@ module Elasticsearch
           @hosts       = arguments[:hosts]   || []
           @options     = arguments[:options] || {}
           @options[:http] ||= {}
+          @options[:retry_on_status] ||= []
 
           @block       = block
           @connections = __build_connections


### PR DESCRIPTION
- If the options[:retry_on_status] returns a Nil:Class the
Array(options[:rety_on_status]) when instanciated raise a error.