### PR TITLE
Improve error output in travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ matrix:
 
     - rvm: 2.4.0
       jdk: oraclejdk8
-      env: TEST_SUITE=integration SERVER=start TEST_CLUSTER_LOGS=/tmp/log TEST_BUILD_REF=origin/master TEST_CLUSTER_COMMAND=/tmp/elasticsearch-7.0.0-alpha1-SNAPSHOT/bin/elasticsearch
+      env: TEST_SUITE=integration SERVER=start TEST_CLUSTER_LOGS=/tmp/log TEST_BUILD_REF=origin/master TEST_CLUSTER_COMMAND=/tmp/elasticsearch-7.0.0-alpha1-SNAPSHOT/bin/elasticsearch QUIET=y
 
 before_install:
   - gem update --system


### PR DESCRIPTION
This change to the travis config quiets all of the output from passing tests, which brings the volume of test output down to where you can see what's going on and we can hopefully fix the build.