### PR TITLE
Fix for Issue 421 - InvalidURIError is raised when password has speci…

### DIFF
--- a/elasticsearch-transport/lib/elasticsearch/transport/transport/connections/connection.rb
+++ b/elasticsearch-transport/lib/elasticsearch/transport/transport/connections/connection.rb
@@ -39,7 +39,7 @@ module Elasticsearch
           #
           def full_url(path, params={})
             url  = "#{host[:protocol]}://"
-            url += "#{host[:user]}:#{host[:password]}@" if host[:user]
+            url += "#{CGI.escape(host[:user])}:#{CGI.escape(host[:password])}@" if host[:user]
             url += "#{host[:host]}:#{host[:port]}"
             url += "#{host[:path]}" if host[:path]
             url += "/#{full_path(path, params)}"

--- a/elasticsearch-transport/test/unit/connection_test.rb
+++ b/elasticsearch-transport/test/unit/connection_test.rb
@@ -30,6 +30,11 @@ class Elasticsearch::Transport::Transport::Connections::ConnectionTest < Test::U
       assert_equal 'http://U:P@localhost:9200/_search?foo=bar', c.full_url('_search', {:foo => 'bar'})
     end
 
+    should "return full url with credentials - escape spl chars" do
+      c = Connection.new :host => { :protocol => 'http', :user => 'U', :password => 'P`assword', :host => 'localhost', :port => '9200' }
+      assert_equal 'http://U:P%60assword@localhost:9200/_search?foo=bar', c.full_url('_search', {:foo => 'bar'})
+    end
+
     should "return full url with path" do
       c = Connection.new :host => { :protocol => 'http', :host => 'localhost', :port => '9200', :path => '/foo' }
       assert_equal 'http://localhost:9200/foo/_search?foo=bar', c.full_url('_search', {:foo => 'bar'})


### PR DESCRIPTION
…al characters

When password has special characters that are not supported in the URL, then InvalidURIError is raised. Fixed the full_url method in Connection.rb to URL encode the password and username. Also added a unit test for the same