### PR TITLE
fix hardcoded elastic url in trace

### DIFF
--- a/elasticsearch-transport/lib/elasticsearch/transport/transport/base.rb
+++ b/elasticsearch-transport/lib/elasticsearch/transport/transport/base.rb
@@ -185,7 +185,7 @@ module Elasticsearch
         # @api private
         #
         def __trace(method, path, params, body, url, response, json, took, duration)
-          trace_url  = "http://localhost:9200/#{path}?pretty" +
+          trace_url  = url.sub(path,'') + path + '?pretty' +
                        ( params.empty? ? '' : "&#{::Faraday::Utils::ParamsHash[params].to_query}" )
           trace_body = body ? " -d '#{__convert_to_json(body, :pretty => true)}'" : ''
           tracer.info  "curl -X #{method.to_s.upcase} '#{trace_url}'#{trace_body}\n"


### PR DESCRIPTION
Hello,
Was trying to debug ssl error and kept seeing http://localhost instead of what I was expecting in trace. Turns out this was hardcoded. 