### PR TITLE
Fix MRI 2.4 compatibility for 1.x

### DIFF
--- a/elasticsearch-transport/lib/elasticsearch/transport/transport/base.rb
+++ b/elasticsearch-transport/lib/elasticsearch/transport/transport/base.rb
@@ -49,9 +49,9 @@ module Elasticsearch
           @counter_mtx = Mutex.new
           @last_request_at = Time.now
           @reload_connections = options[:reload_connections]
-          @reload_after    = options[:reload_connections].is_a?(Fixnum) ? options[:reload_connections] : DEFAULT_RELOAD_AFTER
+          @reload_after    = options[:reload_connections].is_a?(0.class) ? options[:reload_connections] : DEFAULT_RELOAD_AFTER
           @resurrect_after = options[:resurrect_after] || DEFAULT_RESURRECT_AFTER
-          @max_retries     = options[:retry_on_failure].is_a?(Fixnum)   ? options[:retry_on_failure]   : DEFAULT_MAX_RETRIES
+          @max_retries     = options[:retry_on_failure].is_a?(0.class)   ? options[:retry_on_failure]   : DEFAULT_MAX_RETRIES
           @retry_on_status = Array(options[:retry_on_status]).map { |d| d.to_i }
         end
 


### PR DESCRIPTION
Updates the 1.x branch to account for running under Ruby 2.4 where
[Fixnum/Bignum have been merged](https://bugs.ruby-lang.org/issues/12739) and an integer can be of class
`Fixnum` or `Integer`.

A similar (less flexible) fix has already been applied to the 5.x and
2.x branches via #382.