### PR TITLE
Let keyed option be set to false

### DIFF
--- a/elasticsearch-dsl/lib/elasticsearch/dsl/search/aggregations/range.rb
+++ b/elasticsearch-dsl/lib/elasticsearch/dsl/search/aggregations/range.rb
@@ -37,10 +37,11 @@ module Elasticsearch
           option_method :field
           option_method :script
           option_method :params
+          option_method :keyed
 
           def key(key, value)
             @hash[name].update(@args) if @args
-            @hash[name][:keyed]  ||= true
+            @hash[name][:keyed] = true unless @hash[name].has_key?(:keyed)
             @hash[name][:ranges] ||= []
             @hash[name][:ranges] << value.merge(key: key) unless @hash[name][:ranges].any? { |i| i[:key] == key }
             self

--- a/elasticsearch-dsl/test/unit/aggregations/range_test.rb
+++ b/elasticsearch-dsl/test/unit/aggregations/range_test.rb
@@ -32,6 +32,17 @@ module Elasticsearch
             assert_equal({ range: { field: "test", keyed: true, ranges: [ {to: 10, key: 'foo'}, { from: 10, to: 20, key: 'bar'}]}}, subject.to_hash)
           end
 
+          should "let you set keyed to false explicitly" do
+            subject = Range.new do
+              keyed false
+              field 'test'
+              key   'foo', to: 10
+              key   'bar', from: 10, to: 20
+            end
+
+            assert_equal({ range: { field: "test", keyed: false, ranges: [ {to: 10, key: 'foo'}, { from: 10, to: 20, key: 'bar'}]}}, subject.to_hash)
+          end
+
           should "define field in the block" do
             subject = Range.new do
               field 'test'


### PR DESCRIPTION
The way this is currently constituted it's impossible to set the `keyed` option to false and also to provide custom keys for the aggregation.

The use case for this is to have the custom keys appear in the aggregation, but still be presented as an array rather than JSON hash.