### PR TITLE
Update stats.rb

### DIFF
--- a/elasticsearch-api/lib/elasticsearch/api/actions/nodes/stats.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/nodes/stats.rb
@@ -48,7 +48,7 @@ module Elasticsearch
           valid_params = [
             :metric,
             :index_metric,
-            :node_id,
+            :nodeId,
             :completion_fields,
             :fielddata_fields,
             :fields,


### PR DESCRIPTION
original node_id can't used in elasticsearch 5.0, nodeId is suggested.