### PR TITLE
Update docs, replace 'string' with 'text'

### DIFF
--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/put_mapping.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/put_mapping.rb
@@ -12,7 +12,7 @@ module Elasticsearch
         #     client.indices.put_mapping index: 'myindex', type: 'mytype', body: {
         #       mytype: {
         #         properties: {
-        #           title: { type: 'string', analyzer: 'snowball' }
+        #           title: { type: 'text', analyzer: 'snowball' }
         #         }
         #       }
         #     }


### PR DESCRIPTION
Just noticed this. Since 'string' is deprecated 'text' or 'keyword' are better examples.