### PR TITLE
Fix error when response frozen

### DIFF
--- a/elasticsearch-transport/lib/elasticsearch/transport/transport/response.rb
+++ b/elasticsearch-transport/lib/elasticsearch/transport/transport/response.rb
@@ -12,7 +12,7 @@ module Elasticsearch
         # @param headers [Hash]    Response headers
         def initialize(status, body, headers={})
           @status, @body, @headers = status, body, headers
-          @body = body.force_encoding('UTF-8') if body.respond_to?(:force_encoding)
+          @body = body.dup.force_encoding('UTF-8') if body.respond_to?(:force_encoding)
         end
       end
 


### PR DESCRIPTION
Hi.
I got `can't modify frozen String` error when use elasticsearch-transport in ruby 2.3.1.
It's occure maybe `force_encoding` to frozen `@body`


```
    RuntimeError:
       can't modify frozen String
     # /usr/local/bundle/gems/elasticsearch-transport-2.0.2/lib/elasticsearch/transport/transport/response.rb:16:in `force_encoding'
     # /usr/local/bundle/gems/elasticsearch-transport-2.0.2/lib/elasticsearch/transport/transport/response.rb:16:in `initialize'
     # /usr/local/bundle/gems/elasticsearch-transport-2.0.2/lib/elasticsearch/transport/transport/http/curb.rb:34:in `new'
     # /usr/local/bundle/gems/elasticsearch-transport-2.0.2/lib/elasticsearch/transport/transport/http/curb.rb:34:in `block in perform_request'
     # /usr/local/bundle/gems/elasticsearch-transport-2.0.2/lib/elasticsearch/transport/transport/base.rb:258:in `perform_request'
     # /usr/local/bundle/gems/elasticsearch-transport-2.0.2/lib/elasticsearch/transport/transport/http/curb.rb:19:in `perform_request'
     # /usr/local/bundle/gems/elasticsearch-transport-2.0.2/lib/elasticsearch/transport/client.rb:128:in `perform_request'
     # /usr/local/bundle/gems/elasticsearch-api-2.0.2/lib/elasticsearch/api/actions/search.rb:172:in `search'
```