### PR TITLE
Respect index and type parameter in search_exists

### DIFF
--- a/elasticsearch-api/lib/elasticsearch/api/actions/search_exists.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/search_exists.rb
@@ -33,6 +33,8 @@ module Elasticsearch
       # @see http://www.elastic.co/guide/en/elasticsearch/reference/master/search-exists.html
       #
       def search_exists(arguments={})
+        arguments[:index] = UNDERSCORE_ALL if ! arguments[:index] && arguments[:type]
+
         valid_params = [
           :ignore_unavailable,
           :allow_no_indices,

--- a/elasticsearch-api/lib/elasticsearch/api/actions/search_exists.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/search_exists.rb
@@ -48,7 +48,7 @@ module Elasticsearch
           :lenient,
           :lowercase_expanded_terms ]
         method = 'POST'
-        path   = "_search/exists"
+        path   = Utils.__pathify( Utils.__listify(arguments[:index]), Utils.__listify(arguments[:type]), "_search/exists" )
         params = Utils.__validate_and_extract_params arguments, valid_params
         body   = arguments[:body]
 

--- a/elasticsearch-api/test/unit/search_exists_test.rb
+++ b/elasticsearch-api/test/unit/search_exists_test.rb
@@ -19,6 +19,38 @@ module Elasticsearch
           subject.search_exists :q => 'foo'
         end
 
+        should "perform request against an index" do
+          subject.expects(:perform_request).with do |method, url, params, body|
+            assert_equal 'POST', method
+            assert_equal 'books/_search/exists', url
+            assert_nil   body
+            true
+          end.returns(FakeResponse.new)
+
+          subject.search_exists :index => 'books'
+        end
+
+        should "perform request against an index and type" do
+          subject.expects(:perform_request).with do |method, url, params, body|
+            assert_equal 'POST', method
+            assert_equal 'books/holly/_search/exists', url
+            assert_nil   body
+            true
+          end.returns(FakeResponse.new)
+
+          subject.search_exists :index => 'books', :type => 'holly'
+        end
+
+        should "perform request against default index if type given" do
+          subject.expects(:perform_request).with do |method, url, params, body|
+            assert_equal 'POST', method
+            assert_equal '_all/holly/_search/exists', url
+            assert_nil   body
+            true
+          end.returns(FakeResponse.new)
+
+          subject.search_exists :type => 'holly'
+        end
       end
 
     end


### PR DESCRIPTION
Currently there is no way to provide type or index to `search_exists`.