### PR TITLE
Swallow fatal log when ignore is specified

### DIFF
--- a/elasticsearch-transport/lib/elasticsearch/transport/transport/base.rb
+++ b/elasticsearch-transport/lib/elasticsearch/transport/transport/base.rb
@@ -312,9 +312,9 @@ module Elasticsearch
           if response.status.to_i >= 300
             __log    method, path, params, body, url, response, nil, 'N/A', duration if logger
             __trace  method, path, params, body, url, response, nil, 'N/A', duration if tracer
-            __log_failed response if logger
 
-            # Swallow the exception when the `ignore` parameter matches response status
+            # Swallow the exception and log when the `ignore` parameter matches response status
+            __log_failed response if logger && !ignore.include?(response.status.to_i)
             __raise_transport_error response unless ignore.include?(response.status.to_i)
           end
 


### PR DESCRIPTION
The primary objective of this PR is to swallow fatal log in addition to exception, which has been supported since 6ae36e4648f0ac80ac984345e7e11f19363a5d4c.

In my humble opinion, when HTTP status code is explicitly specified with `ignore` option, receiving the status code is not fatal. For example, `[404]` fatal log invoked by checking document existence by HEAD request is not so informative nor required, I think.

After this PR is merged, hopefully, I also would like to replace `Elasticsearch::API::Utils.__rescue_from_not_found` with `ignore` option of `perform_request`, which is simpler and more efficient way with better maintainability.