### PR TITLE
[DSL] Add Scripting Feature Outside Filter Query

### DIFF
--- a/elasticsearch-dsl/lib/elasticsearch/dsl/search.rb
+++ b/elasticsearch-dsl/lib/elasticsearch/dsl/search.rb
@@ -219,6 +219,22 @@ module Elasticsearch
           @suggest = value
         end
 
+        # DSL method for building the `script` part of a search definition
+        #
+        # @return [self]
+        #
+        def script(*args, &block)
+          if block
+            @script = Script.new(*args, &block)
+            self
+          elsif !args.empty?
+            @script = args.first
+            self
+          else
+            @script
+          end
+        end
+
         # Delegates to the methods provided by the {Options} class
         #
         def method_missing(name, *args, &block)
@@ -246,6 +262,7 @@ module Elasticsearch
           hash.update(from: @from) if @from
           hash.update(suggest: @suggest.reduce({}) { |sum,item| sum.update item.last.to_hash }) if @suggest
           hash.update(highlight: @highlight.to_hash) if @highlight
+          hash.update(script: @script) if @script
           hash.update(@options) unless @options.empty?
           hash
         end

--- a/elasticsearch-dsl/lib/elasticsearch/dsl/search/script.rb
+++ b/elasticsearch-dsl/lib/elasticsearch/dsl/search/script.rb
@@ -6,13 +6,24 @@ module Elasticsearch
       #
       # @see https://www.elastic.co/guide/en/elasticsearch/reference/5.5/query-dsl-script-query.html
       #
+
+      #
+      # @example
+      #
+      #     search do
+      #       script do
+      #         inline 'test'
+      #         params [value: 7]
+      #       end
+      #     end
+      #
       class Script
         include BaseComponent
 
         option_method :script
         option_method :inline
         option_method :params
-        
+
       end
     end
   end

--- a/elasticsearch-dsl/lib/elasticsearch/dsl/search/script.rb
+++ b/elasticsearch-dsl/lib/elasticsearch/dsl/search/script.rb
@@ -1,0 +1,19 @@
+module Elasticsearch
+  module DSL
+    module Search
+
+      # Wraps the `script` part of a search definition
+      #
+      # @see https://www.elastic.co/guide/en/elasticsearch/reference/5.5/query-dsl-script-query.html
+      #
+      class Script
+        include BaseComponent
+
+        option_method :script
+        option_method :inline
+        option_method :params
+        
+      end
+    end
+  end
+end

--- a/elasticsearch-dsl/test/unit/search_script_test.rb
+++ b/elasticsearch-dsl/test/unit/search_script_test.rb
@@ -1,0 +1,65 @@
+require 'test_helper'
+
+module Elasticsearch
+  module Test
+    class SearchScriptTest < ::Elasticsearch::Test::UnitTestCase
+      subject { Elasticsearch::DSL::Search::Script.new }
+
+      context "Search sort" do
+
+        should "add a single field" do
+          subject = Elasticsearch::DSL::Search::Script.new :params
+          assert_equal( [:params], subject.to_hash )
+        end
+
+        should "add multiple fields" do
+          subject = Elasticsearch::DSL::Search::Script.new [:params, :inline]
+          assert_equal( [:params, :inline], subject.to_hash )
+        end
+
+        should "add a field with options" do
+          subject = Elasticsearch::DSL::Search::Script.new script: { params: 'hi', inline: 'test' }
+          assert_equal( [ { script: { params: 'hi', inline: 'test' } } ], subject.to_hash )
+        end
+
+        should "add fields with the DSL method" do
+          subject = Elasticsearch::DSL::Search::Script.new do
+            inline: "bloop._source['test'] = bleep.test; "
+            params: 'test'
+          end
+
+          assert_equal(
+            [
+              { inline: { "bloop._source['test'] = bleep.test; " },
+              { params: { 'test' } },
+            ], subject.to_hash )
+        end
+
+        should "be empty" do
+          subject = Elasticsearch::DSL::Search::Script.new
+          assert_equal subject.empty?, true
+        end
+
+        should "not be empty" do
+          subject = Elasticsearch::DSL::Search::Script.new params: { 'test' }
+          assert_equal subject.empty?, false
+        end
+
+        context "#to_hash" do
+          should "not duplicate values when defined by arguments" do
+            subject = Elasticsearch::DSL::Search::Script.new params: { 'test' }
+            assert_equal(subject.to_hash, subject.to_hash)
+          end
+
+          should "not duplicate values when defined by a block" do
+            subject = Elasticsearch::DSL::Search::Script.new do
+              params: 'test'
+            end
+
+            assert_equal(subject.to_hash, subject.to_hash)
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Add ability to use scripting outside of the Filter method, as well as some unit tests.

https://www.elastic.co/guide/en/elasticsearch/reference/5.5/query-dsl-script-query.html

cc: @marclapierre