### PR TITLE
Add how specifying Elasticsearch host to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,9 @@ require 'elasticsearch'
 
 client = Elasticsearch::Client.new log: true
 
+# if you specify Elasticsearch host
+# client = Elasticsearch::Client.new url: 'http://localhost:9200', log: true
+
 client.transport.reload_connections!
 
 client.cluster.health


### PR DESCRIPTION
Since specifying Elasticsearch host is very important information for users, I added it.