### PR TITLE
[CLIENT] Fixed default port handling during __build_connections

### DIFF
--- a/elasticsearch-transport/lib/elasticsearch/transport/transport/base.rb
+++ b/elasticsearch-transport/lib/elasticsearch/transport/transport/base.rb
@@ -129,7 +129,7 @@ module Elasticsearch
           Connections::Collection.new \
             :connections => hosts.map { |host|
               host[:protocol] = host[:scheme] || options[:scheme] || options[:http][:scheme] || DEFAULT_PROTOCOL
-              host[:port] ||= options[:port] || options[:http][:scheme] || DEFAULT_PORT
+              host[:port] ||= options[:port] || options[:http][:port] || DEFAULT_PORT
               if (options[:user] || options[:http][:user]) && !host[:user]
                 host[:user] ||= options[:user] || options[:http][:user]
                 host[:password] ||= options[:password] || options[:http][:password]


### PR DESCRIPTION
Fixes a typo introduced some time ago in https://github.com/elastic/elasticsearch-ruby/commit/6e97bde36b76624f684d7d5477a2ae15cb99080d#diff-031bf01d5e547f3e45e7df7ab30e7326R38:

```diff
-   host[:protocol] = host[:scheme] || options[:scheme] || DEFAULT_PROTOCOL
-   host[:port] ||= options[:port] || DEFAULT_PORT
+   host[:protocol] = host[:scheme] || options[:scheme] || options[:http][:scheme] || DEFAULT_PROTOCOL
+   host[:port] ||= options[:port] || options[:http][:scheme] || DEFAULT_PORT
```

fixes https://github.com/logstash-plugins/logstash-filter-elasticsearch/issues/58