### PR TITLE
In the backup extension, oj and patron are required. Move to runtime dependency.

### DIFF
--- a/elasticsearch-extensions/elasticsearch-extensions.gemspec
+++ b/elasticsearch-extensions/elasticsearch-extensions.gemspec
@@ -21,6 +21,7 @@ Gem::Specification.new do |s|
   s.add_dependency "ansi"
   s.add_dependency "elasticsearch"
   s.add_dependency "oj"
+  s.add_dependency "patron"
 
   if defined?(RUBY_VERSION) && RUBY_VERSION > '1.9'
     s.add_development_dependency "minitest", "~> 4.0"
@@ -57,7 +58,4 @@ Gem::Specification.new do |s|
   if defined?(RUBY_VERSION) && RUBY_VERSION > '2.2'
     s.add_development_dependency "test-unit", '~> 2'
   end
-
-  # Gems for testing integrations
-  s.add_development_dependency "patron"
 end

--- a/elasticsearch-extensions/elasticsearch-extensions.gemspec
+++ b/elasticsearch-extensions/elasticsearch-extensions.gemspec
@@ -20,6 +20,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency "ansi"
   s.add_dependency "elasticsearch"
+  s.add_dependency "oj"
 
   if defined?(RUBY_VERSION) && RUBY_VERSION > '1.9'
     s.add_development_dependency "minitest", "~> 4.0"
@@ -59,5 +60,4 @@ Gem::Specification.new do |s|
 
   # Gems for testing integrations
   s.add_development_dependency "patron"
-  s.add_development_dependency "oj"
 end


### PR DESCRIPTION
Per https://github.com/elastic/elasticsearch-ruby/blob/master/elasticsearch-extensions/lib/elasticsearch/extensions/backup.rb#L7