### PR TITLE
Fix frozen string error

### DIFF
--- a/elasticsearch-transport/lib/elasticsearch/transport/client.rb
+++ b/elasticsearch-transport/lib/elasticsearch/transport/client.rb
@@ -182,7 +182,7 @@ module Elasticsearch
           end
 
           # Remove the trailing slash
-          host_parts[:path].chomp!('/') if host_parts[:path]
+          host_parts[:path] = host_parts[:path].chomp('/') if host_parts[:path]
 
           host_parts
         end


### PR DESCRIPTION
`chomp!` gives error when the URI.path is frozen string literal.
This PR fixes the error by rewriting `chomp!`

Here is an error example below.

```ruby
[1] pry(main)> host = URI::HTTP.build(host: '127.0.0.1', port: '9200')
=> #<URI::HTTP http://127.0.0.1:9200>
[2] pry(main)> host.path
=> ""
[3] pry(main)> host.path.frozen?
=> true
[4] pry(main)> Elasticsearch::Client.new(host: host)
FrozenError: can't modify frozen String
from /Users/xxx/vendor/bundle/ruby/2.5.0/gems/elasticsearch-transport-5.0.5/lib/elasticsearch/transport/client.rb:185:in `chomp!'
```
URI.path can be frozen string literal. And this [code](https://github.com/elastic/elasticsearch-ruby/blob/master/elasticsearch-transport/lib/elasticsearch/transport/client.rb#L168) takes URI.path directly.