### PR TITLE
[API] Added terminate_after parameter to Count action

### DIFF
--- a/elasticsearch-api/lib/elasticsearch/api/actions/count.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/count.rb
@@ -42,7 +42,10 @@ module Elasticsearch
       #                                      to a numeric field) should be ignored
       # @option arguments [Boolean] :lowercase_expanded_terms Specify whether query terms should be lowercased
       #
-      # @see http://elasticsearch.org/guide/reference/api/count/
+      # @option arguments [Boolean] :terminate_after Specify the maximum count for each shard, upon reaching
+      #                                      which the query execution will terminate early.
+      #
+      # @see https://www.elastic.co/guide/en/elasticsearch/reference/current/search-count.html
       #
       def count(arguments={})
         valid_params = [
@@ -58,7 +61,8 @@ module Elasticsearch
           :default_operator,
           :df,
           :lenient,
-          :lowercase_expanded_terms ]
+          :lowercase_expanded_terms,
+          :terminate_after ]
 
         method = HTTP_GET
         path   = Utils.__pathify( Utils.__listify(arguments[:index]), Utils.__listify(arguments[:type]), '_count' )


### PR DESCRIPTION
Add [`terminate_after`](https://www.elastic.co/guide/en/elasticsearch/reference/current/search-count.html#_request_parameters) parameter to the Count action to be able to specify the maximum count for each shard, upon reaching which the query execution will terminate early.

Also update the link to Elasic Count API guide.