### PR TITLE
Add DSL method for building the store_fields part of a search definition

### DIFF
--- a/elasticsearch-dsl/lib/elasticsearch/dsl/search.rb
+++ b/elasticsearch-dsl/lib/elasticsearch/dsl/search.rb
@@ -159,6 +159,19 @@ module Elasticsearch
           end
         end
 
+        # DSL method for building the `stored_fields` part of a search definition
+        #
+        # @return [self]
+        #
+        def stored_fields(value=nil)
+          if value
+            @stored_fields = value
+            self
+          else
+            @stored_fields
+          end
+        end; alias_method :stored_fields=, :stored_fields
+
         # DSL method for building the `size` part of a search definition
         #
         # @return [self]
@@ -229,6 +242,7 @@ module Elasticsearch
           hash.update(aggregations: @aggregations.reduce({}) { |sum,item| sum.update item.first => item.last.to_hash }) if @aggregations
           hash.update(sort: @sort.to_hash) if @sort
           hash.update(size: @size) if @size
+          hash.update(stored_fields: @stored_fields) if @stored_fields
           hash.update(from: @from) if @from
           hash.update(suggest: @suggest.reduce({}) { |sum,item| sum.update item.last.to_hash }) if @suggest
           hash.update(highlight: @highlight.to_hash) if @highlight

--- a/elasticsearch-dsl/test/unit/search_test.rb
+++ b/elasticsearch-dsl/test/unit/search_test.rb
@@ -38,6 +38,7 @@ module Elasticsearch
               search do |q|
                 q.from value
                 q.size @other_value
+                q.stored_fields ['term']
 
                 q.filter do |q|
                   q._and do |q|
@@ -51,6 +52,7 @@ module Elasticsearch
 
           assert_equal({from: 42,
                         size: 'foo',
+                        stored_fields: ['term'],
                         filter: { and: [ { term:  { thang: 'foo' } },
                                          { term:  { attributes: 42 } }]}},
           DummySearchReceiver.new.search_definition.to_hash)


### PR DESCRIPTION
This PR is to add DSL method for building the store_fields part of a search definition. The `stored_fields` parameter is about fields that are explicitly marked as stored in the mapping.

https://www.elastic.co/guide/en/elasticsearch/reference/current/search-request-stored-fields.html