### PR TITLE
[DSL] Add MatchPhrase and MatchPhrasePrefix Queries

### DIFF
--- a/elasticsearch-dsl/lib/elasticsearch/dsl/search/queries/match.rb
+++ b/elasticsearch-dsl/lib/elasticsearch/dsl/search/queries/match.rb
@@ -24,7 +24,6 @@ module Elasticsearch
 
           option_method :query
           option_method :operator
-          option_method :type
           option_method :boost
           option_method :fuzziness
           option_method :max_expansions

--- a/elasticsearch-dsl/lib/elasticsearch/dsl/search/queries/match.rb
+++ b/elasticsearch-dsl/lib/elasticsearch/dsl/search/queries/match.rb
@@ -27,6 +27,7 @@ module Elasticsearch
           option_method :type
           option_method :boost
           option_method :fuzziness
+          option_method :max_expansions
         end
 
       end

--- a/elasticsearch-dsl/lib/elasticsearch/dsl/search/queries/match_phrase.rb
+++ b/elasticsearch-dsl/lib/elasticsearch/dsl/search/queries/match_phrase.rb
@@ -24,7 +24,7 @@ module Elasticsearch
           option_method :query
           option_method :analyzer
           option_method :boost
-          option_method :max_expansions
+          option_method :slop
         end
 
       end

--- a/elasticsearch-dsl/lib/elasticsearch/dsl/search/queries/match_phrase.rb
+++ b/elasticsearch-dsl/lib/elasticsearch/dsl/search/queries/match_phrase.rb
@@ -3,7 +3,7 @@ module Elasticsearch
     module Search
       module Queries
 
-        # A query which matches all documents
+        # A query that analyzes the text and creates a phrase query out of the analyzed text
         #
         # @example
         #

--- a/elasticsearch-dsl/lib/elasticsearch/dsl/search/queries/match_phrase.rb
+++ b/elasticsearch-dsl/lib/elasticsearch/dsl/search/queries/match_phrase.rb
@@ -24,6 +24,7 @@ module Elasticsearch
           option_method :query
           option_method :analyzer
           option_method :boost
+          option_method :max_expansions
         end
 
       end

--- a/elasticsearch-dsl/lib/elasticsearch/dsl/search/queries/match_phrase.rb
+++ b/elasticsearch-dsl/lib/elasticsearch/dsl/search/queries/match_phrase.rb
@@ -1,0 +1,32 @@
+
+module Elasticsearch
+  module DSL
+    module Search
+      module Queries
+
+        # A query which matches all documents
+        #
+        # @example
+        #
+        #     search do
+        #       query do
+        #         match_phrase :content do
+        #           query 'example content'
+        #         end
+        #       end
+        #     end
+        #
+        # @see https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-match-query-phrase.html
+        #
+        class MatchPhrase
+          include BaseComponent
+
+          option_method :query
+          option_method :analyzer
+          option_method :boost
+        end
+
+      end
+    end
+  end
+end

--- a/elasticsearch-dsl/lib/elasticsearch/dsl/search/queries/match_phrase_prefix.rb
+++ b/elasticsearch-dsl/lib/elasticsearch/dsl/search/queries/match_phrase_prefix.rb
@@ -3,7 +3,7 @@ module Elasticsearch
     module Search
       module Queries
 
-        # A query which matches all documents
+        # The same as match_phrase, except that it allows for prefix matches on the last term in the text
         #
         # @example
         #

--- a/elasticsearch-dsl/lib/elasticsearch/dsl/search/queries/match_phrase_prefix.rb
+++ b/elasticsearch-dsl/lib/elasticsearch/dsl/search/queries/match_phrase_prefix.rb
@@ -9,21 +9,21 @@ module Elasticsearch
         #
         #     search do
         #       query do
-        #         match_phrase :content do
+        #         match_phrase_prefix :content do
         #           query 'example content'
-        #           analyzer 'standard'
+        #           max_expansions 10
         #         end
         #       end
         #     end
         #
-        # @see https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-match-query-phrase.html
+        # @see https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-match-query-phrase-prefix.html
         #
-        class MatchPhrase
+        class MatchPhrasePrefix
           include BaseComponent
 
           option_method :query
-          option_method :analyzer
           option_method :boost
+          option_method :max_expansions
         end
 
       end

--- a/elasticsearch-dsl/test/unit/queries/match_phrase_prefix_test.rb
+++ b/elasticsearch-dsl/test/unit/queries/match_phrase_prefix_test.rb
@@ -1,0 +1,62 @@
+require 'test_helper'
+
+module Elasticsearch
+  module Test
+    module Queries
+      class MatchPhrasePrefixTest < ::Test::Unit::TestCase
+        include Elasticsearch::DSL::Search::Queries
+
+        context "Match Phrase Prefix Query" do
+          subject { MatchPhrasePrefix.new }
+
+          should "be converted to a Hash" do
+            assert_equal({ match_phrase_prefix: {} }, subject.to_hash)
+          end
+
+          should "take a concrete value" do
+            subject = MatchPhrasePrefix.new message: 'test'
+
+            assert_equal({match_phrase_prefix: {message: "test"}}, subject.to_hash)
+          end
+
+          should "have option methods" do
+            subject = MatchPhrasePrefix.new
+
+            subject.query    'bar'
+            subject.boost    10
+            subject.max_expansions     1
+
+            assert_equal %w[ boost max_expansions query ],
+                         subject.to_hash[:match_phrase_prefix].keys.map(&:to_s).sort
+            assert_equal 'bar', subject.to_hash[:match_phrase_prefix][:query]
+          end
+
+          should "take a Hash" do
+            subject = MatchPhrasePrefix.new message: { query: 'test' }
+
+            assert_equal({match_phrase_prefix: {message: {query: "test" }}}, subject.to_hash)
+          end
+
+          should "take a block" do
+            subject = MatchPhrasePrefix.new :message do
+              query          'test'
+              boost          2
+              max_expansions 1
+            end
+
+            assert_equal({match_phrase_prefix: {message: {query: "test", max_expansions: 1, boost: 2 }}},
+                         subject.to_hash)
+          end
+
+          should "take a method call" do
+            subject = MatchPhrasePrefix.new :message
+            subject.query    'test'
+
+            assert_equal({match_phrase_prefix: {message: {query: "test" }}}, subject.to_hash)
+          end
+
+        end
+      end
+    end
+  end
+end

--- a/elasticsearch-dsl/test/unit/queries/match_phrase_test.rb
+++ b/elasticsearch-dsl/test/unit/queries/match_phrase_test.rb
@@ -1,0 +1,63 @@
+require 'test_helper'
+
+module Elasticsearch
+  module Test
+    module Queries
+      class MatchPhraseTest < ::Test::Unit::TestCase
+        include Elasticsearch::DSL::Search::Queries
+
+        context "Match Phrase Query" do
+          subject { MatchPhrase.new }
+
+          should "be converted to a Hash" do
+            assert_equal({ match_phrase: {} }, subject.to_hash)
+          end
+
+          should "take a concrete value" do
+            subject = MatchPhrase.new message: 'test'
+
+            assert_equal({match_phrase: {message: "test"}}, subject.to_hash)
+          end
+
+          should "have option methods" do
+            subject = MatchPhrase.new
+
+            subject.query    'bar'
+            subject.analyzer 'standard'
+            subject.boost    10
+            subject.slop     1
+
+            assert_equal %w[ analyzer boost query slop ],
+                         subject.to_hash[:match_phrase].keys.map(&:to_s).sort
+            assert_equal 'bar', subject.to_hash[:match_phrase][:query]
+          end
+
+          should "take a Hash" do
+            subject = MatchPhrase.new message: { query: 'test' }
+
+            assert_equal({match_phrase: {message: {query: "test" }}}, subject.to_hash)
+          end
+
+          should "take a block" do
+            subject = MatchPhrase.new :message do
+              query     'test'
+              slop      1
+              boost     2
+            end
+
+            assert_equal({match_phrase: {message: {query: "test", slop: 1, boost: 2 }}},
+                         subject.to_hash)
+          end
+
+          should "take a method call" do
+            subject = MatchPhrase.new :message
+            subject.query    'test'
+
+            assert_equal({match_phrase: {message: {query: "test" }}}, subject.to_hash)
+          end
+
+        end
+      end
+    end
+  end
+end

--- a/elasticsearch-dsl/test/unit/queries/match_test.rb
+++ b/elasticsearch-dsl/test/unit/queries/match_test.rb
@@ -24,9 +24,8 @@ module Elasticsearch
 
             subject.query    'bar'
             subject.operator 'bar'
-            subject.type     'bar'
 
-            assert_equal %w[ operator query type ],
+            assert_equal %w[ operator query ],
                          subject.to_hash[:match].keys.map(&:to_s).sort
             assert_equal 'bar', subject.to_hash[:match][:query]
           end
@@ -41,12 +40,11 @@ module Elasticsearch
             subject = Match.new :message do
               query     'test'
               operator  'and'
-              type      'phrase_prefix'
               boost     2
               fuzziness 'AUTO'
             end
 
-            assert_equal({match: {message: {query: "test", operator: "and", type: 'phrase_prefix', boost: 2, fuzziness: 'AUTO'}}},
+            assert_equal({match: {message: {query: "test", operator: "and",  boost: 2, fuzziness: 'AUTO'}}},
                          subject.to_hash)
           end
 


### PR DESCRIPTION
Fixes https://github.com/elastic/elasticsearch-ruby/issues/441 includes passing unit tests. Adds support for [match_phrase](https://www.elastic.co/guide/en/elasticsearch/reference/5.4/query-dsl-match-query-phrase.html) and [match_phrase_prefix](https://www.elastic.co/guide/en/elasticsearch/reference/5.4/query-dsl-match-query-phrase-prefix.html) queries