### PR TITLE
multiple connections per host, if provided

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,14 +31,14 @@ matrix:
 
     - rvm: 2.4.0
       jdk: oraclejdk8
-      env: TEST_SUITE=integration SERVER=start TEST_CLUSTER_LOGS=/tmp/log TEST_BUILD_REF=origin/master TEST_CLUSTER_COMMAND=/tmp/elasticsearch-6.0.0-beta1-SNAPSHOT/bin/elasticsearch
+      env: TEST_SUITE=integration SERVER=start TEST_CLUSTER_LOGS=/tmp/log TEST_BUILD_REF=origin/master TEST_CLUSTER_COMMAND=/tmp/elasticsearch-6.0.0-rc1/bin/elasticsearch
 
 before_install:
   - gem update --system
   - gem --version
   - gem install bundler -v 1.14.3
   - bundle version
-  - curl -sS https://snapshots.elastic.co/downloads/elasticsearch/elasticsearch-6.0.0-beta1-SNAPSHOT.tar.gz | tar xz -C /tmp
+  - curl -sS https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-6.0.0-rc1.tar.gz | tar xz -C /tmp
   - rake setup
   - rake elasticsearch:update
 


### PR DESCRIPTION
Create `:connections_per_host` connections and add them to the pool, if provided as an option for the constructor.