### PR TITLE
Fix the path for indices exists_type? method

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,14 +30,14 @@ matrix:
 
     - rvm: 2.4.0
       jdk: oraclejdk8
-      env: TEST_SUITE=integration SERVER=start TEST_CLUSTER_LOGS=/tmp/log TEST_BUILD_REF=origin/5.x TEST_CLUSTER_COMMAND=/tmp/elasticsearch-5.4.0-SNAPSHOT/bin/elasticsearch
+      env: TEST_SUITE=integration SERVER=start TEST_CLUSTER_LOGS=/tmp/log TEST_BUILD_REF=origin/5.5 TEST_CLUSTER_COMMAND=/tmp/elasticsearch-5.5.3/bin/elasticsearch
 
 before_install:
   - gem update --system
   - gem --version
   - gem install bundler -v 1.14.3
   - bundle version
-  - curl -sS https://snapshots.elastic.co/downloads/elasticsearch/elasticsearch-5.4.0-SNAPSHOT.tar.gz | tar xz -C /tmp
+  - curl -sS https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-5.5.3.tar.gz | tar xz -C /tmp
   - rake setup
   - rake elasticsearch:update
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/exists_type.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/exists_type.rb
@@ -22,7 +22,7 @@ module Elasticsearch
         # @option arguments [Boolean] :local Return local information, do not retrieve the state from master node
         #                                    (default: false)
         #
-        # @see http://www.elasticsearch.org/guide/reference/api/admin-indices-types-exists/
+        # @see https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-types-exists.html
         #
         def exists_type(arguments={})
           raise ArgumentError, "Required argument 'index' missing" unless arguments[:index]
@@ -36,7 +36,7 @@ module Elasticsearch
           ]
 
           method = HTTP_HEAD
-          path   = Utils.__pathify Utils.__listify(arguments[:index]), Utils.__escape(arguments[:type])
+          path   = Utils.__pathify Utils.__listify(arguments[:index]), '_mapping', Utils.__escape(arguments[:type])
 
           params = Utils.__validate_and_extract_params arguments, valid_params
           body = nil

--- a/elasticsearch-api/test/unit/indices/exists_type_test.rb
+++ b/elasticsearch-api/test/unit/indices/exists_type_test.rb
@@ -10,7 +10,7 @@ module Elasticsearch
         should "perform correct request" do
           subject.expects(:perform_request).with do |method, url, params, body|
             assert_equal 'HEAD', method
-            assert_equal 'foo/bar', url
+            assert_equal 'foo/_mapping/bar', url
             assert_equal Hash.new, params
             assert_nil   body
             true
@@ -21,7 +21,7 @@ module Elasticsearch
 
         should "perform request against multiple indices" do
           subject.expects(:perform_request).with do |method, url, params, body|
-            assert_equal 'foo,bar/bam', url
+            assert_equal 'foo,bar/_mapping/bam', url
             true
           end.returns(FakeResponse.new)
 
@@ -30,7 +30,7 @@ module Elasticsearch
 
         should "URL-escape the parts" do
           subject.expects(:perform_request).with do |method, url, params, body|
-            assert_equal 'foo%5Ebar/bar%2Fbam', url
+            assert_equal 'foo%5Ebar/_mapping/bar%2Fbam', url
             true
           end.returns(FakeResponse.new)
 


### PR DESCRIPTION
ElasticSearch version 5+ has a [breaking change](https://www.elastic.co/guide/en/elasticsearch/reference/current/breaking_50_rest_api_changes.html#_literal_head_index_type_literal_replaced_with_literal_head_index__mapping_type_literal) which means the endpoint for checking `exists_type?` has changed from: 
`HEAD index_name/type_name` to `HEAD index_name/_mapping/type_name`.

Currently, the elasticsearch-ruby gem has not been updated to reflect this change and the result for us after upgrading is a `Elasticsearch::Transport::Transport::Errors::BadRequest [400]` when using  `client.indices.exists_type?`.  As I am currently working on project with ES 5.5.3, I have targeted this PR at the `5.x` branch but as [the change exists in v6.0 too](https://www.elastic.co/guide/en/elasticsearch/reference/6.0/indices-types-exists.html)  I presume it should also be fixed in `master`.