### PR TITLE
[CLIENT] Add response info to ServerError exceptions

### DIFF
--- a/elasticsearch-transport/lib/elasticsearch/transport/transport/base.rb
+++ b/elasticsearch-transport/lib/elasticsearch/transport/transport/base.rb
@@ -202,7 +202,7 @@ module Elasticsearch
         #
         def __raise_transport_error(response)
           error = ERRORS[response.status] || ServerError
-          raise error.new "[#{response.status}] #{response.body}"
+          raise error.new "[#{response.status}] #{response.body}", response
         end
 
         # Converts any non-String object to JSON

--- a/elasticsearch-transport/lib/elasticsearch/transport/transport/errors.rb
+++ b/elasticsearch-transport/lib/elasticsearch/transport/transport/errors.rb
@@ -12,7 +12,14 @@ module Elasticsearch
 
       # Elasticsearch server error (HTTP status 5xx)
       #
-      class ServerError < Error; end
+      class ServerError < Error
+        attr_reader :response
+
+        def initialize(message=nil, response=nil)
+          super(message)
+          @response = response
+        end
+      end
 
       module Errors; end
 


### PR DESCRIPTION
Currently if a ServerError or any of its descendants are raised, the response body is included as part of the exception's message string. For example:

    > client.indices.delete(index: 'wat')
    Elasticsearch::Transport::Transport::Errors::NotFound: [404] {"error":
    {"root_cause":[{"type":"index_not_found_exception",
    "reason":"no such index","resource.type":"index_or_alias",
    "resource.id":"wat","index_uuid":"_na_","index":"wat"}],
    "type":"index_not_found_exception","reason":"no such index",
    "resource.type":"index_or_alias","resource.id":"wat",
    "index_uuid":"_na_","index":"wat"},"status":404}

In this case, a user may want to ignore the exception since the non-existence of the index is exactly their intention. However, it's hard for them to directly access the reason for the error, as the JSON response is just part of an unformatted string.

To make the underlying response date easier to access, this change adds an optional `response` parameter to the ServerError family of exceptions, allowing third-party code to more fully inspect the issue, and respond appropriately.

### Feedback

Any feedback would be very welcome, but specific questions I have are:

* I've not added a new test or altered any existing ones. I believe the [existing assertions](https://github.com/futurelearn/elasticsearch-ruby/blob/cf18a24437924e6dcb3a8069485af6056ae2f404/elasticsearch-transport/test/unit/transport_base_test.rb#L252-L256) around raising errors ensure I've not broken anything, and I'm not sure it's worth making a more brittle assertion that insists on the inclusion of the response. Does this seem reasonable?
* I've included the whole response object verbatim, leaving it up to the client to handle it (parse the body, inspect the status etc.). This seemed preferable to anticipating client needs and complicating the handling in this gem. Again, does this seem okay?

Thanks very much for looking at this - if there are any changes you'd like to see, just let me know.

Simon

----

Edit: as far as I can see the build failure appears to be a transient issue in the integration suite where the cluster failed to come up properly. If someone with the appropriate permissions wouldn't mind restarting the build that'd be much appreciated. :)