### PR TITLE
url path need encode

### DIFF
--- a/elasticsearch-transport/lib/elasticsearch/transport/transport/connections/connection.rb
+++ b/elasticsearch-transport/lib/elasticsearch/transport/transport/connections/connection.rb
@@ -50,7 +50,7 @@ module Elasticsearch
           # @return [String]
           #
           def full_path(path, params={})
-            path + (params.empty? ? '' : "?#{::Faraday::Utils::ParamsHash[params].to_query}")
+            URI.encode(path) + (params.empty? ? '' : "?#{::Faraday::Utils::ParamsHash[params].to_query}")
           end
 
           # Returns true when this connection has been marked dead, false otherwise.


### PR DESCRIPTION
when path like this `localhost:9200/_analyze?pretty&analyzer=ik_smart&text=你好`, it will raise  URI::InvalidURIError: URI must be ascii , path need encode.