### PR TITLE
[EXT] Remove gem dependencies that aren't compatible with JRuby.

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,8 @@ and the [`elasticsearch-api`](http://rubydoc.info/gems/elasticsearch-api) docume
 
 _Keep in mind, that for optimal performance, you should use a HTTP library which supports persistent
 ("keep-alive") connections, e.g. [Patron](https://github.com/toland/patron) or
-[Typhoeus](https://github.com/typhoeus/typhoeus)._
+[Typhoeus](https://github.com/typhoeus/typhoeus)._ These libraries are not dependencies of the elasticsearch gems, so
+be sure to define a dependency in your own application.
 
 This repository contains these additional Ruby libraries:
 

--- a/elasticsearch-extensions/elasticsearch-extensions.gemspec
+++ b/elasticsearch-extensions/elasticsearch-extensions.gemspec
@@ -20,8 +20,6 @@ Gem::Specification.new do |s|
 
   s.add_dependency "ansi"
   s.add_dependency "elasticsearch"
-  s.add_dependency "oj" unless defined?(JRUBY_VERSION)
-  s.add_dependency "patron" unless defined?(JRUBY_VERSION)
 
   if defined?(RUBY_VERSION) && RUBY_VERSION > '1.9'
     s.add_dependency "ruby-prof" unless defined?(JRUBY_VERSION) || defined?(Rubinius)
@@ -45,6 +43,8 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'yard'
   s.add_development_dependency 'cane'
   s.add_development_dependency 'pry'
+  s.add_development_dependency 'oj' unless defined?(JRUBY_VERSION)
+  s.add_development_dependency 'patron' unless defined?(JRUBY_VERSION)
 
   if defined?(RUBY_VERSION) && RUBY_VERSION < '1.9'
     s.add_development_dependency "json", '~> 1.8'

--- a/elasticsearch-extensions/elasticsearch-extensions.gemspec
+++ b/elasticsearch-extensions/elasticsearch-extensions.gemspec
@@ -43,8 +43,11 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'yard'
   s.add_development_dependency 'cane'
   s.add_development_dependency 'pry'
-  s.add_development_dependency 'oj' unless defined?(JRUBY_VERSION)
-  s.add_development_dependency 'patron' unless defined?(JRUBY_VERSION)
+
+  unless defined?(JRUBY_VERSION)
+    s.add_development_dependency 'oj'
+    s.add_development_dependency 'patron'
+  end
 
   if defined?(RUBY_VERSION) && RUBY_VERSION < '1.9'
     s.add_development_dependency "json", '~> 1.8'

--- a/elasticsearch-extensions/lib/elasticsearch/extensions/backup.rb
+++ b/elasticsearch-extensions/lib/elasticsearch/extensions/backup.rb
@@ -11,8 +11,14 @@ rescue LoadError
   warn('The "oj" gem could not be loaded. JSON parsing and serialization performance may not be optimal.')
 end
 
+begin
+  require 'patron'
+rescue LoadError
+  warn('The "patron" gem could not be loaded. HTTP requests may not be performed optimally.')
+end
+
+
 require 'elasticsearch'
-require 'patron' unless defined?(JRUBY_VERSION)
 
 module Backup
   module Database

--- a/elasticsearch-extensions/lib/elasticsearch/extensions/backup.rb
+++ b/elasticsearch-extensions/lib/elasticsearch/extensions/backup.rb
@@ -4,7 +4,12 @@ require 'pathname'
 require 'fileutils'
 
 require 'multi_json'
-require 'oj' unless defined?(JRUBY_VERSION)
+
+begin
+  require 'oj'
+rescue LoadError
+  warn('The "oj" gem could not be loaded. JSON parsing and serialization performance may not be optimal.')
+end
 
 require 'elasticsearch'
 require 'patron' unless defined?(JRUBY_VERSION)


### PR DESCRIPTION
We should remove the elasticsearch-extensions gem dependency on 'oj' and 'patron' so that it can be used with JRuby.