### PR TITLE
fix scroll call

### DIFF
--- a/elasticsearch-api/lib/elasticsearch/api/actions/scroll.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/scroll.rb
@@ -57,6 +57,7 @@ module Elasticsearch
 
         params = Utils.__validate_and_extract_params arguments, valid_params
         body   = arguments[:body]
+        body[:scroll_id] = params[:scroll_id]
 
         perform_request(method, path, params, body).body
       end

--- a/elasticsearch-api/test/unit/scroll_test.rb
+++ b/elasticsearch-api/test/unit/scroll_test.rb
@@ -12,7 +12,7 @@ module Elasticsearch
             assert_equal 'GET', method
             assert_equal '_search/scroll', url
             assert_equal 'cXVlcn...', params[:scroll_id]
-            assert_equal nil, body
+            assert_equal { scroll_id: 'cXVlcn...' }, body
             true
           end.returns(FakeResponse.new)
 


### PR DESCRIPTION
Previously the scroll api would fail when the scroll_id was too long.
The work around previously was to include scroll_id in the body, to
solve this we include the scroll_id in the body explicitly.

Resolves https://github.com/elastic/elasticsearch-ruby/issues/423