### PR TITLE
Add headers to custom client documentation

### DIFF
--- a/elasticsearch-api/README.md
+++ b/elasticsearch-api/README.md
@@ -86,8 +86,8 @@ class MySimpleClient
 
   CONNECTION = ::Faraday::Connection.new url: 'http://localhost:9200'
 
-  def perform_request(method, path, params, body)
-    puts "--> #{method.upcase} #{path} #{params} #{body}"
+  def perform_request(method, path, params, body, header = nil)
+    puts "--> #{method.upcase} #{path} #{params} #{body} #{headers}"
 
     CONNECTION.run_request \
       method.downcase.to_sym,


### PR DESCRIPTION
As it can be seen [here](https://github.com/elastic/elasticsearch-ruby/blob/5c2d178f686f8eba4686298ac3240710b4eaf0d8/elasticsearch-api/lib/elasticsearch/api/namespace/common.rb#L21) for example, sometimes headers get send to `#perform_request`. However, other times (like [here](https://github.com/elastic/elasticsearch-ruby/blob/bdf5e145e5acc21726dddcd34492debbbddde568/elasticsearch-api/lib/elasticsearch/api/actions/info.rb#L15)) this argument is not passed.

The example found in the readme actually fails in some cases (e.g. when creating an index).