### PR TITLE
include-version-as-an-argument

### DIFF
--- a/elasticsearch-extensions/lib/elasticsearch/extensions/test/cluster.rb
+++ b/elasticsearch-extensions/lib/elasticsearch/extensions/test/cluster.rb
@@ -419,8 +419,9 @@ module Elasticsearch
 
           # Determine Elasticsearch version to be launched
           #
-          # Tries to parse the version number from the `lib/elasticsearch-X.Y.Z.jar` file,
-          # it not available, uses `elasticsearch --version` or `elasticsearch -v`
+          # Tries to get the version from the arguments passed,
+          # if not available, it parses the version number from the `lib/elasticsearch-X.Y.Z.jar` file,
+          # if that is not available, uses `elasticsearch --version` or `elasticsearch -v`
           #
           # @api private
           #
@@ -428,10 +429,9 @@ module Elasticsearch
           #
           def __determine_version
             path_to_lib = File.dirname(arguments[:command]) + '/../lib/'
-
-            jar = Dir.entries(path_to_lib).select { |f| f.start_with? 'elasticsearch' }.first if File.exist? path_to_lib
-
-            version = if jar
+            version = if arguments[:version]
+              arguments[:version]
+            elsif File.exist?(path_to_lib) && !(jar = Dir.entries(path_to_lib).select { |f| f.start_with? 'elasticsearch' }.first).nil?
               __log "Determining version from [#{jar}]" if ENV['DEBUG']
               if m = jar.match(/elasticsearch\-(\d+\.\d+\.\d+).*/)
                 m[1]

--- a/elasticsearch-extensions/test/test/cluster/unit/cluster_test.rb
+++ b/elasticsearch-extensions/test/test/cluster/unit/cluster_test.rb
@@ -271,6 +271,11 @@ class Elasticsearch::Extensions::TestClusterTest < Test::Unit::TestCase
           assert_equal '2.0', @subject.__determine_version
         end
 
+        should "return version from arguments" do
+          cluster = Elasticsearch::Extensions::Test::Cluster::Cluster.new command: '/foo/bar/bin/elasticsearch', version: '5.2'
+          assert_equal '5.0', cluster.__determine_version
+        end
+
         should "raise an exception when the version cannot be parsed from .jar" do
           # Incorrect jar version (no dots)
           File.expects(:exist?).with('/foo/bar/bin/../lib/').returns(true)


### PR DESCRIPTION
the `elasticsearch --version` command takes a while and sometimes it takes a little longer than just 10 seconds (https://github.com/elastic/elasticsearch-ruby/commit/937f6f5d20feeb7915e60539ff270c05456d51ad#diff-96217e83f071b5f3e2ed9f9601cdcbb7R434)
<img width="596" alt="screen shot 2017-02-21 at 11 07 22 am" src="https://cloud.githubusercontent.com/assets/1497438/23173078/f76a9142-f825-11e6-90ab-e3e4cbfd98c4.png">

This just gives clients the option to pass `version` ... saving time and preventing tests from possible failure because of the timeout.