### PR TITLE
Speed up Utils.__listify and Utils.__pathify

### DIFF
--- a/elasticsearch-api/lib/elasticsearch/api/utils.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/utils.rb
@@ -35,11 +35,12 @@ module Elasticsearch
       def __listify(*list)
         options = list.last.is_a?(Hash) ? list.pop : {}
 
-        Array(list).flatten.
-          map { |e| e.respond_to?(:split) ? e.split(',') : e }.
+        escape = options[:escape]
+        Array(list).
+          flat_map { |e| e.respond_to?(:split) ? e.split(',') : e }.
           flatten.
           compact.
-          map { |e| options[:escape] == false ? e : __escape(e) }.
+          map { |e| escape == false ? e : __escape(e) }.
           join(',')
       end
 

--- a/elasticsearch-api/lib/elasticsearch/api/utils.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/utils.rb
@@ -59,7 +59,7 @@ module Elasticsearch
       def __pathify(*segments)
         Array(segments).flatten.
           compact.
-          reject { |s| s.to_s =~ /^\s*$/ }.
+          reject { |s| s.squeeze(' ').size == 0 }.
           join('/').
           squeeze('/')
       end


### PR DESCRIPTION
 ##### Speed up `Elasticsearch::API::Utils.__listify`

Change `.map{ ... }.flatten` to `.flat_map` and
fetch escape option only once

```
    Calculating -------------------------------------
               __listify     67.427k (± 7.1%) i/s -      2.014M in  30.028225s
           __listify_new     78.107k (± 3.2%) i/s -      2.345M in  30.057810s

    Comparison:
           __listify_new:    78106.7 i/s
               __listify:    67426.5 i/s - 1.16x  slower

```


##### Speed up `Elasticsearch::API::Utils.__pathify`

Use String#squeeze instead of a Regexp to check for blank strings

```
    Calculating -------------------------------------
               __pathify    241.514k (± 4.4%) i/s -      7.246M in  30.067229s
           __pathify_new    277.492k (± 3.9%) i/s -      8.323M in  30.043878s

    Comparison:
           __pathify_new:   277492.5 i/s
               __pathify:   241514.4 i/s - 1.15x  slower
```

[Benchmark script](https://gist.github.com/jamescook/14d8f9c19fa731a73bd26af5e61f46f5)
