### PR TITLE
Add inner_hits option support for has_parent/has_child query and filter

### DIFF
--- a/elasticsearch-dsl/lib/elasticsearch/dsl/search/filters/has_child.rb
+++ b/elasticsearch-dsl/lib/elasticsearch/dsl/search/filters/has_child.rb
@@ -30,6 +30,7 @@ module Elasticsearch
           option_method :type
           option_method :min_children
           option_method :max_children
+          option_method :inner_hits
 
           # DSL method for building the `query` part of the query definition
           #

--- a/elasticsearch-dsl/lib/elasticsearch/dsl/search/filters/has_parent.rb
+++ b/elasticsearch-dsl/lib/elasticsearch/dsl/search/filters/has_parent.rb
@@ -29,6 +29,7 @@ module Elasticsearch
 
           option_method :parent_type
           option_method :score_mode
+          option_method :inner_hits
 
           # DSL method for building the `query` part of the query definition
           #

--- a/elasticsearch-dsl/lib/elasticsearch/dsl/search/queries/has_child.rb
+++ b/elasticsearch-dsl/lib/elasticsearch/dsl/search/queries/has_child.rb
@@ -27,6 +27,7 @@ module Elasticsearch
           option_method :score_mode
           option_method :min_children
           option_method :max_children
+          option_method :inner_hits
 
           # DSL method for building the `query` part of the query definition
           #

--- a/elasticsearch-dsl/lib/elasticsearch/dsl/search/queries/has_parent.rb
+++ b/elasticsearch-dsl/lib/elasticsearch/dsl/search/queries/has_parent.rb
@@ -27,6 +27,7 @@ module Elasticsearch
 
           option_method :parent_type
           option_method :score_mode
+          option_method :inner_hits
 
           # DSL method for building the `query` part of the query definition
           #

--- a/elasticsearch-dsl/test/unit/filters/has_child_test.rb
+++ b/elasticsearch-dsl/test/unit/filters/has_child_test.rb
@@ -21,10 +21,12 @@ module Elasticsearch
             subject.filter 'bar'
             subject.min_children 'bar'
             subject.max_children 'bar'
+            subject.inner_hits({ size: 1 })
 
-            assert_equal %w[ filter max_children min_children query type ],
+            assert_equal %w[ filter inner_hits max_children min_children query type ],
                          subject.to_hash[:has_child].keys.map(&:to_s).sort
             assert_equal 'bar', subject.to_hash[:has_child][:type]
+            assert_equal({ size: 1 }, subject.to_hash[:has_child][:inner_hits])
           end
 
           should "take a block" do

--- a/elasticsearch-dsl/test/unit/filters/has_parent_test.rb
+++ b/elasticsearch-dsl/test/unit/filters/has_parent_test.rb
@@ -20,10 +20,12 @@ module Elasticsearch
             subject.filter 'bar'
             subject.query 'bar'
             subject.score_mode 'bar'
+            subject.inner_hits({ size: 1 })
 
-            assert_equal %w[ filter parent_type query score_mode ],
+            assert_equal %w[ filter inner_hits parent_type query score_mode ],
                          subject.to_hash[:has_parent].keys.map(&:to_s).sort
             assert_equal 'bar', subject.to_hash[:has_parent][:parent_type]
+            assert_equal({ size: 1 }, subject.to_hash[:has_parent][:inner_hits])
           end
 
           should "take a block" do

--- a/elasticsearch-dsl/test/unit/queries/has_child_test.rb
+++ b/elasticsearch-dsl/test/unit/queries/has_child_test.rb
@@ -21,10 +21,12 @@ module Elasticsearch
             subject.score_mode 'bar'
             subject.min_children 'bar'
             subject.max_children 'bar'
+            subject.inner_hits({ size: 1 })
 
-            assert_equal %w[ max_children min_children query score_mode type ],
+            assert_equal %w[ inner_hits max_children min_children query score_mode type ],
                          subject.to_hash[:has_child].keys.map(&:to_s).sort
             assert_equal 'bar', subject.to_hash[:has_child][:type]
+            assert_equal({ size: 1 }, subject.to_hash[:has_child][:inner_hits])
           end
 
           should "take a block" do

--- a/elasticsearch-dsl/test/unit/queries/has_parent_test.rb
+++ b/elasticsearch-dsl/test/unit/queries/has_parent_test.rb
@@ -19,10 +19,12 @@ module Elasticsearch
             subject.parent_type 'bar'
             subject.query 'bar'
             subject.score_mode 'bar'
+            subject.inner_hits({ size: 1 })
 
-            assert_equal %w[ parent_type query score_mode ],
+            assert_equal %w[ inner_hits parent_type query score_mode ],
                          subject.to_hash[:has_parent].keys.map(&:to_s).sort
             assert_equal 'bar', subject.to_hash[:has_parent][:parent_type]
+            assert_equal({ size: 1 }, subject.to_hash[:has_parent][:inner_hits])
           end
 
           should "take a block" do


### PR DESCRIPTION
#463 This pull request adds `inner_hits` option of `has_parent`/`has_child` query and filters.

Elasticsaerch reference:
https://www.elastic.co/guide/en/elasticsearch/reference/current/search-request-inner-hits.html#parent-child-inner-hits