### PR TITLE
Replaced most if not all instances of 'nodes' with 'number_of_nodes'

### DIFF
--- a/elasticsearch-dsl/test/integration/search_aggregation_children_test.rb
+++ b/elasticsearch-dsl/test/integration/search_aggregation_children_test.rb
@@ -7,7 +7,7 @@ module Elasticsearch
 
       context "A children aggregation" do
         startup do
-          Elasticsearch::Extensions::Test::Cluster.start(nodes: 1) if ENV['SERVER'] and not Elasticsearch::Extensions::Test::Cluster.running?
+          Elasticsearch::Extensions::Test::Cluster.start(number_of_nodes: 1) if ENV['SERVER'] and not Elasticsearch::Extensions::Test::Cluster.running?(number_of_nodes: 1)
         end
 
         setup do

--- a/elasticsearch-dsl/test/integration/search_aggregation_geo_test.rb
+++ b/elasticsearch-dsl/test/integration/search_aggregation_geo_test.rb
@@ -7,7 +7,7 @@ module Elasticsearch
 
       context "A geo aggregation" do
         startup do
-          Elasticsearch::Extensions::Test::Cluster.start(nodes: 1) if ENV['SERVER'] and not Elasticsearch::Extensions::Test::Cluster.running?
+          Elasticsearch::Extensions::Test::Cluster.start(number_of_nodes: 1) if ENV['SERVER'] and not Elasticsearch::Extensions::Test::Cluster.running?(number_of_nodes: 1)
         end
 
         setup do

--- a/elasticsearch-dsl/test/integration/search_aggregation_nested_test.rb
+++ b/elasticsearch-dsl/test/integration/search_aggregation_nested_test.rb
@@ -7,7 +7,7 @@ module Elasticsearch
 
       context "A nested aggregation" do
         startup do
-          Elasticsearch::Extensions::Test::Cluster.start(nodes: 1) if ENV['SERVER'] and not Elasticsearch::Extensions::Test::Cluster.running?
+          Elasticsearch::Extensions::Test::Cluster.start(number_of_nodes: 1) if ENV['SERVER'] and not Elasticsearch::Extensions::Test::Cluster.running?(number_of_nodes: 1)
         end
 
         setup do

--- a/elasticsearch-dsl/test/integration/search_filters_test.rb
+++ b/elasticsearch-dsl/test/integration/search_filters_test.rb
@@ -9,7 +9,7 @@ module Elasticsearch
 
       context "Filters integration" do
         startup do
-          Elasticsearch::Extensions::Test::Cluster.start(nodes: 1) if ENV['SERVER'] and not Elasticsearch::Extensions::Test::Cluster.running?
+          Elasticsearch::Extensions::Test::Cluster.start(number_of_nodes: 1) if ENV['SERVER'] and not Elasticsearch::Extensions::Test::Cluster.running?(number_of_nodes: 1)
         end
 
         setup do

--- a/elasticsearch-dsl/test/integration/search_query_test.rb
+++ b/elasticsearch-dsl/test/integration/search_query_test.rb
@@ -7,7 +7,7 @@ module Elasticsearch
 
       context "Queries integration" do
         startup do
-          Elasticsearch::Extensions::Test::Cluster.start(nodes: 1) if ENV['SERVER'] and not Elasticsearch::Extensions::Test::Cluster.running?
+          Elasticsearch::Extensions::Test::Cluster.start(number_of_nodes: 1) if ENV['SERVER'] and not Elasticsearch::Extensions::Test::Cluster.running?(number_of_nodes: 1)
         end
 
         setup do

--- a/elasticsearch-dsl/test/integration/search_sort_test.rb
+++ b/elasticsearch-dsl/test/integration/search_sort_test.rb
@@ -7,7 +7,7 @@ module Elasticsearch
 
       context "Sorting integration" do
         startup do
-          Elasticsearch::Extensions::Test::Cluster.start(nodes: 1) if ENV['SERVER'] and not Elasticsearch::Extensions::Test::Cluster.running?
+          Elasticsearch::Extensions::Test::Cluster.start(number_of_nodes: 1) if ENV['SERVER'] and not Elasticsearch::Extensions::Test::Cluster.running?(number_of_nodes: 1)
         end
 
         setup do

--- a/elasticsearch-dsl/test/integration/search_suggest_test.rb
+++ b/elasticsearch-dsl/test/integration/search_suggest_test.rb
@@ -9,7 +9,7 @@ module Elasticsearch
 
       context "Suggest integration" do
         startup do
-          Elasticsearch::Extensions::Test::Cluster.start(nodes: 1) if ENV['SERVER'] and not Elasticsearch::Extensions::Test::Cluster.running?
+          Elasticsearch::Extensions::Test::Cluster.start(number_of_nodes: 1) if ENV['SERVER'] and not Elasticsearch::Extensions::Test::Cluster.running?(number_of_nodes: 1)
         end
 
         setup do

--- a/elasticsearch-dsl/test/integration/search_test.rb
+++ b/elasticsearch-dsl/test/integration/search_test.rb
@@ -34,7 +34,7 @@ module Elasticsearch
 
       context "The Search class" do
         startup do
-          Elasticsearch::Extensions::Test::Cluster.start(nodes: 1) if ENV['SERVER'] and not Elasticsearch::Extensions::Test::Cluster.running?
+          Elasticsearch::Extensions::Test::Cluster.start(number_of_nodes: 1) if ENV['SERVER'] and not Elasticsearch::Extensions::Test::Cluster.running?(number_of_nodes: 1)
         end
 
         setup do

--- a/elasticsearch-dsl/test/test_helper.rb
+++ b/elasticsearch-dsl/test/test_helper.rb
@@ -46,8 +46,8 @@ module Elasticsearch
       extend  StartupShutdown
 
       startup do
-        Cluster.start(nodes: 1) if ENV['SERVER'] \
-                                && ! Elasticsearch::Extensions::Test::Cluster.running?
+        Cluster.start(number_of_nodes: 1) if ENV['SERVER'] \
+                                && ! Elasticsearch::Extensions::Test::Cluster.running?(number_of_nodes: 1)
       end
 
       shutdown do

--- a/elasticsearch-extensions/test/test_helper.rb
+++ b/elasticsearch-extensions/test/test_helper.rb
@@ -42,11 +42,11 @@ module Elasticsearch
       extend  StartupShutdown
 
       startup do
-        Elasticsearch::Extensions::Test::Cluster.start(nodes: 2) if ENV['SERVER'] and not Elasticsearch::Extensions::Test::Cluster.running?
+        Elasticsearch::Extensions::Test::Cluster.start(number_of_nodes: 2) if ENV['SERVER'] and not Elasticsearch::Extensions::Test::Cluster.running?(number_of_nodes: 2)
       end
 
       shutdown do
-        Elasticsearch::Extensions::Test::Cluster.stop if ENV['SERVER'] and Elasticsearch::Extensions::Test::Cluster.running?
+        Elasticsearch::Extensions::Test::Cluster.stop(number_of_nodes: 2) if ENV['SERVER'] and Elasticsearch::Extensions::Test::Cluster.running?(number_of_nodes: 2)
       end
     end
   end

--- a/elasticsearch-transport/test/integration/client_test.rb
+++ b/elasticsearch-transport/test/integration/client_test.rb
@@ -2,11 +2,11 @@ require 'test_helper'
 
 class Elasticsearch::Transport::ClientIntegrationTest < Elasticsearch::Test::IntegrationTestCase
   startup do
-    Elasticsearch::Extensions::Test::Cluster.start(nodes: 2) if ENV['SERVER'] and not Elasticsearch::Extensions::Test::Cluster.running?
+    Elasticsearch::Extensions::Test::Cluster.start(number_of_nodes: 2) if ENV['SERVER'] and not Elasticsearch::Extensions::Test::Cluster.running?(number_of_nodes: 2)
   end
 
   shutdown do
-    Elasticsearch::Extensions::Test::Cluster.stop if ENV['SERVER'] and Elasticsearch::Extensions::Test::Cluster.running?
+    Elasticsearch::Extensions::Test::Cluster.stop(number_of_nodes: 2) if ENV['SERVER'] and Elasticsearch::Extensions::Test::Cluster.running?(number_of_nodes: 2)
   end
 
   context "Elasticsearch client" do

--- a/elasticsearch-transport/test/integration/transport_test.rb
+++ b/elasticsearch-transport/test/integration/transport_test.rb
@@ -2,11 +2,11 @@ require 'test_helper'
 
 class Elasticsearch::Transport::ClientIntegrationTest < Elasticsearch::Test::IntegrationTestCase
   startup do
-    Elasticsearch::Extensions::Test::Cluster.start(nodes: 2) if ENV['SERVER'] and not Elasticsearch::Extensions::Test::Cluster.running?
+    Elasticsearch::Extensions::Test::Cluster.start(number_of_nodes: 2) if ENV['SERVER'] and not Elasticsearch::Extensions::Test::Cluster.running?(number_of_nodes: 2)
   end
 
   shutdown do
-    Elasticsearch::Extensions::Test::Cluster.stop if ENV['SERVER'] and Elasticsearch::Extensions::Test::Cluster.running?
+    Elasticsearch::Extensions::Test::Cluster.stop(number_of_nodes: 2) if ENV['SERVER'] and Elasticsearch::Extensions::Test::Cluster.running?(number_of_nodes: 2)
   end
 
   context "Transport" do

--- a/elasticsearch-watcher/test/test_helper.rb
+++ b/elasticsearch-watcher/test/test_helper.rb
@@ -27,8 +27,8 @@ module Elasticsearch
       extend  StartupShutdown
 
       startup do
-        Cluster.start(nodes: 1) if ENV['SERVER'] \
-                                && ! Elasticsearch::Extensions::Test::Cluster.running?
+        Cluster.start(number_of_nodes: 1) if ENV['SERVER'] \
+                                && ! Elasticsearch::Extensions::Test::Cluster.running?(number_of_nodes: 1)
       end
 
       shutdown do

--- a/elasticsearch/test/integration/client_integration_test.rb
+++ b/elasticsearch/test/integration/client_integration_test.rb
@@ -5,11 +5,11 @@ module Elasticsearch
   module Test
     class ClientIntegrationTest < Elasticsearch::Test::IntegrationTestCase
       startup do
-        Elasticsearch::Extensions::Test::Cluster.start(nodes: 2) if ENV['SERVER'] and not Elasticsearch::Extensions::Test::Cluster.running?
+        Elasticsearch::Extensions::Test::Cluster.start(number_of_nodes: 2) if ENV['SERVER'] and not Elasticsearch::Extensions::Test::Cluster.running?(number_of_nodes: 2)
       end
 
       shutdown do
-        Elasticsearch::Extensions::Test::Cluster.stop if ENV['SERVER'] and Elasticsearch::Extensions::Test::Cluster.running?
+        Elasticsearch::Extensions::Test::Cluster.stop(number_of_nodes: 2) if ENV['SERVER'] and Elasticsearch::Extensions::Test::Cluster.running?(number_of_nodes: 2)
       end
 
       context "Elasticsearch client" do


### PR DESCRIPTION
I believe two major issues exist in the current gem:

1. The ```nodes``` argument is being improperly used when loading clusters, rather than ```number_of_nodes```
2. ```running?``` needs to match parameters from what was initialized to return a truthy value.

For 1, let's take a quick look at the initialize method:

```ruby
def initialize(arguments={})
  @arguments = arguments.dup

  @arguments[:command]           ||= ENV.fetch('TEST_CLUSTER_COMMAND',   'elasticsearch')
  @arguments[:port]              ||= ENV.fetch('TEST_CLUSTER_PORT',      9250).to_i
  @arguments[:cluster_name]      ||= ENV.fetch('TEST_CLUSTER_NAME',      __default_cluster_name).chomp
  @arguments[:node_name]         ||= ENV.fetch('TEST_CLUSTER_NODE_NAME', 'node')
  @arguments[:path_data]         ||= ENV.fetch('TEST_CLUSTER_DATA',      '/tmp/elasticsearch_test')
  @arguments[:path_work]         ||= ENV.fetch('TEST_CLUSTER_TMP',       '/tmp')
  @arguments[:path_logs]         ||= ENV.fetch('TEST_CLUSTER_LOGS',      '/tmp/log/elasticsearch')
  @arguments[:es_params]         ||= ENV.fetch('TEST_CLUSTER_PARAMS',    '')
  @arguments[:multicast_enabled] ||= ENV.fetch('TEST_CLUSTER_MULTICAST', 'true')
  @arguments[:timeout]           ||= ENV.fetch('TEST_CLUSTER_TIMEOUT',   60).to_i
  @arguments[:timeout_version]   ||= ENV.fetch('TEST_CLUSTER_TIMEOUT_VERSION', 15).to_i
  @arguments[:number_of_nodes]   ||= ENV.fetch('TEST_CLUSTER_NODES',     2).to_i
  @arguments[:network_host]      ||= ENV.fetch('TEST_CLUSTER_NETWORK_HOST', __default_network_host)
  @arguments[:quiet]             ||= ! ENV.fetch('QUIET', '').empty?

  @clear_cluster = !!@arguments[:clear_cluster] || (ENV.fetch('TEST_CLUSTER_CLEAR', 'true') != 'false')

  # Make sure `cluster_name` is not dangerous
  raise ArgumentError, "The `cluster_name` argument cannot be empty string or a slash" \
    if @arguments[:cluster_name] =~ /^[\/\\]?$/
end
```

The initialize method is called when ```Cluster.new``` is called, which is in turn called in methods ```start```, ```stop```, ```running?```, ```wait_for_green```, among others. So whenever any of these methods get passed  arguments, it in turn passes those same arguments to the initialize method. But looking above, we can see that initialize doesn't handle any sort of ```arguments[:nodes]```, which I think was a relic of the arguments of previous generations of the gem.

For 2, let's take a quick look at the two  ```running?``` methods:

```ruby
def running?(arguments={})
  Cluster.new(arguments).running?
end
```

So again, this will call the initializer, and then run the other ```running?``` method:

```ruby
def running?
  if cluster_health = Timeout::timeout(0.25) { __get_cluster_health } rescue nil
    return cluster_health['cluster_name']    == arguments[:cluster_name] && \
           cluster_health['number_of_nodes'] == arguments[:number_of_nodes]
  end
  return false
end
```

Now lets take the following code
```ruby
Elasticsearch::Extensions::Test::Cluster.start(nodes: 1) if ENV['SERVER'] and not Elasticsearch::Extensions::Test::Cluster.running?
```
For one, as explained above, this wouldn't start a cluster with 1 node -- since ```arguments[:nodes]``` is not a thing, it defaults to the user's ```TEST_CLUSTER_NODES``` ENV variable, or 2. 

But this actually silently makes this code work -- when no parameters are given to the ```running?``` method, it will use the default arguments as well, which again is 2 nodes.

When we fix this however, by changing it to the right code:

```ruby
Elasticsearch::Extensions::Test::Cluster.start(number_of_nodes: 1) if ENV['SERVER'] and not Elasticsearch::Extensions::Test::Cluster.running?
```

This makes the code fail, because when no parameters are passed to the ```running?``` method, when it calls the ```Cluster.new``` method it will again default without a ```number_of_nodes``` argument to 2,  and then when it does the check in the other ```running?``` method, it will be:

```ruby
return cluster_health['cluster_name']    == arguments[:cluster_name] && \
           cluster_health['number_of_nodes'] == arguments[:number_of_nodes]
```

```cluster_health['number_of_nodes']``` will be 1, because we initialized it properly when we started it, but ```arguments[:number_of_nodes]``` will be 2, because we didn't pass in an argument there and so it set it to the default.

So in general, anytime we call the ```running?``` method, we need to make sure we pass it the same arguments we pass the ```start``` method, or it won't return the correct results I believe.

Hope that makes sense, let me know what people's thoughts are.