### PR TITLE
Fix the API endpoints for Watch actions.

### DIFF
--- a/elasticsearch-watcher/lib/elasticsearch/watcher/api/actions/ack_watch.rb
+++ b/elasticsearch-watcher/lib/elasticsearch/watcher/api/actions/ack_watch.rb
@@ -15,7 +15,7 @@ module Elasticsearch
             :master_timeout
           ]
           method = 'PUT'
-          path   = "_watcher/watch/#{arguments[:id]}/_ack"
+          path   = "_xpack/watcher/watch/#{arguments[:id]}/_ack"
           params = {}
           body   = nil
 

--- a/elasticsearch-watcher/lib/elasticsearch/watcher/api/actions/delete_watch.rb
+++ b/elasticsearch-watcher/lib/elasticsearch/watcher/api/actions/delete_watch.rb
@@ -17,7 +17,7 @@ module Elasticsearch
             :force
           ]
           method = 'DELETE'
-          path   = "_watcher/watch/#{arguments[:id]}"
+          path   = "_xpack/watcher/watch/#{arguments[:id]}"
           params = {}
           body   = nil
 

--- a/elasticsearch-watcher/lib/elasticsearch/watcher/api/actions/execute_watch.rb
+++ b/elasticsearch-watcher/lib/elasticsearch/watcher/api/actions/execute_watch.rb
@@ -15,7 +15,7 @@ module Elasticsearch
           valid_params = [
              ]
           method = 'PUT'
-          path   = "_watcher/watch/#{arguments[:id]}/_execute"
+          path   = "_xpack/watcher/watch/#{arguments[:id]}/_execute"
           params = {}
           body   = arguments[:body]
 

--- a/elasticsearch-watcher/lib/elasticsearch/watcher/api/actions/get_watch.rb
+++ b/elasticsearch-watcher/lib/elasticsearch/watcher/api/actions/get_watch.rb
@@ -14,7 +14,7 @@ module Elasticsearch
           valid_params = [
              ]
           method = 'GET'
-          path   = "_watcher/watch/#{arguments[:id]}"
+          path   = "_xpack/watcher/watch/#{arguments[:id]}"
           params = {}
           body   = nil
 

--- a/elasticsearch-watcher/lib/elasticsearch/watcher/api/actions/put_watch.rb
+++ b/elasticsearch-watcher/lib/elasticsearch/watcher/api/actions/put_watch.rb
@@ -17,7 +17,7 @@ module Elasticsearch
           valid_params = [
             :master_timeout ]
           method = 'PUT'
-          path   = "_watcher/watch/#{arguments[:id]}"
+          path   = "_xpack/watcher/watch/#{arguments[:id]}"
           params = Utils.__validate_and_extract_params arguments, valid_params
           body   = arguments[:body]
 

--- a/elasticsearch-watcher/lib/elasticsearch/watcher/api/actions/restart.rb
+++ b/elasticsearch-watcher/lib/elasticsearch/watcher/api/actions/restart.rb
@@ -12,7 +12,7 @@ module Elasticsearch
           valid_params = [
              ]
           method = 'PUT'
-          path   = "/_watcher/_restart"
+          path   = "/_xpack/watcher/_restart"
           params = {}
           body   = nil
 

--- a/elasticsearch-watcher/lib/elasticsearch/watcher/api/actions/start.rb
+++ b/elasticsearch-watcher/lib/elasticsearch/watcher/api/actions/start.rb
@@ -11,7 +11,7 @@ module Elasticsearch
           valid_params = [
              ]
           method = 'PUT'
-          path   = "/_watcher/_start"
+          path   = "/_xpack/watcher/_start"
           params = {}
           body   = nil
 

--- a/elasticsearch-watcher/lib/elasticsearch/watcher/api/actions/stats.rb
+++ b/elasticsearch-watcher/lib/elasticsearch/watcher/api/actions/stats.rb
@@ -11,7 +11,7 @@ module Elasticsearch
           valid_params = [
              ]
           method = 'GET'
-          path   = "/_watcher/stats"
+          path   = "/_xpack/watcher/stats"
           params = {}
           body   = nil
 

--- a/elasticsearch-watcher/lib/elasticsearch/watcher/api/actions/stop.rb
+++ b/elasticsearch-watcher/lib/elasticsearch/watcher/api/actions/stop.rb
@@ -11,7 +11,7 @@ module Elasticsearch
           valid_params = [
              ]
           method = 'PUT'
-          path   = "/_watcher/_stop"
+          path   = "/_xpack/watcher/_stop"
           params = {}
           body   = nil
 

--- a/elasticsearch-watcher/test/unit/ack_watch_test.rb
+++ b/elasticsearch-watcher/test/unit/ack_watch_test.rb
@@ -10,7 +10,7 @@ module Elasticsearch
         should "perform correct request" do
           subject.expects(:perform_request).with do |method, url, params, body|
             assert_equal 'PUT', method
-            assert_equal '_watcher/watch/foo/_ack', url
+            assert_equal '_xpack/watcher/watch/foo/_ack', url
             assert_equal Hash.new, params
             assert_nil   body
             true

--- a/elasticsearch-watcher/test/unit/delete_watch_test.rb
+++ b/elasticsearch-watcher/test/unit/delete_watch_test.rb
@@ -10,7 +10,7 @@ module Elasticsearch
         should "perform correct request" do
           subject.expects(:perform_request).with do |method, url, params, body|
             assert_equal 'DELETE', method
-            assert_equal "_watcher/watch/foo", url
+            assert_equal "_xpack/watcher/watch/foo", url
             assert_equal Hash.new, params
             assert_nil   body
             true

--- a/elasticsearch-watcher/test/unit/execute_watch_test.rb
+++ b/elasticsearch-watcher/test/unit/execute_watch_test.rb
@@ -10,7 +10,7 @@ module Elasticsearch
         should "perform correct request" do
           subject.expects(:perform_request).with do |method, url, params, body|
             assert_equal 'PUT', method
-            assert_equal "_watcher/watch/foo/_execute", url
+            assert_equal "_xpack/watcher/watch/foo/_execute", url
             assert_equal Hash.new, params
             assert_equal Hash.new, body
             true

--- a/elasticsearch-watcher/test/unit/get_watch_test.rb
+++ b/elasticsearch-watcher/test/unit/get_watch_test.rb
@@ -10,7 +10,7 @@ module Elasticsearch
         should "perform correct request" do
           subject.expects(:perform_request).with do |method, url, params, body|
             assert_equal 'GET', method
-            assert_equal "_watcher/watch/foo", url
+            assert_equal "_xpack/watcher/watch/foo", url
             assert_equal Hash.new, params
             assert_nil   body
             true

--- a/elasticsearch-watcher/test/unit/put_watch_test.rb
+++ b/elasticsearch-watcher/test/unit/put_watch_test.rb
@@ -10,7 +10,7 @@ module Elasticsearch
         should "perform correct request" do
           subject.expects(:perform_request).with do |method, url, params, body|
             assert_equal 'PUT', method
-            assert_equal "_watcher/watch/foo", url
+            assert_equal "_xpack/watcher/watch/foo", url
             assert_equal Hash.new, params
             assert_equal({foo: 'bar'}, body)
             true

--- a/elasticsearch-watcher/test/unit/restart_test.rb
+++ b/elasticsearch-watcher/test/unit/restart_test.rb
@@ -10,7 +10,7 @@ module Elasticsearch
         should "perform correct request" do
           subject.expects(:perform_request).with do |method, url, params, body|
             assert_equal 'PUT', method
-            assert_equal "/_watcher/_restart", url
+            assert_equal "/_xpack/watcher/_restart", url
             assert_equal Hash.new, params
             assert_nil   body
             true

--- a/elasticsearch-watcher/test/unit/start_test.rb
+++ b/elasticsearch-watcher/test/unit/start_test.rb
@@ -10,7 +10,7 @@ module Elasticsearch
         should "perform correct request" do
           subject.expects(:perform_request).with do |method, url, params, body|
             assert_equal 'PUT', method
-            assert_equal "/_watcher/_start", url
+            assert_equal "/_xpack/watcher/_start", url
             assert_equal Hash.new, params
             assert_nil   body
             true

--- a/elasticsearch-watcher/test/unit/stats_test.rb
+++ b/elasticsearch-watcher/test/unit/stats_test.rb
@@ -10,7 +10,7 @@ module Elasticsearch
         should "perform correct request" do
           subject.expects(:perform_request).with do |method, url, params, body|
             assert_equal 'GET', method
-            assert_equal "/_watcher/stats", url
+            assert_equal "/_xpack/watcher/stats", url
             assert_equal Hash.new, params
             assert_nil   body
             true

--- a/elasticsearch-watcher/test/unit/stop_test.rb
+++ b/elasticsearch-watcher/test/unit/stop_test.rb
@@ -10,7 +10,7 @@ module Elasticsearch
         should "perform correct request" do
           subject.expects(:perform_request).with do |method, url, params, body|
             assert_equal 'PUT', method
-            assert_equal "/_watcher/_stop", url
+            assert_equal "/_xpack/watcher/_stop", url
             assert_equal Hash.new, params
             assert_nil   body
             true


### PR DESCRIPTION
  * `ack`
  * `delete`
  * `execute`
  * `get`
  * `put`
  * `restart`
  * `start`
  * `stats`
  * `stop`

Please note that I skipped `info` because it is no longer part of the
[official API](https://www.elastic.co/guide/en/elasticsearch/reference/current/watcher-api.html).