### PR TITLE
[TRANSPORT] Don't block waiting for body on HEAD requests

### DIFF
--- a/elasticsearch-transport/lib/elasticsearch/transport/transport/http/curb.rb
+++ b/elasticsearch-transport/lib/elasticsearch/transport/transport/http/curb.rb
@@ -21,7 +21,10 @@ module Elasticsearch
 
               case method
                 when 'HEAD'
+                  connection.connection.set :nobody, true
                 when 'GET', 'POST', 'PUT', 'DELETE'
+                  connection.connection.set :nobody, false
+
                   connection.connection.put_data = __convert_to_json(body) if body
                 else raise ArgumentError, "Unsupported HTTP method: #{method}"
               end


### PR DESCRIPTION
Since "Add correct Content-Length on HEAD requests"
(elastic/elasticsearch#21123), Elasticsearch correctly returns a non
zero Content-Length header. Unfortunately that uncovered a bug in the
Curb transport driver.

HEAD responses are special, they return a non zero Content-Length header
but send no body at all. libcurl by default expects to read
`Content-Length` bytes which are never sent. This causes libcurl to
block until the timeout is reached.

Since we use the low-level `http()` curb interface we have to explicitly
set `CURLOPT_NOBODY` before the request.