### PR TITLE
Fix the example watch.

### DIFF
--- a/elasticsearch-watcher/README.md
+++ b/elasticsearch-watcher/README.md
@@ -70,8 +70,8 @@ client.watcher.put_watch id: 'error_500', body: {
                  indices: ['test'],
                  body: {
                    query: {
-                     filtered: {
-                       query: { match: { status: 500 } },
+                     bool: {
+                       must: { match: { status: 500 } },
                        filter: { range: { timestamp: { from: '{{ctx.trigger.scheduled_time}}||-5m', to: '{{ctx.trigger.triggered_time}}' } } }
                      }
                    },


### PR DESCRIPTION
IIRC `filtered` was deprecated in v2 and removed in v5. This
example didn't work as is. I've converted it to use `bool`.