### PR TITLE
[API] Avoid instantiating an array of valid params for each request, each time it is called

### DIFF
--- a/elasticsearch-api/lib/elasticsearch/api.rb
+++ b/elasticsearch-api/lib/elasticsearch/api.rb
@@ -5,9 +5,8 @@ require "elasticsearch/api/version"
 require "elasticsearch/api/namespace/common"
 require "elasticsearch/api/utils"
 require "elasticsearch/api/actions/params_registry"
-require "elasticsearch/api/actions/cat/params_registry"
-require "elasticsearch/api/actions/cluster/params_registry"
 
+Dir[ File.expand_path('../api/actions/**/params_registry.rb', __FILE__) ].each   { |f| require f }
 Dir[ File.expand_path('../api/actions/**/*.rb', __FILE__) ].each   { |f| require f }
 Dir[ File.expand_path('../api/namespace/**/*.rb', __FILE__) ].each { |f| require f }
 

--- a/elasticsearch-api/lib/elasticsearch/api.rb
+++ b/elasticsearch-api/lib/elasticsearch/api.rb
@@ -6,6 +6,7 @@ require "elasticsearch/api/namespace/common"
 require "elasticsearch/api/utils"
 require "elasticsearch/api/actions/params_registry"
 require "elasticsearch/api/actions/cat/params_registry"
+require "elasticsearch/api/actions/cluster/params_registry"
 
 Dir[ File.expand_path('../api/actions/**/*.rb', __FILE__) ].each   { |f| require f }
 Dir[ File.expand_path('../api/namespace/**/*.rb', __FILE__) ].each { |f| require f }

--- a/elasticsearch-api/lib/elasticsearch/api.rb
+++ b/elasticsearch-api/lib/elasticsearch/api.rb
@@ -5,6 +5,7 @@ require "elasticsearch/api/version"
 require "elasticsearch/api/namespace/common"
 require "elasticsearch/api/utils"
 require "elasticsearch/api/actions/params_registry"
+require "elasticsearch/api/actions/cat/params_registry"
 
 Dir[ File.expand_path('../api/actions/**/*.rb', __FILE__) ].each   { |f| require f }
 Dir[ File.expand_path('../api/namespace/**/*.rb', __FILE__) ].each { |f| require f }

--- a/elasticsearch-api/lib/elasticsearch/api.rb
+++ b/elasticsearch-api/lib/elasticsearch/api.rb
@@ -4,6 +4,7 @@ require "multi_json"
 require "elasticsearch/api/version"
 require "elasticsearch/api/namespace/common"
 require "elasticsearch/api/utils"
+require "elasticsearch/api/actions/params_registry"
 
 Dir[ File.expand_path('../api/actions/**/*.rb', __FILE__) ].each   { |f| require f }
 Dir[ File.expand_path('../api/namespace/**/*.rb', __FILE__) ].each { |f| require f }

--- a/elasticsearch-api/lib/elasticsearch/api/actions/benchmark.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/benchmark.rb
@@ -48,15 +48,18 @@ module Elasticsearch
       # @see http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/search-benchmark.html
       #
       def benchmark(arguments={})
-        valid_params = [
-          :verbose ]
         method = HTTP_PUT
         path   = "_bench"
-        params = Utils.__validate_and_extract_params arguments, valid_params
+        params = Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
         body   = arguments[:body]
 
         perform_request(method, path, params, body).body
       end
+
+      # Register this action with its valid params when the module is loaded.
+      #
+      # @since 6.1.1
+      ParamsRegistry.register(:benchmark, [ :verbose ].freeze)
     end
   end
 end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/bulk.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/bulk.rb
@@ -68,22 +68,10 @@ module Elasticsearch
 
         type      = arguments.delete(:type)
 
-        valid_params = [
-          :wait_for_active_shards,
-          :refresh,
-          :routing,
-          :timeout,
-          :type,
-          :fields,
-          :_source,
-          :_source_exclude,
-          :_source_include,
-          :pipeline ]
-
         method = HTTP_POST
         path   = Utils.__pathify Utils.__escape(arguments[:index]), Utils.__escape(type), '_bulk'
 
-        params = Utils.__validate_and_extract_params arguments, valid_params
+        params = Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
         body   = arguments[:body]
 
         if body.is_a? Array
@@ -94,6 +82,21 @@ module Elasticsearch
 
         perform_request(method, path, params, payload, {"Content-Type" => "application/x-ndjson"}).body
       end
+
+      # Register this action with its valid params when the module is loaded.
+      #
+      # @since 6.1.1
+      ParamsRegistry.register(:bulk, [
+          :wait_for_active_shards,
+          :refresh,
+          :routing,
+          :timeout,
+          :type,
+          :fields,
+          :_source,
+          :_source_exclude,
+          :_source_include,
+          :pipeline ].freeze)
     end
   end
 end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/cat/aliases.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/cat/aliases.rb
@@ -46,27 +46,25 @@ module Elasticsearch
         # @see http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/cat-aliases.html
         #
         def aliases(arguments={})
-          valid_params = [
+          name = arguments.delete(:name)
+          method = HTTP_GET
+          path   = Utils.__pathify '_cat/aliases', Utils.__listify(name)
+          params = Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
+          params[:h] = Utils.__listify(params[:h]) if params[:h]
+          body   = nil
+          perform_request(method, path, params, body).body
+        end
+
+        # Register this action with its valid params when the module is loaded.
+        #
+        # @since 6.1.1
+        ParamsRegistry.register(:aliases, [
             :local,
             :master_timeout,
             :h,
             :help,
             :v,
-            :s ]
-
-          name = arguments.delete(:name)
-
-          method = HTTP_GET
-
-          path   = Utils.__pathify '_cat/aliases', Utils.__listify(name)
-
-          params = Utils.__validate_and_extract_params arguments, valid_params
-          params[:h] = Utils.__listify(params[:h]) if params[:h]
-
-          body   = nil
-
-          perform_request(method, path, params, body).body
-        end
+            :s ].freeze)
       end
     end
   end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/cat/allocation.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/cat/allocation.rb
@@ -43,28 +43,26 @@ module Elasticsearch
         # @see http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/cat-allocation.html
         #
         def allocation(arguments={})
-          valid_params = [
+          node_id = arguments.delete(:node_id)
+          method = HTTP_GET
+          path   = Utils.__pathify '_cat/allocation', Utils.__listify(node_id)
+          params = Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
+          params[:h] = Utils.__listify(params[:h]) if params[:h]
+          body   = nil
+          perform_request(method, path, params, body).body
+        end
+
+        # Register this action with its valid params when the module is loaded.
+        #
+        # @since 6.1.1
+        ParamsRegistry.register(:allocation, [
             :bytes,
             :local,
             :master_timeout,
             :h,
             :help,
             :v,
-            :s ]
-
-          node_id = arguments.delete(:node_id)
-
-          method = HTTP_GET
-
-          path   = Utils.__pathify '_cat/allocation', Utils.__listify(node_id)
-
-          params = Utils.__validate_and_extract_params arguments, valid_params
-          params[:h] = Utils.__listify(params[:h]) if params[:h]
-
-          body   = nil
-
-          perform_request(method, path, params, body).body
-        end
+            :s ].freeze)
       end
     end
   end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/cat/count.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/cat/count.rb
@@ -38,27 +38,30 @@ module Elasticsearch
         # @see http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/cat-count.html
         #
         def count(arguments={})
-          valid_params = [
-            :local,
-            :master_timeout,
-            :h,
-            :help,
-            :v,
-            :s ]
-
           index = arguments.delete(:index)
 
           method = HTTP_GET
 
           path   = Utils.__pathify '_cat/count', Utils.__listify(index)
 
-          params = Utils.__validate_and_extract_params arguments, valid_params
+          params = Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
           params[:h] = Utils.__listify(params[:h]) if params[:h]
 
           body   = nil
 
           perform_request(method, path, params, body).body
         end
+
+        # Register this action with its valid params when the module is loaded.
+        #
+        # @since 6.1.1
+        ParamsRegistry.register(:count, [
+            :local,
+            :master_timeout,
+            :h,
+            :help,
+            :v,
+            :s ].freeze)
       end
     end
   end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/cat/fielddata.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/cat/fielddata.rb
@@ -26,7 +26,20 @@ module Elasticsearch
         # @see http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/cat-fielddata.html
         #
         def fielddata(arguments={})
-          valid_params = [
+          fields = arguments.delete(:fields)
+
+          method = HTTP_GET
+          path   = Utils.__pathify "_cat/fielddata", Utils.__listify(fields)
+          params = Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
+          body   = nil
+
+          perform_request(method, path, params, body).body
+        end
+
+        # Register this action with its valid params when the module is loaded.
+        #
+        # @since 6.1.1
+        ParamsRegistry.register(:fielddata, [
             :bytes,
             :local,
             :master_timeout,
@@ -34,17 +47,7 @@ module Elasticsearch
             :help,
             :v,
             :s,
-            :fields ]
-
-          fields = arguments.delete(:fields)
-
-          method = HTTP_GET
-          path   = Utils.__pathify "_cat/fielddata", Utils.__listify(fields)
-          params = Utils.__validate_and_extract_params arguments, valid_params
-          body   = nil
-
-          perform_request(method, path, params, body).body
-        end
+            :fields ].freeze)
       end
     end
   end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/cat/health.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/cat/health.rb
@@ -30,23 +30,26 @@ module Elasticsearch
         # @see http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/cat-health.html
         #
         def health(arguments={})
-          valid_params = [
+          method = HTTP_GET
+          path   = "_cat/health"
+          params = Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
+          params[:h] = Utils.__listify(params[:h]) if params[:h]
+          body   = nil
+
+          perform_request(method, path, params, body).body
+        end
+
+        # Register this action with its valid params when the module is loaded.
+        #
+        # @since 6.1.1
+        ParamsRegistry.register(:health, [
             :local,
             :master_timeout,
             :h,
             :help,
             :ts,
             :v,
-            :s ]
-
-          method = HTTP_GET
-          path   = "_cat/health"
-          params = Utils.__validate_and_extract_params arguments, valid_params
-          params[:h] = Utils.__listify(params[:h]) if params[:h]
-          body   = nil
-
-          perform_request(method, path, params, body).body
-        end
+            :s ].freeze)
       end
     end
   end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/cat/help.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/cat/help.rb
@@ -10,15 +10,19 @@ module Elasticsearch
         # @see http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/cat.html
         #
         def help(arguments={})
-          valid_params = [
-            :help ]
           method = HTTP_GET
           path   = "_cat"
-          params = Utils.__validate_and_extract_params arguments, valid_params
+          params = Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
           body   = nil
 
           perform_request(method, path, params, body).body
         end
+
+        # Register this action with its valid params when the module is loaded.
+        #
+        # @since 6.1.1
+        ParamsRegistry.register(:help, [
+            :help ].freeze)
       end
     end
   end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/cat/indices.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/cat/indices.rb
@@ -52,7 +52,23 @@ module Elasticsearch
         # @see http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/cat-indices.html
         #
         def indices(arguments={})
-          valid_params = [
+          index = arguments.delete(:index)
+          method = HTTP_GET
+
+          path   = Utils.__pathify '_cat/indices', Utils.__listify(index)
+
+          params = Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
+          params[:h] = Utils.__listify(params[:h]) if params[:h]
+
+          body   = nil
+
+          perform_request(method, path, params, body).body
+        end
+
+        # Register this action with its valid params when the module is loaded.
+        #
+        # @since 6.1.1
+        ParamsRegistry.register(:indices, [
             :bytes,
             :h,
             :health,
@@ -61,21 +77,7 @@ module Elasticsearch
             :master_timeout,
             :pri,
             :v,
-            :s ]
-
-          index = arguments.delete(:index)
-
-          method = HTTP_GET
-
-          path   = Utils.__pathify '_cat/indices', Utils.__listify(index)
-
-          params = Utils.__validate_and_extract_params arguments, valid_params
-          params[:h] = Utils.__listify(params[:h]) if params[:h]
-
-          body   = nil
-
-          perform_request(method, path, params, body).body
-        end
+            :s ].freeze)
       end
     end
   end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/cat/master.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/cat/master.rb
@@ -29,21 +29,24 @@ module Elasticsearch
         # @see http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/cat-master.html
         #
         def master(arguments={})
-          valid_params = [
+          method = HTTP_GET
+          path   = "_cat/master"
+          params = Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
+          body   = nil
+
+          perform_request(method, path, params, body).body
+        end
+
+        # Register this action with its valid params when the module is loaded.
+        #
+        # @since 6.1.1
+        ParamsRegistry.register(:master, [
             :local,
             :master_timeout,
             :h,
             :help,
             :v,
-            :s ]
-
-          method = HTTP_GET
-          path   = "_cat/master"
-          params = Utils.__validate_and_extract_params arguments, valid_params
-          body   = nil
-
-          perform_request(method, path, params, body).body
-        end
+            :s ].freeze)
       end
     end
   end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/cat/nodeattrs.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/cat/nodeattrs.rb
@@ -15,20 +15,24 @@ module Elasticsearch
         # @see http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-nodeattrs.html
         #
         def nodeattrs(arguments={})
-          valid_params = [
+          method = 'GET'
+          path   = "_cat/nodeattrs"
+          params = Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
+          body   = nil
+
+          perform_request(method, path, params, body).body
+        end
+
+        # Register this action with its valid params when the module is loaded.
+        #
+        # @since 6.1.1
+        ParamsRegistry.register(:nodeattrs, [
             :local,
             :master_timeout,
             :h,
             :help,
             :v,
-            :s ]
-          method = 'GET'
-          path   = "_cat/nodeattrs"
-          params = Utils.__validate_and_extract_params arguments, valid_params
-          body   = nil
-
-          perform_request(method, path, params, body).body
-        end
+            :s ].freeze)
       end
     end
   end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/cat/nodes.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/cat/nodes.rb
@@ -38,25 +38,28 @@ module Elasticsearch
         # @see http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/cat-nodes.html
         #
         def nodes(arguments={})
-          valid_params = [
-            :full_id,
-            :local,
-            :master_timeout,
-            :h,
-            :help,
-            :v,
-            :s ]
-
           method = HTTP_GET
           path   = "_cat/nodes"
 
-          params = Utils.__validate_and_extract_params arguments, valid_params
+          params = Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
           params[:h] = Utils.__listify(params[:h], :escape => false) if params[:h]
 
           body   = nil
 
           perform_request(method, path, params, body).body
         end
+
+        # Register this action with its valid params when the module is loaded.
+        #
+        # @since 6.1.1
+        ParamsRegistry.register(:nodes, [
+            :full_id,
+            :local,
+            :master_timeout,
+            :h,
+            :help,
+            :v,
+            :s ].freeze)
       end
     end
   end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/cat/params_registry.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/cat/params_registry.rb
@@ -1,0 +1,44 @@
+module Elasticsearch
+  module API
+    module Cat
+      module Actions
+        module ParamsRegistry
+
+          extend self
+
+          # A Mapping of all the actions to their list of valid params.
+          #
+          # @since 6.1.1
+          PARAMS = {}
+
+          # Register an action with its list of valid params.
+          #
+          # @example Register the action.
+          #   ParamsRegistry.register(:benchmark, [ :verbose ])
+          #
+          # @param [ Symbol ] action The action to register.
+          # @param [ Array[Symbol] ] valid_params The list of valid params.
+          #
+          # @since 6.1.1
+          def register(action, valid_params)
+            PARAMS[action.to_sym] = valid_params
+          end
+
+          # Get the list of valid params for a given action.
+          #
+          # @example Get the list of valid params.
+          #   ParamsRegistry.get(:benchmark)
+          #
+          # @param [ Symbol ] action The action.
+          #
+          # @return [ Array<Symbol> ] The list of valid params for the action.
+          #
+          # @since 6.1.1
+          def get(action)
+            PARAMS.fetch(action, [])
+          end
+        end
+      end
+    end
+  end
+end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/cat/pending_tasks.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/cat/pending_tasks.rb
@@ -29,22 +29,25 @@ module Elasticsearch
         # @see http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/cat-pending-tasks.html
         #
         def pending_tasks(arguments={})
-          valid_params = [
-            :local,
-            :master_timeout,
-            :h,
-            :help,
-            :v,
-            :s ]
-
           method = HTTP_GET
           path   = "_cat/pending_tasks"
-          params = Utils.__validate_and_extract_params arguments, valid_params
+          params = Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
           params[:h] = Utils.__listify(params[:h]) if params[:h]
           body   = nil
 
           perform_request(method, path, params, body).body
         end
+
+        # Register this action with its valid params when the module is loaded.
+        #
+        # @since 6.1.1
+        ParamsRegistry.register(:pending_tasks, [
+            :local,
+            :master_timeout,
+            :h,
+            :help,
+            :v,
+            :s ].freeze)
       end
     end
   end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/cat/plugins.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/cat/plugins.rb
@@ -16,20 +16,24 @@ module Elasticsearch
         # @see http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-plugins.html
         #
         def plugins(arguments={})
-          valid_params = [
+          method = 'GET'
+          path   = "_cat/plugins"
+          params = Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
+          body   = nil
+
+          perform_request(method, path, params, body).body
+        end
+
+        # Register this action with its valid params when the module is loaded.
+        #
+        # @since 6.1.1
+        ParamsRegistry.register(:plugins, [
             :local,
             :master_timeout,
             :h,
             :help,
             :v,
-            :s ]
-          method = 'GET'
-          path   = "_cat/plugins"
-          params = Utils.__validate_and_extract_params arguments, valid_params
-          body   = nil
-
-          perform_request(method, path, params, body).body
-        end
+            :s ].freeze)
       end
     end
   end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/cat/recovery.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/cat/recovery.rb
@@ -47,28 +47,31 @@ module Elasticsearch
         # @see http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/cat-recovery.html
         #
         def recovery(arguments={})
-          valid_params = [
-            :bytes,
-            :local,
-            :master_timeout,
-            :h,
-            :help,
-            :v,
-            :s ]
-
           index = arguments.delete(:index)
 
           method = HTTP_GET
 
           path   = Utils.__pathify '_cat/recovery', Utils.__listify(index)
 
-          params = Utils.__validate_and_extract_params arguments, valid_params
+          params = Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
           params[:h] = Utils.__listify(params[:h]) if params[:h]
 
           body   = nil
 
           perform_request(method, path, params, body).body
         end
+
+        # Register this action with its valid params when the module is loaded.
+        #
+        # @since 6.1.1
+        ParamsRegistry.register(:recovery, [
+            :bytes,
+            :local,
+            :master_timeout,
+            :h,
+            :help,
+            :v,
+            :s ].freeze)
       end
     end
   end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/cat/repositories.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/cat/repositories.rb
@@ -22,20 +22,23 @@ module Elasticsearch
         # @see https://www.elastic.co/guide/en/elasticsearch/reference/current/cat-repositories.html
         #
         def repositories(arguments={})
-          valid_params = [
-            :master_timeout,
-            :h,
-            :help,
-            :v,
-            :s ]
-
           method = HTTP_GET
           path   = "_cat/repositories"
-          params = Utils.__validate_and_extract_params arguments, valid_params
+          params = Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
           body   = nil
 
           perform_request(method, path, params, body).body
         end
+
+        # Register this action with its valid params when the module is loaded.
+        #
+        # @since 6.1.1
+        ParamsRegistry.register(:repositories, [
+            :master_timeout,
+            :h,
+            :help,
+            :v,
+            :s ].freeze)
       end
     end
   end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/cat/segments.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/cat/segments.rb
@@ -19,20 +19,24 @@ module Elasticsearch
         # @see http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/cat-segments.html
         #
         def segments(arguments={})
-          valid_params = [
+          method = 'GET'
+          path   = "_cat/segments"
+          params = Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
+          body   = nil
+
+          perform_request(method, path, params, body).body
+        end
+
+        # Register this action with its valid params when the module is loaded.
+        #
+        # @since 6.1.1
+        ParamsRegistry.register(:segments, [
             :bytes,
             :index,
             :h,
             :help,
             :v,
-            :s ]
-          method = 'GET'
-          path   = "_cat/segments"
-          params = Utils.__validate_and_extract_params arguments, valid_params
-          body   = nil
-
-          perform_request(method, path, params, body).body
-        end
+            :s ].freeze)
       end
     end
   end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/cat/shards.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/cat/shards.rb
@@ -51,28 +51,29 @@ module Elasticsearch
         # @see http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/cat-shards.html
         #
         def shards(arguments={})
-          valid_params = [
-            :local,
-            :master_timeout,
-            :bytes,
-            :h,
-            :help,
-            :v,
-            :s ]
-
           index = arguments.delete(:index)
-
           method = HTTP_GET
-
           path   = Utils.__pathify '_cat/shards', Utils.__listify(index)
 
-          params = Utils.__validate_and_extract_params arguments, valid_params
+          params = Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
           params[:h] = Utils.__listify(params[:h]) if params[:h]
 
           body   = nil
 
           perform_request(method, path, params, body).body
         end
+
+        # Register this action with its valid params when the module is loaded.
+        #
+        # @since 6.1.1
+        ParamsRegistry.register(:shards, [
+            :local,
+            :master_timeout,
+            :bytes,
+            :h,
+            :help,
+            :v,
+            :s ].freeze)
       end
     end
   end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/cat/snapshots.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/cat/snapshots.rb
@@ -23,23 +23,25 @@ module Elasticsearch
         #
         def snapshots(arguments={})
           raise ArgumentError, "Required argument 'repository' missing" if !arguments[:repository] && !arguments[:help]
-
-          valid_params = [
-            :master_timeout,
-            :h,
-            :help,
-            :v,
-            :s ]
-
           repository = arguments.delete(:repository)
 
           method = HTTP_GET
           path   = Utils.__pathify "_cat/snapshots", Utils.__escape(repository)
-          params = Utils.__validate_and_extract_params arguments, valid_params
+          params = Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
           body   = nil
 
           perform_request(method, path, params, body).body
         end
+
+        # Register this action with its valid params when the module is loaded.
+        #
+        # @since 6.1.1
+        ParamsRegistry.register(:snapshots, [
+            :master_timeout,
+            :h,
+            :help,
+            :v,
+            :s ].freeze)
       end
     end
   end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/cat/tasks.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/cat/tasks.rb
@@ -19,7 +19,18 @@ module Elasticsearch
         # @see http://www.elastic.co/guide/en/elasticsearch/reference/master/tasks.html
         #
         def tasks(arguments={})
-          valid_params = [
+          method = 'GET'
+          path   = "_cat/tasks"
+          params = Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
+          body   = nil
+
+          perform_request(method, path, params, body).body
+        end
+
+        # Register this action with its valid params when the module is loaded.
+        #
+        # @since 6.1.1
+        ParamsRegistry.register(:tasks, [
             :format,
             :node_id,
             :actions,
@@ -29,14 +40,7 @@ module Elasticsearch
             :h,
             :help,
             :v,
-            :s ]
-          method = 'GET'
-          path   = "_cat/tasks"
-          params = Utils.__validate_and_extract_params arguments, valid_params
-          body   = nil
-
-          perform_request(method, path, params, body).body
-        end
+            :s ].freeze)
       end
     end
   end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/cat/templates.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/cat/templates.rb
@@ -17,7 +17,18 @@ module Elasticsearch
         # @see http://www.elastic.co/guide/en/elasticsearch/reference/master/cat-templates.html
         #
         def templates(arguments={})
-          valid_params = [
+          method = HTTP_GET
+          path   = "_cat/templates"
+          params = Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
+          body   = nil
+
+          perform_request(method, path, params, body).body
+        end
+
+        # Register this action with its valid params when the module is loaded.
+        #
+        # @since 6.1.1
+        ParamsRegistry.register(:templates, [
             :name,
             :format,
             :local,
@@ -25,14 +36,7 @@ module Elasticsearch
             :h,
             :help,
             :v,
-            :s ]
-          method = HTTP_GET
-          path   = "_cat/templates"
-          params = Utils.__validate_and_extract_params arguments, valid_params
-          body   = nil
-
-          perform_request(method, path, params, body).body
-        end
+            :s ].freeze)
       end
     end
   end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/cat/thread_pool.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/cat/thread_pool.rb
@@ -39,7 +39,19 @@ module Elasticsearch
         # @see http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/cat-thread-pool.html
         #
         def thread_pool(arguments={})
-          valid_params = [
+          method = HTTP_GET
+          path   = "_cat/thread_pool"
+          params = Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
+          params[:h] = Utils.__listify(params[:h]) if params[:h]
+          body   = nil
+
+          perform_request(method, path, params, body).body
+        end
+
+        # Register this action with its valid params when the module is loaded.
+        #
+        # @since 6.1.1
+        ParamsRegistry.register(:thread_pool, [
             :full_id,
             :size,
             :local,
@@ -48,16 +60,7 @@ module Elasticsearch
             :h,
             :help,
             :v,
-            :s ]
-
-          method = HTTP_GET
-          path   = "_cat/thread_pool"
-          params = Utils.__validate_and_extract_params arguments, valid_params
-          params[:h] = Utils.__listify(params[:h]) if params[:h]
-          body   = nil
-
-          perform_request(method, path, params, body).body
-        end
+            :s ].freeze)
       end
     end
   end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/cluster/allocation_explain.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/cluster/allocation_explain.rb
@@ -13,16 +13,20 @@ module Elasticsearch
         # @see http://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-allocation-explain.html
         #
         def allocation_explain(arguments={})
-          valid_params = [
-            :include_yes_decisions,
-            :include_disk_info ]
           method = 'GET'
           path   = "_cluster/allocation/explain"
-          params = Utils.__validate_and_extract_params arguments, valid_params
+          params = Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
           body   = arguments[:body]
 
           perform_request(method, path, params, body).body
         end
+
+        # Register this action with its valid params when the module is loaded.
+        #
+        # @since 6.1.1
+        ParamsRegistry.register(:allocation_explain, [
+            :include_yes_decisions,
+            :include_disk_info ].freeze)
       end
     end
   end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/cluster/get_settings.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/cluster/get_settings.rb
@@ -16,18 +16,20 @@ module Elasticsearch
         # @see http://elasticsearch.org/guide/reference/api/admin-cluster-update-settings/
         #
         def get_settings(arguments={})
-          valid_params = [
-            :flat_settings,
-            :include_defaults
-          ]
-
           method = HTTP_GET
           path   = "_cluster/settings"
-          params = Utils.__validate_and_extract_params arguments, valid_params
+          params = Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
           body   = nil
 
           perform_request(method, path, params, body).body
         end
+
+        # Register this action with its valid params when the module is loaded.
+        #
+        # @since 6.1.1
+        ParamsRegistry.register(:get_settings, [
+            :flat_settings,
+            :include_defaults ].freeze)
       end
     end
   end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/cluster/health.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/cluster/health.rb
@@ -38,8 +38,19 @@ module Elasticsearch
         def health(arguments={})
           arguments = arguments.clone
           index     = arguments.delete(:index)
+          method = HTTP_GET
+          path   = Utils.__pathify "_cluster/health", Utils.__listify(index)
 
-          valid_params = [
+          params = Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
+          body = nil
+
+          perform_request(method, path, params, body).body
+        end
+
+        # Register this action with its valid params when the module is loaded.
+        #
+        # @since 6.1.1
+        ParamsRegistry.register(:health, [
             :level,
             :local,
             :master_timeout,
@@ -50,16 +61,7 @@ module Elasticsearch
             :wait_for_no_relocating_shards,
             :wait_for_no_initializing_shards,
             :wait_for_status,
-            :wait_for_events ]
-
-          method = HTTP_GET
-          path   = Utils.__pathify "_cluster/health", Utils.__listify(index)
-
-          params = Utils.__validate_and_extract_params arguments, valid_params
-          body = nil
-
-          perform_request(method, path, params, body).body
-        end
+            :wait_for_events ].freeze)
       end
     end
   end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/cluster/params_registry.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/cluster/params_registry.rb
@@ -1,0 +1,44 @@
+module Elasticsearch
+  module API
+    module Cluster
+      module Actions
+        module ParamsRegistry
+
+          extend self
+
+          # A Mapping of all the actions to their list of valid params.
+          #
+          # @since 6.1.1
+          PARAMS = {}
+
+          # Register an action with its list of valid params.
+          #
+          # @example Register the action.
+          #   ParamsRegistry.register(:benchmark, [ :verbose ])
+          #
+          # @param [ Symbol ] action The action to register.
+          # @param [ Array[Symbol] ] valid_params The list of valid params.
+          #
+          # @since 6.1.1
+          def register(action, valid_params)
+            PARAMS[action.to_sym] = valid_params
+          end
+
+          # Get the list of valid params for a given action.
+          #
+          # @example Get the list of valid params.
+          #   ParamsRegistry.get(:benchmark)
+          #
+          # @param [ Symbol ] action The action.
+          #
+          # @return [ Array<Symbol> ] The list of valid params for the action.
+          #
+          # @since 6.1.1
+          def get(action)
+            PARAMS.fetch(action, [])
+          end
+        end
+      end
+    end
+  end
+end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/cluster/pending_tasks.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/cluster/pending_tasks.rb
@@ -17,16 +17,20 @@ module Elasticsearch
         # @see http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/cluster-pending.html
         #
         def pending_tasks(arguments={})
-          valid_params = [
-            :local,
-            :master_timeout ]
           method = HTTP_GET
           path   = "_cluster/pending_tasks"
-          params = Utils.__validate_and_extract_params arguments, valid_params
+          params = Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
           body   = nil
 
           perform_request(method, path, params, body).body
         end
+
+        # Register this action with its valid params when the module is loaded.
+        #
+        # @since 6.1.1
+        ParamsRegistry.register(:pending_tasks, [
+            :local,
+            :master_timeout ].freeze)
       end
     end
   end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/cluster/put_settings.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/cluster/put_settings.rb
@@ -15,15 +15,18 @@ module Elasticsearch
         # @see http://elasticsearch.org/guide/reference/api/admin-cluster-update-settings/
         #
         def put_settings(arguments={})
-          valid_params = [ :flat_settings ]
-
           method = HTTP_PUT
           path   = "_cluster/settings"
-          params = Utils.__validate_and_extract_params arguments, valid_params
+          params = Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
           body   = arguments[:body] || {}
 
           perform_request(method, path, params, body).body
         end
+
+        # Register this action with its valid params when the module is loaded.
+        #
+        # @since 6.1.1
+        ParamsRegistry.register(:put_settings, [ :flat_settings ].freeze)
       end
     end
   end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/cluster/reroute.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/cluster/reroute.rb
@@ -32,16 +32,25 @@ module Elasticsearch
         # @see http://elasticsearch.org/guide/reference/api/admin-cluster-reroute/
         #
         def reroute(arguments={})
-          valid_params = [ :dry_run, :explain, :metric, :master_timeout, :retry_failed, :timeout ]
-
           method = HTTP_POST
           path   = "_cluster/reroute"
 
-          params = Utils.__validate_and_extract_params arguments, valid_params
+          params = Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
           body   = arguments[:body] || {}
 
           perform_request(method, path, params, body).body
         end
+
+        # Register this action with its valid params when the module is loaded.
+        #
+        # @since 6.1.1
+        ParamsRegistry.register(:reroute, [
+            :dry_run,
+            :explain,
+            :metric,
+            :master_timeout,
+            :retry_failed,
+            :timeout ].freeze)
       end
     end
   end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/cluster/state.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/cluster/state.rb
@@ -31,25 +31,12 @@ module Elasticsearch
           arguments = arguments.clone
           index     = arguments.delete(:index)
           metric    = arguments.delete(:metric)
-
-          valid_params = [
-            :metric,
-            :index_templates,
-            :local,
-            :master_timeout,
-            :flat_settings,
-            :allow_no_indices,
-            :expand_wildcards,
-            :ignore_unavailable ]
-
           method = HTTP_GET
-          path   = "_cluster/state"
-
           path   = Utils.__pathify '_cluster/state',
                                    Utils.__listify(metric),
                                    Utils.__listify(index)
 
-          params = Utils.__validate_and_extract_params arguments, valid_params
+          params = Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
 
           [:index_templates].each do |key|
             params[key] = Utils.__listify(params[key]) if params[key]
@@ -59,6 +46,19 @@ module Elasticsearch
 
           perform_request(method, path, params, body).body
         end
+
+        # Register this action with its valid params when the module is loaded.
+        #
+        # @since 6.1.1
+        ParamsRegistry.register(:state, [
+            :metric,
+            :index_templates,
+            :local,
+            :master_timeout,
+            :flat_settings,
+            :allow_no_indices,
+            :expand_wildcards,
+            :ignore_unavailable ].freeze)
       end
     end
   end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/cluster/stats.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/cluster/stats.rb
@@ -13,17 +13,21 @@ module Elasticsearch
         # @see http://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-stats.html
         #
         def stats(arguments={})
-          valid_params = [
-            :flat_settings,
-            :human,
-            :timeout ]
           method = 'GET'
           path   = "_cluster/stats"
-          params = Utils.__validate_and_extract_params arguments, valid_params
+          params = Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
           body   = nil
 
           perform_request(method, path, params, body).body
         end
+
+        # Register this action with its valid params when the module is loaded.
+        #
+        # @since 6.1.1
+        ParamsRegistry.register(:stats, [
+            :flat_settings,
+            :human,
+            :timeout ].freeze)
       end
     end
   end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/count.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/count.rb
@@ -48,7 +48,19 @@ module Elasticsearch
       # @see https://www.elastic.co/guide/en/elasticsearch/reference/current/search-count.html
       #
       def count(arguments={})
-        valid_params = [
+        method = HTTP_GET
+        path   = Utils.__pathify( Utils.__listify(arguments[:index]), Utils.__listify(arguments[:type]), '_count' )
+
+        params = Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
+        body   = arguments[:body]
+
+        perform_request(method, path, params, body).body
+      end
+
+      # Register this action with its valid params when the module is loaded.
+      #
+      # @since 6.1.1
+      ParamsRegistry.register(:count, [
           :ignore_unavailable,
           :allow_no_indices,
           :expand_wildcards,
@@ -62,16 +74,7 @@ module Elasticsearch
           :df,
           :lenient,
           :lowercase_expanded_terms,
-          :terminate_after ]
-
-        method = HTTP_GET
-        path   = Utils.__pathify( Utils.__listify(arguments[:index]), Utils.__listify(arguments[:type]), '_count' )
-
-        params = Utils.__validate_and_extract_params arguments, valid_params
-        body   = arguments[:body]
-
-        perform_request(method, path, params, body).body
-      end
+          :terminate_after ].freeze)
     end
   end
 end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/count_percolate.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/count_percolate.rb
@@ -2,6 +2,11 @@ module Elasticsearch
   module API
     module Actions
 
+      # The valid parameters for this action.
+      #
+      # @since 6.0.1
+      VALID_PARAMS =
+
       # Return the number of queries matching a document.
       #
       # Percolator allows you to register queries and then evaluate a document against them:
@@ -51,7 +56,23 @@ module Elasticsearch
       def count_percolate(arguments={})
         raise ArgumentError, "Required argument 'index' missing" unless arguments[:index]
         raise ArgumentError, "Required argument 'type' missing"  unless arguments[:type]
-        valid_params = [
+
+        method = HTTP_GET
+        path   = Utils.__pathify Utils.__escape(arguments[:index]),
+                                 Utils.__escape(arguments[:type]),
+                                 arguments[:id],
+                                 '_percolate/count'
+
+        params = Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
+        body   = arguments[:body]
+
+        perform_request(method, path, params, body).body
+      end
+
+      # Register this action with its valid params when the module is loaded.
+      #
+      # @since 6.1.1
+      ParamsRegistry.register(:count_percolate, [
           :routing,
           :preference,
           :ignore_unavailable,
@@ -60,19 +81,7 @@ module Elasticsearch
           :percolate_index,
           :percolate_type,
           :version,
-          :version_type ]
-
-        method = HTTP_GET
-        path   = Utils.__pathify Utils.__escape(arguments[:index]),
-                                 Utils.__escape(arguments[:type]),
-                                 arguments[:id],
-                                 '_percolate/count'
-
-        params = Utils.__validate_and_extract_params arguments, valid_params
-        body   = arguments[:body]
-
-        perform_request(method, path, params, body).body
-      end
+          :version_type ].freeze)
     end
   end
 end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/count_percolate.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/count_percolate.rb
@@ -2,11 +2,6 @@ module Elasticsearch
   module API
     module Actions
 
-      # The valid parameters for this action.
-      #
-      # @since 6.0.1
-      VALID_PARAMS =
-
       # Return the number of queries matching a document.
       #
       # Percolator allows you to register queries and then evaluate a document against them:

--- a/elasticsearch-api/lib/elasticsearch/api/actions/delete.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/delete.rb
@@ -33,22 +33,12 @@ module Elasticsearch
         raise ArgumentError, "Required argument 'type' missing"  unless arguments[:type]
         raise ArgumentError, "Required argument 'id' missing"    unless arguments[:id]
 
-        valid_params = [
-          :consistency,
-          :parent,
-          :refresh,
-          :replication,
-          :routing,
-          :timeout,
-          :version,
-          :version_type ]
-
         method = HTTP_DELETE
         path   = Utils.__pathify Utils.__escape(arguments[:index]),
                                  Utils.__escape(arguments[:type]),
                                  Utils.__escape(arguments[:id])
 
-        params = Utils.__validate_and_extract_params arguments, valid_params
+        params = Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
         body   = nil
 
         if Array(arguments[:ignore]).include?(404)
@@ -57,6 +47,19 @@ module Elasticsearch
           perform_request(method, path, params, body).body
         end
       end
+
+      # Register this action with its valid params when the module is loaded.
+      #
+      # @since 6.1.1
+      ParamsRegistry.register(:delete, [
+          :consistency,
+          :parent,
+          :refresh,
+          :replication,
+          :routing,
+          :timeout,
+          :version,
+          :version_type ].freeze)
     end
   end
 end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/delete_by_query.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/delete_by_query.rb
@@ -55,8 +55,21 @@ module Elasticsearch
       #
       def delete_by_query(arguments={})
         raise ArgumentError, "Required argument 'index' missing" unless arguments[:index]
+        method = HTTP_POST
+        path   = Utils.__pathify Utils.__listify(arguments[:index]),
+                                 Utils.__listify(arguments[:type]),
+                                 '/_delete_by_query'
 
-        valid_params = [
+        params = Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
+        body   = arguments[:body]
+
+        perform_request(method, path, params, body).body
+      end
+
+      # Register this action with its valid params when the module is loaded.
+      #
+      # @since 6.1.1
+      ParamsRegistry.register(:delete_by_query, [
           :analyzer,
           :analyze_wildcard,
           :default_operator,
@@ -88,18 +101,7 @@ module Elasticsearch
           :scroll_size,
           :wait_for_completion,
           :requests_per_second,
-          :slices ]
-
-        method = HTTP_POST
-        path   = Utils.__pathify Utils.__listify(arguments[:index]),
-                                 Utils.__listify(arguments[:type]),
-                                 '/_delete_by_query'
-
-        params = Utils.__validate_and_extract_params arguments, valid_params
-        body   = arguments[:body]
-
-        perform_request(method, path, params, body).body
-      end
+          :slices ].freeze)
     end
   end
 end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/delete_script.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/delete_script.rb
@@ -13,9 +13,6 @@ module Elasticsearch
       #
       def delete_script(arguments={})
         raise ArgumentError, "Required argument 'id' missing"   unless arguments[:id]
-
-        valid_params =
-
         method = HTTP_DELETE
         path   = "_scripts/#{arguments.has_key?(:lang) ? "#{arguments.delete(:lang)}/" : ''}#{arguments[:id]}"
         params = Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)

--- a/elasticsearch-api/lib/elasticsearch/api/actions/delete_script.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/delete_script.rb
@@ -14,17 +14,22 @@ module Elasticsearch
       def delete_script(arguments={})
         raise ArgumentError, "Required argument 'id' missing"   unless arguments[:id]
 
-        valid_params = [
-          :version,
-          :version_type ]
+        valid_params =
 
         method = HTTP_DELETE
         path   = "_scripts/#{arguments.has_key?(:lang) ? "#{arguments.delete(:lang)}/" : ''}#{arguments[:id]}"
-        params = Utils.__validate_and_extract_params arguments, valid_params
+        params = Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
         body   = nil
 
         perform_request(method, path, params, body).body
       end
+
+      # Register this action with its valid params when the module is loaded.
+      #
+      # @since 6.1.1
+      ParamsRegistry.register(:delete_script, [
+          :version,
+          :version_type ].freeze)
     end
   end
 end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/explain.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/explain.rb
@@ -47,9 +47,6 @@ module Elasticsearch
         raise ArgumentError, "Required argument 'index' missing" unless arguments[:index]
         raise ArgumentError, "Required argument 'type' missing"  unless arguments[:type]
         raise ArgumentError, "Required argument 'id' missing"    unless arguments[:id]
-
-        valid_params =
-
         method = HTTP_GET
         path   = Utils.__pathify Utils.__escape(arguments[:index]),
                                  Utils.__escape(arguments[:type]),

--- a/elasticsearch-api/lib/elasticsearch/api/actions/explain.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/explain.rb
@@ -48,7 +48,26 @@ module Elasticsearch
         raise ArgumentError, "Required argument 'type' missing"  unless arguments[:type]
         raise ArgumentError, "Required argument 'id' missing"    unless arguments[:id]
 
-        valid_params = [
+        valid_params =
+
+        method = HTTP_GET
+        path   = Utils.__pathify Utils.__escape(arguments[:index]),
+                                 Utils.__escape(arguments[:type]),
+                                 Utils.__escape(arguments[:id]),
+                                 '_explain'
+
+        params = Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
+        body   = arguments[:body]
+
+        params[:fields] = Utils.__listify(params[:fields]) if params[:fields]
+
+        perform_request(method, path, params, body).body
+      end
+
+      # Register this action with its valid params when the module is loaded.
+      #
+      # @since 6.1.1
+      ParamsRegistry.register(:explain, [
           :analyze_wildcard,
           :analyzer,
           :default_operator,
@@ -64,21 +83,7 @@ module Elasticsearch
           :_source,
           :_source_include,
           :_source_exclude,
-          :stored_fields ]
-
-        method = HTTP_GET
-        path   = Utils.__pathify Utils.__escape(arguments[:index]),
-                                 Utils.__escape(arguments[:type]),
-                                 Utils.__escape(arguments[:id]),
-                                 '_explain'
-
-        params = Utils.__validate_and_extract_params arguments, valid_params
-        body   = arguments[:body]
-
-        params[:fields] = Utils.__listify(params[:fields]) if params[:fields]
-
-        perform_request(method, path, params, body).body
-      end
+          :stored_fields ].freeze)
     end
   end
 end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/field_caps.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/field_caps.rb
@@ -27,26 +27,15 @@ module Elasticsearch
         perform_request(method, path, params, body).body
       end
 
+
       # Register this action with its valid params when the module is loaded.
       #
       # @since 6.1.1
       ParamsRegistry.register(:field_caps, [
-          :analyze_wildcard,
-          :analyzer,
-          :default_operator,
-          :df,
           :fields,
-          :lenient,
-          :lowercase_expanded_terms,
-          :parent,
-          :preference,
-          :q,
-          :routing,
-          :source,
-          :_source,
-          :_source_include,
-          :_source_exclude,
-          :stored_fields ].freeze)
+          :ignore_unavailable,
+          :allow_no_indices,
+          :expand_wildcards ].freeze)
     end
   end
 end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/field_caps.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/field_caps.rb
@@ -19,20 +19,34 @@ module Elasticsearch
       #
       def field_caps(arguments={})
         raise ArgumentError, "Required argument 'fields' missing" unless arguments[:fields]
-
-        valid_params = [
-          :fields,
-          :ignore_unavailable,
-          :allow_no_indices,
-          :expand_wildcards ]
-
         method = HTTP_GET
         path   = Utils.__pathify Utils.__listify(arguments[:index]), '_field_caps'
-        params = Utils.__validate_and_extract_params arguments, valid_params
+        params = Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
         body   = arguments[:body]
 
         perform_request(method, path, params, body).body
       end
+
+      # Register this action with its valid params when the module is loaded.
+      #
+      # @since 6.1.1
+      ParamsRegistry.register(:field_caps, [
+          :analyze_wildcard,
+          :analyzer,
+          :default_operator,
+          :df,
+          :fields,
+          :lenient,
+          :lowercase_expanded_terms,
+          :parent,
+          :preference,
+          :q,
+          :routing,
+          :source,
+          :_source,
+          :_source_include,
+          :_source_exclude,
+          :stored_fields ].freeze)
     end
   end
 end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/field_stats.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/field_stats.rb
@@ -14,19 +14,23 @@ module Elasticsearch
       # @see http://www.elastic.co/guide/en/elasticsearch/reference/master/search-field-stats.html
       #
       def field_stats(arguments={})
-        valid_params = [
-          :fields,
-          :level,
-          :ignore_unavailable,
-          :allow_no_indices,
-          :expand_wildcards ]
         method = 'GET'
         path   = Utils.__pathify Utils.__escape(arguments[:index]), "_field_stats"
-        params = Utils.__validate_and_extract_params arguments, valid_params
+        params = Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
         body   = arguments[:body]
 
         perform_request(method, path, params, body).body
       end
+
+      # Register this action with its valid params when the module is loaded.
+      #
+      # @since 6.1.1
+      ParamsRegistry.register(:field_stats, [
+          :fields,
+          :level,
+          :ignore_unavailable,
+          :allow_no_indices,
+          :expand_wildcards ].freeze)
     end
   end
 end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/get.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/get.rb
@@ -37,9 +37,6 @@ module Elasticsearch
         raise ArgumentError, "Required argument 'index' missing" unless arguments[:index]
         raise ArgumentError, "Required argument 'id' missing"    unless arguments[:id]
         arguments[:type] ||= UNDERSCORE_ALL
-
-        valid_params =
-
         method = HTTP_GET
         path   = Utils.__pathify Utils.__escape(arguments[:index]),
                                  Utils.__escape(arguments[:type]),

--- a/elasticsearch-api/lib/elasticsearch/api/actions/get_source.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/get_source.rb
@@ -35,25 +35,13 @@ module Elasticsearch
         raise ArgumentError, "Required argument 'index' missing" unless arguments[:index]
         raise ArgumentError, "Required argument 'id' missing"    unless arguments[:id]
         arguments[:type] ||= UNDERSCORE_ALL
-
-        valid_params = [
-          :fields,
-          :parent,
-          :preference,
-          :realtime,
-          :refresh,
-          :routing,
-          :_source,
-          :_source_include,
-          :_source_exclude ]
-
         method = HTTP_GET
         path   = Utils.__pathify Utils.__escape(arguments[:index]),
                                  Utils.__escape(arguments[:type]),
                                  Utils.__escape(arguments[:id]),
                                  '_source'
 
-        params = Utils.__validate_and_extract_params arguments, valid_params
+        params = Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
         body   = nil
 
         params[:fields] = Utils.__listify(params[:fields]) if params[:fields]
@@ -62,6 +50,20 @@ module Elasticsearch
           perform_request(method, path, params, body).body
         end
       end
+
+      # Register this action with its valid params when the module is loaded.
+      #
+      # @since 6.1.1
+      ParamsRegistry.register(:get_source, [
+          :fields,
+          :parent,
+          :preference,
+          :realtime,
+          :refresh,
+          :routing,
+          :_source,
+          :_source_include,
+          :_source_exclude ].freeze)
     end
   end
 end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/index.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/index.rb
@@ -73,8 +73,21 @@ module Elasticsearch
       def index(arguments={})
         raise ArgumentError, "Required argument 'index' missing" unless arguments[:index]
         raise ArgumentError, "Required argument 'type' missing"  unless arguments[:type]
+        method = arguments[:id] ? HTTP_PUT : HTTP_POST
+        path   = Utils.__pathify Utils.__escape(arguments[:index]),
+                                 Utils.__escape(arguments[:type]),
+                                 Utils.__escape(arguments[:id])
 
-        valid_params = [
+        params = Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
+        body   = arguments[:body]
+
+        perform_request(method, path, params, body).body
+      end
+
+      # Register this action with its valid params when the module is loaded.
+      #
+      # @since 6.1.1
+      ParamsRegistry.register(:index, [
           :consistency,
           :op_type,
           :parent,
@@ -87,18 +100,7 @@ module Elasticsearch
           :timestamp,
           :ttl,
           :version,
-          :version_type ]
-
-        method = arguments[:id] ? HTTP_PUT : HTTP_POST
-        path   = Utils.__pathify Utils.__escape(arguments[:index]),
-                                 Utils.__escape(arguments[:type]),
-                                 Utils.__escape(arguments[:id])
-
-        params = Utils.__validate_and_extract_params arguments, valid_params
-        body   = arguments[:body]
-
-        perform_request(method, path, params, body).body
-      end
+          :version_type ].freeze)
     end
   end
 end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/analyze.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/analyze.rb
@@ -49,7 +49,21 @@ module Elasticsearch
         # @see http://www.elasticsearch.org/guide/reference/api/admin-indices-analyze/
         #
         def analyze(arguments={})
-          valid_params = [
+          method = HTTP_GET
+          path   = Utils.__pathify Utils.__listify(arguments[:index]), '_analyze'
+
+          params = Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
+          params[:filters] = Utils.__listify(params[:filters]) if params[:filters]
+
+          body   = arguments[:body]
+
+          perform_request(method, path, params, body).body
+        end
+
+        # Register this action with its valid params when the module is loaded.
+        #
+        # @since 6.1.1
+        ParamsRegistry.register(:analyze, [
             :analyzer,
             :char_filters,
             :explain,
@@ -62,18 +76,7 @@ module Elasticsearch
             :text,
             :tokenizer,
             :token_filters,
-            :format ]
-
-          method = HTTP_GET
-          path   = Utils.__pathify Utils.__listify(arguments[:index]), '_analyze'
-
-          params = Utils.__validate_and_extract_params arguments, valid_params
-          params[:filters] = Utils.__listify(params[:filters]) if params[:filters]
-
-          body   = arguments[:body]
-
-          perform_request(method, path, params, body).body
-        end
+            :format ].freeze)
       end
     end
   end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/clear_cache.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/clear_cache.rb
@@ -38,7 +38,21 @@ module Elasticsearch
         # @see https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-clearcache.html
         #
         def clear_cache(arguments={})
-          valid_params = [
+          method = HTTP_POST
+          path   = Utils.__pathify Utils.__listify(arguments[:index]), '_cache/clear'
+
+          params = Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
+          body   = nil
+
+          params[:fields] = Utils.__listify(params[:fields]) if params[:fields]
+
+          perform_request(method, path, params, body).body
+        end
+
+        # Register this action with its valid params when the module is loaded.
+        #
+        # @since 6.1.1
+        ParamsRegistry.register(:clear_cache, [
             :field_data,
             :fielddata,
             :fields,
@@ -49,18 +63,7 @@ module Elasticsearch
             :index,
             :recycler,
             :request_cache,
-            :request ]
-
-          method = HTTP_POST
-          path   = Utils.__pathify Utils.__listify(arguments[:index]), '_cache/clear'
-
-          params = Utils.__validate_and_extract_params arguments, valid_params
-          body   = nil
-
-          params[:fields] = Utils.__listify(params[:fields]) if params[:fields]
-
-          perform_request(method, path, params, body).body
-        end
+            :request ].freeze)
       end
     end
   end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/close.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/close.rb
@@ -28,23 +28,24 @@ module Elasticsearch
         #
         def close(arguments={})
           raise ArgumentError, "Required argument 'index' missing" unless arguments[:index]
-
-          valid_params = [
-            :ignore_indices,
-            :ignore_unavailable,
-            :allow_no_indices,
-            :expand_wildcards,
-            :timeout
-          ]
-
           method = HTTP_POST
           path   = Utils.__pathify Utils.__listify(arguments[:index]), '_close'
 
-          params = Utils.__validate_and_extract_params arguments, valid_params
+          params = Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
           body   = nil
 
           perform_request(method, path, params, body).body
         end
+
+        # Register this action with its valid params when the module is loaded.
+        #
+        # @since 6.1.1
+        ParamsRegistry.register(:close, [
+            :ignore_indices,
+            :ignore_unavailable,
+            :allow_no_indices,
+            :expand_wildcards,
+            :timeout ].freeze)
       end
     end
   end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/create.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/create.rb
@@ -70,21 +70,23 @@ module Elasticsearch
         #
         def create(arguments={})
           raise ArgumentError, "Required argument 'index' missing" unless arguments[:index]
-          valid_params = [
-            :timeout,
-            :master_timeout,
-            :update_all_types,
-            :wait_for_active_shards
-          ]
-
           method = HTTP_PUT
           path   = Utils.__pathify Utils.__escape(arguments[:index])
 
-          params = Utils.__validate_and_extract_params arguments, valid_params
+          params = Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
           body   = arguments[:body]
 
           perform_request(method, path, params, body).body
         end
+
+        # Register this action with its valid params when the module is loaded.
+        #
+        # @since 6.1.1
+        ParamsRegistry.register(:create, [
+            :timeout,
+            :master_timeout,
+            :update_all_types,
+            :wait_for_active_shards ].freeze)
       end
     end
   end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/delete.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/delete.rb
@@ -34,18 +34,10 @@ module Elasticsearch
         # @see http://www.elasticsearch.org/guide/reference/api/admin-indices-delete-index/
         #
         def delete(arguments={})
-          valid_params = [
-            :timeout,
-            :master_timeout,
-            :ignore_unavailable,
-            :allow_no_indices,
-            :expand_wildcards
-           ]
-
           method = HTTP_DELETE
           path   = Utils.__pathify Utils.__listify(arguments[:index])
 
-          params = Utils.__validate_and_extract_params arguments, valid_params
+          params = Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
           body   = nil
 
           if Array(arguments[:ignore]).include?(404)
@@ -54,6 +46,16 @@ module Elasticsearch
             perform_request(method, path, params, body).body
           end
         end
+
+        # Register this action with its valid params when the module is loaded.
+        #
+        # @since 6.1.1
+        ParamsRegistry.register(:delete, [
+            :timeout,
+            :master_timeout,
+            :ignore_unavailable,
+            :allow_no_indices,
+            :expand_wildcards ].freeze)
       end
     end
   end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/delete_alias.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/delete_alias.rb
@@ -20,16 +20,19 @@ module Elasticsearch
         def delete_alias(arguments={})
           raise ArgumentError, "Required argument 'index' missing" unless arguments[:index]
           raise ArgumentError, "Required argument 'name' missing"  unless arguments[:name]
-          valid_params = [ :timeout ]
-
           method = HTTP_DELETE
           path   = Utils.__pathify Utils.__escape(arguments[:index]), '_alias', Utils.__escape(arguments[:name])
 
-          params = Utils.__validate_and_extract_params arguments, valid_params
+          params = Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
           body   = nil
 
           perform_request(method, path, params, body).body
         end
+
+        # Register this action with its valid params when the module is loaded.
+        #
+        # @since 6.1.1
+        ParamsRegistry.register(:delete, [ :timeout ].freeze)
       end
     end
   end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/delete_alias.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/delete_alias.rb
@@ -32,7 +32,7 @@ module Elasticsearch
         # Register this action with its valid params when the module is loaded.
         #
         # @since 6.1.1
-        ParamsRegistry.register(:delete, [ :timeout ].freeze)
+        ParamsRegistry.register(:delete_alias, [ :timeout ].freeze)
       end
     end
   end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/delete_template.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/delete_template.rb
@@ -20,12 +20,10 @@ module Elasticsearch
         #
         def delete_template(arguments={})
           raise ArgumentError, "Required argument 'name' missing" unless arguments[:name]
-          valid_params = [ :timeout ]
-
           method = HTTP_DELETE
           path   = Utils.__pathify '_template', Utils.__escape(arguments[:name])
 
-          params = Utils.__validate_and_extract_params arguments, valid_params
+          params = Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
           body = nil
 
           if Array(arguments[:ignore]).include?(404)
@@ -34,6 +32,11 @@ module Elasticsearch
             perform_request(method, path, params, body).body
           end
         end
+
+        # Register this action with its valid params when the module is loaded.
+        #
+        # @since 6.1.1
+        ParamsRegistry.register(:delete_template, [ :timeout ].freeze)
       end
     end
   end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/exists.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/exists.rb
@@ -28,26 +28,26 @@ module Elasticsearch
         #
         def exists(arguments={})
           raise ArgumentError, "Required argument 'index' missing" unless arguments[:index]
-
-          valid_params = [
-            :ignore_indices,
-            :ignore_unavailable,
-            :allow_no_indices,
-            :expand_wildcards,
-            :local
-          ]
-
           method = HTTP_HEAD
           path   = Utils.__listify(arguments[:index])
-          params = Utils.__validate_and_extract_params arguments, valid_params
+          params = Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
           body   = nil
 
           Utils.__rescue_from_not_found do
             perform_request(method, path, params, body).status == 200 ? true : false
           end
         end
-
         alias_method :exists?, :exists
+
+        # Register this action with its valid params when the module is loaded.
+        #
+        # @since 6.1.1
+        ParamsRegistry.register(:exists, [
+            :ignore_indices,
+            :ignore_unavailable,
+            :allow_no_indices,
+            :expand_wildcards,
+            :local ].freeze)
       end
     end
   end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/exists_alias.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/exists_alias.rb
@@ -26,26 +26,27 @@ module Elasticsearch
         # @see http://www.elasticsearch.org/guide/reference/api/admin-indices-aliases/
         #
         def exists_alias(arguments={})
-          valid_params = [
-            :ignore_indices,
-            :ignore_unavailable,
-            :allow_no_indices,
-            :expand_wildcards,
-            :local
-          ]
-
           method = HTTP_HEAD
           path   = Utils.__pathify Utils.__listify(arguments[:index]), '_alias', Utils.__escape(arguments[:name])
 
-          params = Utils.__validate_and_extract_params arguments, valid_params
+          params = Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
           body = nil
 
           Utils.__rescue_from_not_found do
             perform_request(method, path, params, body).status == 200 ? true : false
           end
         end
-
         alias_method :exists_alias?, :exists_alias
+
+        # Register this action with its valid params when the module is loaded.
+        #
+        # @since 6.1.1
+        ParamsRegistry.register(:exists_alias, [
+            :ignore_indices,
+            :ignore_unavailable,
+            :allow_no_indices,
+            :expand_wildcards,
+            :local ].freeze)
       end
     end
   end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/exists_template.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/exists_template.rb
@@ -15,20 +15,22 @@ module Elasticsearch
         #
         def exists_template(arguments={})
           raise ArgumentError, "Required argument 'name' missing" unless arguments[:name]
-          valid_params = [ :local, :master_timeout ]
-
           method = HTTP_HEAD
           path   = Utils.__pathify '_template', Utils.__escape(arguments[:name])
 
-          params = Utils.__validate_and_extract_params arguments, valid_params
+          params = Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
           body = nil
 
           Utils.__rescue_from_not_found do
             perform_request(method, path, params, body).status == 200 ? true : false
           end
         end
-
         alias_method :exists_template?, :exists_template
+
+        # Register this action with its valid params when the module is loaded.
+        #
+        # @since 6.1.1
+        ParamsRegistry.register(:exists_template, [ :local, :master_timeout ].freeze)
       end
     end
   end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/exists_type.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/exists_type.rb
@@ -27,26 +27,27 @@ module Elasticsearch
         def exists_type(arguments={})
           raise ArgumentError, "Required argument 'index' missing" unless arguments[:index]
           raise ArgumentError, "Required argument 'type' missing" unless arguments[:type]
-          valid_params = [
-            :ignore_indices,
-            :ignore_unavailable,
-            :allow_no_indices,
-            :expand_wildcards,
-            :local
-          ]
-
           method = HTTP_HEAD
           path   = Utils.__pathify Utils.__listify(arguments[:index]), '_mapping', Utils.__escape(arguments[:type])
 
-          params = Utils.__validate_and_extract_params arguments, valid_params
+          params = Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
           body = nil
 
           Utils.__rescue_from_not_found do
             perform_request(method, path, params, body).status == 200 ? true : false
           end
         end
-
         alias_method :exists_type?, :exists_type
+
+        # Register this action with its valid params when the module is loaded.
+        #
+        # @since 6.1.1
+        ParamsRegistry.register(:exists_type, [
+            :ignore_indices,
+            :ignore_unavailable,
+            :allow_no_indices,
+            :expand_wildcards,
+            :local ].freeze)
       end
     end
   end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/flush.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/flush.rb
@@ -24,21 +24,24 @@ module Elasticsearch
         # @see http://www.elasticsearch.org/guide/reference/api/admin-indices-flush/
         #
         def flush(arguments={})
-          valid_params = [
-            :force,
-            :wait_if_ongoing,
-            :ignore_unavailable,
-            :allow_no_indices,
-            :expand_wildcards ]
-
           method = HTTP_POST
           path   = Utils.__pathify Utils.__listify(arguments[:index]), '_flush'
 
-          params = Utils.__validate_and_extract_params arguments, valid_params
+          params = Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
           body = nil
 
           perform_request(method, path, params, body).body
         end
+
+        # Register this action with its valid params when the module is loaded.
+        #
+        # @since 6.1.1
+        ParamsRegistry.register(:flush, [
+            :force,
+            :wait_if_ongoing,
+            :ignore_unavailable,
+            :allow_no_indices,
+            :expand_wildcards ].freeze)
       end
     end
   end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/flush_synced.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/flush_synced.rb
@@ -11,16 +11,10 @@ module Elasticsearch
         # @see http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-flush.html
         #
         def flush_synced(arguments={})
-          valid_params = [
-            :ignore_unavailable,
-            :allow_no_indices,
-            :expand_wildcards
-          ]
-
           method = HTTP_POST
           path   = Utils.__pathify Utils.__listify(arguments[:index]), '_flush/synced'
 
-          params = Utils.__validate_and_extract_params arguments, valid_params
+          params = Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
           body   = nil
 
           if Array(arguments[:ignore]).include?(404)
@@ -29,6 +23,14 @@ module Elasticsearch
             perform_request(method, path, params, body).body
           end
         end
+
+        # Register this action with its valid params when the module is loaded.
+        #
+        # @since 6.1.1
+        ParamsRegistry.register(:flush_synced, [
+            :ignore_unavailable,
+            :allow_no_indices,
+            :expand_wildcards ].freeze)
       end
     end
   end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/forcemerge.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/forcemerge.rb
@@ -42,20 +42,22 @@ module Elasticsearch
         # @see http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-forcemerge.html
         #
         def forcemerge(arguments={})
-          valid_params = [
-            :max_num_segments,
-            :only_expunge_deletes,
-            :flush
-          ]
-
           method = HTTP_POST
           path   = Utils.__pathify Utils.__listify(arguments[:index]), '_forcemerge'
 
-          params = Utils.__validate_and_extract_params arguments, valid_params
+          params = Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
           body = nil
 
           perform_request(method, path, params, body).body
         end
+
+        # Register this action with its valid params when the module is loaded.
+        #
+        # @since 6.1.1
+        ParamsRegistry.register(:forcemerge, [
+            :max_num_segments,
+            :only_expunge_deletes,
+            :flush ].freeze)
       end
     end
   end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/get.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/get.rb
@@ -25,25 +25,27 @@ module Elasticsearch
         #
         def get(arguments={})
           raise ArgumentError, "Required argument 'index' missing" unless arguments[:index]
+          method = HTTP_GET
 
-          valid_params = [
+          path   = Utils.__pathify Utils.__listify(arguments[:index]), Utils.__listify(arguments.delete(:feature))
+
+          params = Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
+          body = nil
+
+          perform_request(method, path, params, body).body
+        end
+
+        # Register this action with its valid params when the module is loaded.
+        #
+        # @since 6.1.1
+        ParamsRegistry.register(:get, [
             :local,
             :ignore_unavailable,
             :allow_no_indices,
             :expand_wildcards,
             :flat_settings,
             :human,
-            :include_defaults ]
-
-          method = HTTP_GET
-
-          path   = Utils.__pathify Utils.__listify(arguments[:index]), Utils.__listify(arguments.delete(:feature))
-
-          params = Utils.__validate_and_extract_params arguments, valid_params
-          body = nil
-
-          perform_request(method, path, params, body).body
-        end
+            :include_defaults ].freeze)
       end
     end
   end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/get_alias.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/get_alias.rb
@@ -30,22 +30,24 @@ module Elasticsearch
         # @see http://www.elasticsearch.org/guide/reference/api/admin-indices-aliases/
         #
         def get_alias(arguments={})
-          valid_params = [
-            :ignore_indices,
-            :ignore_unavailable,
-            :allow_no_indices,
-            :expand_wildcards,
-            :local
-          ]
-
           method = HTTP_GET
           path   = Utils.__pathify Utils.__listify(arguments[:index]), '_alias', Utils.__escape(arguments[:name])
 
-          params = Utils.__validate_and_extract_params arguments, valid_params
+          params = Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
           body   = nil
 
           perform_request(method, path, params, body).body
         end
+
+        # Register this action with its valid params when the module is loaded.
+        #
+        # @since 6.1.1
+        ParamsRegistry.register(:get_alias, [
+            :ignore_indices,
+            :ignore_unavailable,
+            :allow_no_indices,
+            :expand_wildcards,
+            :local ].freeze)
       end
     end
   end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/get_aliases.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/get_aliases.rb
@@ -18,16 +18,19 @@ module Elasticsearch
         # @see http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/indices-aliases.html
         #
         def get_aliases(arguments={})
-          valid_params = [ :timeout, :local ]
-
           method = HTTP_GET
           path   = Utils.__pathify Utils.__listify(arguments[:index]), '_aliases', Utils.__listify(arguments[:name])
 
-          params = Utils.__validate_and_extract_params arguments, valid_params
+          params = Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
           body   = nil
 
           perform_request(method, path, params, body).body
         end
+
+        # Register this action with its valid params when the module is loaded.
+        #
+        # @since 6.1.1
+        ParamsRegistry.register(:get_aliases, [ :timeout, :local ].freeze)
       end
     end
   end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/get_field_mapping.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/get_field_mapping.rb
@@ -35,18 +35,8 @@ module Elasticsearch
         #
         def get_field_mapping(arguments={})
           arguments = arguments.clone
-
           fields = arguments.delete(:field) || arguments.delete(:fields)
           raise ArgumentError, "Required argument 'field' missing" unless fields
-
-          valid_params = [
-            :include_defaults,
-            :ignore_indices,
-            :ignore_unavailable,
-            :allow_no_indices,
-            :expand_wildcards
-          ]
-
           method = HTTP_GET
           path   = Utils.__pathify(
                      Utils.__listify(arguments[:index]),
@@ -55,11 +45,21 @@ module Elasticsearch
                      'field',
                      Utils.__listify(fields)
                    )
-          params = Utils.__validate_and_extract_params arguments, valid_params
+          params = Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
           body   = nil
 
           perform_request(method, path, params, body).body
         end
+
+        # Register this action with its valid params when the module is loaded.
+        #
+        # @since 6.1.1
+        ParamsRegistry.register(:get_field_mapping, [
+            :include_defaults,
+            :ignore_indices,
+            :ignore_unavailable,
+            :allow_no_indices,
+            :expand_wildcards ].freeze)
       end
     end
   end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/get_mapping.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/get_mapping.rb
@@ -34,23 +34,25 @@ module Elasticsearch
         # @see http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/indices-get-mapping.html
         #
         def get_mapping(arguments={})
-          valid_params = [
-            :ignore_indices,
-            :ignore_unavailable,
-            :allow_no_indices,
-            :expand_wildcards,
-            :local
-          ]
-
           method = HTTP_GET
           path   = Utils.__pathify Utils.__listify(arguments[:index]),
                                    '_mapping',
                                    Utils.__listify(arguments[:type])
-          params = Utils.__validate_and_extract_params arguments, valid_params
+          params = Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
           body = nil
 
           perform_request(method, path, params, body).body
         end
+
+        # Register this action with its valid params when the module is loaded.
+        #
+        # @since 6.1.1
+        ParamsRegistry.register(:get_mapping, [
+            :ignore_indices,
+            :ignore_unavailable,
+            :allow_no_indices,
+            :expand_wildcards,
+            :local ].freeze)
       end
     end
   end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/get_settings.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/get_settings.rb
@@ -42,7 +42,22 @@ module Elasticsearch
         # @see http://www.elasticsearch.org/guide/reference/api/admin-indices-get-settings/
         #
         def get_settings(arguments={})
-          valid_params = [
+          method = HTTP_GET
+          path   = Utils.__pathify Utils.__listify(arguments[:index]),
+                                   Utils.__listify(arguments[:type]),
+                                   arguments.delete(:prefix),
+                                   '_settings',
+                                   Utils.__escape(arguments[:name])
+          params = Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
+          body   = nil
+
+          perform_request(method, path, params, body).body
+        end
+
+        # Register this action with its valid params when the module is loaded.
+        #
+        # @since 6.1.1
+        ParamsRegistry.register(:get_settings, [
             :prefix,
             :ignore_indices,
             :ignore_unavailable,
@@ -50,20 +65,7 @@ module Elasticsearch
             :allow_no_indices,
             :expand_wildcards,
             :flat_settings,
-            :local
-          ]
-
-          method = HTTP_GET
-          path   = Utils.__pathify Utils.__listify(arguments[:index]),
-                                   Utils.__listify(arguments[:type]),
-                                   arguments.delete(:prefix),
-                                   '_settings',
-                                   Utils.__escape(arguments[:name])
-          params = Utils.__validate_and_extract_params arguments, valid_params
-          body   = nil
-
-          perform_request(method, path, params, body).body
-        end
+            :local ].freeze)
       end
     end
   end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/get_template.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/get_template.rb
@@ -24,16 +24,19 @@ module Elasticsearch
         # @see http://www.elasticsearch.org/guide/reference/api/admin-indices-templates/
         #
         def get_template(arguments={})
-          valid_params = [ :flat_settings, :local, :master_timeout ]
-
           method = HTTP_GET
           path   = Utils.__pathify '_template', Utils.__escape(arguments[:name])
 
-          params = Utils.__validate_and_extract_params arguments, valid_params
+          params = Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
           body   = arguments[:body]
 
           perform_request(method, path, params, body).body
         end
+
+        # Register this action with its valid params when the module is loaded.
+        #
+        # @since 6.1.1
+        ParamsRegistry.register(:get_template, [ :flat_settings, :local, :master_timeout ].freeze)
       end
     end
   end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/get_warmer.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/get_warmer.rb
@@ -39,21 +39,23 @@ module Elasticsearch
         # @see http://www.elasticsearch.org/guide/reference/api/admin-indices-warmers/
         #
         def get_warmer(arguments={})
-          valid_params = [
-            :ignore_indices,
-            :ignore_unavailable,
-            :allow_no_indices,
-            :expand_wildcards,
-            :local
-          ]
-
           method = HTTP_GET
           path   = Utils.__pathify( Utils.__listify(arguments[:index]), '_warmer', Utils.__escape(arguments[:name]) )
-          params = Utils.__validate_and_extract_params arguments, valid_params
+          params = Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
           body   = nil
 
           perform_request(method, path, params, body).body
         end
+
+        # Register this action with its valid params when the module is loaded.
+        #
+        # @since 6.1.1
+        ParamsRegistry.register(:get_warmer, [
+            :ignore_indices,
+            :ignore_unavailable,
+            :allow_no_indices,
+            :expand_wildcards,
+            :local ].freeze)
       end
     end
   end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/open.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/open.rb
@@ -27,24 +27,25 @@ module Elasticsearch
         #
         def open(arguments={})
           raise ArgumentError, "Required argument 'index' missing" unless arguments[:index]
+          method = HTTP_POST
+          path   = Utils.__pathify Utils.__escape(arguments[:index]), '_open'
 
-          valid_params = [
+          params = Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
+          body = nil
+
+          perform_request(method, path, params, body).body
+        end
+
+        # Register this action with its valid params when the module is loaded.
+        #
+        # @since 6.1.1
+        ParamsRegistry.register(:open, [
             :ignore_indices,
             :ignore_unavailable,
             :allow_no_indices,
             :expand_wildcards,
             :timeout,
-            :wait_for_active_shards
-          ]
-
-          method = HTTP_POST
-          path   = Utils.__pathify Utils.__escape(arguments[:index]), '_open'
-
-          params = Utils.__validate_and_extract_params arguments, valid_params
-          body = nil
-
-          perform_request(method, path, params, body).body
-        end
+            :wait_for_active_shards ].freeze)
       end
     end
   end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/optimize.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/optimize.rb
@@ -46,7 +46,19 @@ module Elasticsearch
         # @see http://www.elasticsearch.org/guide/reference/api/admin-indices-optimize/
         #
         def optimize(arguments={})
-          valid_params = [
+          method = HTTP_POST
+          path   = Utils.__pathify Utils.__listify(arguments[:index]), '_optimize'
+
+          params = Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
+          body = nil
+
+          perform_request(method, path, params, body).body
+        end
+
+        # Register this action with its valid params when the module is loaded.
+        #
+        # @since 6.1.1
+        ParamsRegistry.register(:optimize, [
             :ignore_indices,
             :ignore_unavailable,
             :allow_no_indices,
@@ -58,16 +70,7 @@ module Elasticsearch
             :only_expunge_deletes,
             :operation_threading,
             :refresh,
-            :wait_for_merge ]
-
-          method = HTTP_POST
-          path   = Utils.__pathify Utils.__listify(arguments[:index]), '_optimize'
-
-          params = Utils.__validate_and_extract_params arguments, valid_params
-          body = nil
-
-          perform_request(method, path, params, body).body
-        end
+            :wait_for_merge ].freeze)
       end
     end
   end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/params_registry.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/params_registry.rb
@@ -1,0 +1,44 @@
+module Elasticsearch
+  module API
+    module Indices
+      module Actions
+        module ParamsRegistry
+
+          extend self
+
+          # A Mapping of all the actions to their list of valid params.
+          #
+          # @since 6.1.1
+          PARAMS = {}
+
+          # Register an action with its list of valid params.
+          #
+          # @example Register the action.
+          #   ParamsRegistry.register(:benchmark, [ :verbose ])
+          #
+          # @param [ Symbol ] action The action to register.
+          # @param [ Array[Symbol] ] valid_params The list of valid params.
+          #
+          # @since 6.1.1
+          def register(action, valid_params)
+            PARAMS[action.to_sym] = valid_params
+          end
+
+          # Get the list of valid params for a given action.
+          #
+          # @example Get the list of valid params.
+          #   ParamsRegistry.get(:benchmark)
+          #
+          # @param [ Symbol ] action The action.
+          #
+          # @return [ Array<Symbol> ] The list of valid params for the action.
+          #
+          # @since 6.1.1
+          def get(action)
+            PARAMS.fetch(action, [])
+          end
+        end
+      end
+    end
+  end
+end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/put_alias.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/put_alias.rb
@@ -26,8 +26,6 @@ module Elasticsearch
         def put_alias(arguments={})
           raise ArgumentError, "Required argument 'index' missing"  unless arguments[:index]
           raise ArgumentError, "Required argument 'name' missing"  unless arguments[:name]
-          valid_params = [ :timeout ]
-
           method = HTTP_PUT
           path   = Utils.__pathify Utils.__listify(arguments[:index]), '_alias', Utils.__escape(arguments[:name])
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/put_alias.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/put_alias.rb
@@ -31,11 +31,16 @@ module Elasticsearch
           method = HTTP_PUT
           path   = Utils.__pathify Utils.__listify(arguments[:index]), '_alias', Utils.__escape(arguments[:name])
 
-          params = Utils.__validate_and_extract_params arguments, valid_params
+          params = Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
           body   = arguments[:body]
 
           perform_request(method, path, params, body).body
         end
+
+        # Register this action with its valid params when the module is loaded.
+        #
+        # @since 6.1.1
+        ParamsRegistry.register(:put_alias, [ :timeout ].freeze)
       end
     end
   end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/put_mapping.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/put_mapping.rb
@@ -50,8 +50,19 @@ module Elasticsearch
         def put_mapping(arguments={})
           raise ArgumentError, "Required argument 'type' missing"  unless arguments[:type]
           raise ArgumentError, "Required argument 'body' missing"  unless arguments[:body]
+          method = HTTP_PUT
+          path   = Utils.__pathify Utils.__listify(arguments[:index]), '_mapping', Utils.__escape(arguments[:type])
 
-          valid_params = [
+          params = Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
+          body   = arguments[:body]
+
+          perform_request(method, path, params, body).body
+        end
+
+        # Register this action with its valid params when the module is loaded.
+        #
+        # @since 6.1.1
+        ParamsRegistry.register(:put_mapping, [
             :ignore_conflicts,
             :ignore_indices,
             :ignore_unavailable,
@@ -59,17 +70,7 @@ module Elasticsearch
             :expand_wildcards,
             :update_all_types,
             :master_timeout,
-            :timeout
-          ]
-
-          method = HTTP_PUT
-          path   = Utils.__pathify Utils.__listify(arguments[:index]), '_mapping', Utils.__escape(arguments[:type])
-
-          params = Utils.__validate_and_extract_params arguments, valid_params
-          body   = arguments[:body]
-
-          perform_request(method, path, params, body).body
-        end
+            :timeout ].freeze)
       end
     end
   end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/put_settings.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/put_settings.rb
@@ -47,8 +47,18 @@ module Elasticsearch
         #
         def put_settings(arguments={})
           raise ArgumentError, "Required argument 'body' missing" unless arguments[:body]
+          method = HTTP_PUT
+          path   = Utils.__pathify Utils.__listify(arguments[:index]), '_settings'
+          params = Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
+          body   = arguments[:body]
 
-          valid_params = [
+          perform_request(method, path, params, body).body
+        end
+
+        # Register this action with its valid params when the module is loaded.
+        #
+        # @since 6.1.1
+        ParamsRegistry.register(:put_settings, [
             :ignore_indices,
             :ignore_unavailable,
             :include_defaults,
@@ -56,16 +66,7 @@ module Elasticsearch
             :expand_wildcards,
             :preserve_existing,
             :master_timeout,
-            :flat_settings
-          ]
-
-          method = HTTP_PUT
-          path   = Utils.__pathify Utils.__listify(arguments[:index]), '_settings'
-          params = Utils.__validate_and_extract_params arguments, valid_params
-          body   = arguments[:body]
-
-          perform_request(method, path, params, body).body
-        end
+            :flat_settings ].freeze)
       end
     end
   end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/put_template.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/put_template.rb
@@ -24,16 +24,19 @@ module Elasticsearch
         def put_template(arguments={})
           raise ArgumentError, "Required argument 'name' missing" unless arguments[:name]
           raise ArgumentError, "Required argument 'body' missing" unless arguments[:body]
-          valid_params = [ :create, :order, :timeout ]
-
           method = HTTP_PUT
           path   = Utils.__pathify '_template', Utils.__escape(arguments[:name])
 
-          params = Utils.__validate_and_extract_params arguments, valid_params
+          params = Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
           body   = arguments[:body]
 
           perform_request(method, path, params, body).body
         end
+
+        # Register this action with its valid params when the module is loaded.
+        #
+        # @since 6.1.1
+        ParamsRegistry.register(:put_template, [ :create, :order, :timeout ].freeze)
       end
     end
   end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/put_warmer.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/put_warmer.rb
@@ -40,24 +40,25 @@ module Elasticsearch
         def put_warmer(arguments={})
           raise ArgumentError, "Required argument 'name' missing"  unless arguments[:name]
           raise ArgumentError, "Required argument 'body' missing"  unless arguments[:body]
-
-          valid_params = [
-            :ignore_indices,
-            :ignore_unavailable,
-            :allow_no_indices,
-            :expand_wildcards
-          ]
-
           method = HTTP_PUT
           path   = Utils.__pathify( Utils.__listify(arguments[:index]),
                                     Utils.__listify(arguments[:type]),
                                     '_warmer',
                                     Utils.__listify(arguments[:name]) )
-          params = Utils.__validate_and_extract_params arguments, valid_params
+          params = Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
           body   = arguments[:body]
 
           perform_request(method, path, params, body).body
         end
+
+        # Register this action with its valid params when the module is loaded.
+        #
+        # @since 6.1.1
+        ParamsRegistry.register(:put_warmer, [
+            :ignore_indices,
+            :ignore_unavailable,
+            :allow_no_indices,
+            :expand_wildcards ].freeze)
       end
     end
   end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/recovery.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/recovery.rb
@@ -25,17 +25,21 @@ module Elasticsearch
         # @see http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/indices-recovery.html
         #
         def recovery(arguments={})
-          valid_params = [
-            :detailed,
-            :active_only,
-            :human ]
           method = HTTP_GET
           path   = Utils.__pathify Utils.__listify(arguments[:index]), '_recovery'
-          params = Utils.__validate_and_extract_params arguments, valid_params
+          params = Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
           body   = nil
 
           perform_request(method, path, params, body).body
         end
+
+        # Register this action with its valid params when the module is loaded.
+        #
+        # @since 6.1.1
+        ParamsRegistry.register(:recovery, [
+            :detailed,
+            :active_only,
+            :human ].freeze)
       end
     end
   end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/refresh.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/refresh.rb
@@ -33,21 +33,23 @@ module Elasticsearch
         # @see http://www.elasticsearch.org/guide/reference/api/admin-indices-refresh/
         #
         def refresh(arguments={})
-          valid_params = [
-            :ignore_indices,
-            :ignore_unavailable,
-            :allow_no_indices,
-            :expand_wildcards
-          ]
-
           method = HTTP_POST
           path   = Utils.__pathify Utils.__listify(arguments[:index]), '_refresh'
 
-          params = Utils.__validate_and_extract_params arguments, valid_params
+          params = Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
           body   = nil
 
           perform_request(method, path, params, body).body
         end
+
+        # Register this action with its valid params when the module is loaded.
+        #
+        # @since 6.1.1
+        ParamsRegistry.register(:refresh, [
+            :ignore_indices,
+            :ignore_unavailable,
+            :allow_no_indices,
+            :expand_wildcards ].freeze)
       end
     end
   end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/rollover.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/rollover.rb
@@ -18,25 +18,25 @@ module Elasticsearch
         #
         def rollover(arguments={})
           raise ArgumentError, "Required argument 'alias' missing" unless arguments[:alias]
-
-          valid_params = [
-            :wait_for_active_shards,
-            :timeout,
-            :master_timeout,
-            :dry_run ]
-
           arguments = arguments.clone
-
           source = arguments.delete(:alias)
           target = arguments.delete(:new_index)
-
           method = HTTP_POST
           path   = Utils.__pathify Utils.__escape(source), '_rollover', Utils.__escape(target)
-          params = Utils.__validate_and_extract_params arguments, valid_params
+          params = Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
           body   = arguments[:body]
 
           perform_request(method, path, params, body).body
         end
+
+        # Register this action with its valid params when the module is loaded.
+        #
+        # @since 6.1.1
+        ParamsRegistry.register(:rollover, [
+            :wait_for_active_shards,
+            :timeout,
+            :master_timeout,
+            :dry_run ].freeze)
       end
     end
   end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/segments.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/segments.rb
@@ -24,22 +24,24 @@ module Elasticsearch
         # @see http://elasticsearch.org/guide/reference/api/admin-indices-segments/
         #
         def segments(arguments={})
-          valid_params = [
-            :ignore_indices,
-            :ignore_unavailable,
-            :allow_no_indices,
-            :expand_wildcards,
-            :verbose
-          ]
-
           method = HTTP_GET
           path   = Utils.__pathify Utils.__listify(arguments[:index]), '_segments'
 
-          params = Utils.__validate_and_extract_params arguments, valid_params
+          params = Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
           body   = nil
 
           perform_request(method, path, params, body).body
         end
+
+        # Register this action with its valid params when the module is loaded.
+        #
+        # @since 6.1.1
+        ParamsRegistry.register(:segments, [
+            :ignore_indices,
+            :ignore_unavailable,
+            :allow_no_indices,
+            :expand_wildcards,
+            :verbose ].freeze)
       end
     end
   end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/shard_stores.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/shard_stores.rb
@@ -15,19 +15,23 @@ module Elasticsearch
         # @see http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-shards-stores.html
         #
         def shard_stores(arguments={})
-          valid_params = [
-            :status,
-            :ignore_unavailable,
-            :allow_no_indices,
-            :expand_wildcards,
-            :operation_threading ]
           method = 'GET'
           path   = Utils.__pathify Utils.__escape(arguments[:index]), "_shard_stores"
-          params = Utils.__validate_and_extract_params arguments, valid_params
+          params = Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
           body   = nil
 
           perform_request(method, path, params, body).body
         end
+
+        # Register this action with its valid params when the module is loaded.
+        #
+        # @since 6.1.1
+        ParamsRegistry.register(:shard_stores, [
+            :status,
+            :ignore_unavailable,
+            :allow_no_indices,
+            :expand_wildcards,
+            :operation_threading ].freeze)
       end
     end
   end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/shrink.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/shrink.rb
@@ -19,26 +19,26 @@ module Elasticsearch
         def shrink(arguments={})
           raise ArgumentError, "Required argument 'index' missing" unless arguments[:index]
           raise ArgumentError, "Required argument 'target' missing" unless arguments[:target]
-
-          valid_params = [
-            :wait_for_active_shards,
-            :wait_for_no_relocating_shards,
-            :timeout,
-            :master_timeout
-          ]
-
           arguments = arguments.clone
-
           source = arguments.delete(:index)
           target = arguments.delete(:target)
 
           method = HTTP_PUT
           path   = Utils.__pathify(source, '_shrink', target)
-          params = Utils.__validate_and_extract_params arguments, valid_params
+          params = Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
           body   = arguments[:body]
 
           perform_request(method, path, params, body).body
         end
+
+        # Register this action with its valid params when the module is loaded.
+        #
+        # @since 6.1.1
+        ParamsRegistry.register(:shrink, [
+            :wait_for_active_shards,
+            :wait_for_no_relocating_shards,
+            :timeout,
+            :master_timeout ].freeze)
       end
     end
   end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/snapshot_index.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/snapshot_index.rb
@@ -22,21 +22,22 @@ module Elasticsearch
         # @see http://www.elasticsearch.org/guide/reference/api/admin-indices-gateway-snapshot/
         #
         def snapshot_index(arguments={})
-          valid_params = [
-            :ignore_indices,
-            :ignore_unavailable,
-            :allow_no_indices,
-            :expand_wildcards
-          ]
-
           method = HTTP_POST
           path   = Utils.__pathify Utils.__listify(arguments[:index]), '_gateway/snapshot'
-
-          params = Utils.__validate_and_extract_params arguments, valid_params
+          params = Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
           body   = nil
 
           perform_request(method, path, params, body).body
         end
+
+        # Register this action with its valid params when the module is loaded.
+        #
+        # @since 6.1.1
+        ParamsRegistry.register(:snapshot_index, [
+            :ignore_indices,
+            :ignore_unavailable,
+            :allow_no_indices,
+            :expand_wildcards ].freeze)
       end
     end
   end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/split.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/split.rb
@@ -18,24 +18,26 @@ module Elasticsearch
         def split(arguments={})
           raise ArgumentError, "Required argument 'index' missing" unless arguments[:index]
           raise ArgumentError, "Required argument 'target' missing" unless arguments[:target]
-          valid_params = [
-              :copy_settings,
-              :timeout,
-              :master_timeout,
-              :wait_for_active_shards ]
-
           arguments = arguments.clone
-
           source = arguments.delete(:index)
           target = arguments.delete(:target)
 
           method = Elasticsearch::API::HTTP_PUT
           path   = Utils.__pathify Utils.__escape(source), '_split', Utils.__escape(target)
-          params = Elasticsearch::API::Utils.__validate_and_extract_params arguments, valid_params
+          params = Elasticsearch::API::Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
           body   = arguments[:body]
 
           perform_request(method, path, params, body).body
         end
+
+        # Register this action with its valid params when the module is loaded.
+        #
+        # @since 6.1.1
+        ParamsRegistry.register(:split, [
+            :copy_settings,
+            :timeout,
+            :master_timeout,
+            :wait_for_active_shards ].freeze)
       end
     end
   end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/stats.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/stats.rb
@@ -76,7 +76,39 @@ module Elasticsearch
         # @see http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/indices-stats.html
         #
         def stats(arguments={})
-          valid_parts = [
+          method = HTTP_GET
+          parts  = Utils.__extract_parts arguments, ParamsRegistry.get(:stats_parts)
+          path   = Utils.__pathify Utils.__listify(arguments[:index]), '_stats', Utils.__listify(parts)
+
+          params = Utils.__validate_and_extract_params arguments, ParamsRegistry.get(:stats_params)
+          params[:fields] = Utils.__listify(params[:fields], :escape => false) if params[:fields]
+          params[:groups] = Utils.__listify(params[:groups], :escape => false) if params[:groups]
+
+          body   = nil
+
+          perform_request(method, path, params, body).body
+        end
+
+        # Register this action with its valid params when the module is loaded.
+        #
+        # @since 6.1.1
+        ParamsRegistry.register(:stats_params, [
+            :fields,
+            :completion_fields,
+            :fielddata_fields,
+            :groups,
+            :level,
+            :types,
+            :ignore_indices,
+            :ignore_unavailable,
+            :allow_no_indices,
+            :expand_wildcards,
+            :include_segment_file_sizes ].freeze)
+
+        # Register this action with its valid parts when the module is loaded.
+        #
+        # @since 6.1.1
+        ParamsRegistry.register(:stats_parts, [
             :docs,
             :fielddata,
             :filter_cache,
@@ -89,34 +121,7 @@ module Elasticsearch
             :search,
             :suggest,
             :store,
-            :warmer ]
-
-          valid_params = [
-            :fields,
-            :completion_fields,
-            :fielddata_fields,
-            :groups,
-            :level,
-            :types,
-            :ignore_indices,
-            :ignore_unavailable,
-            :allow_no_indices,
-            :expand_wildcards,
-            :include_segment_file_sizes ]
-
-          method = HTTP_GET
-
-          parts  = Utils.__extract_parts arguments, valid_parts
-          path   = Utils.__pathify Utils.__listify(arguments[:index]), '_stats', Utils.__listify(parts)
-
-          params = Utils.__validate_and_extract_params arguments, valid_params
-          params[:fields] = Utils.__listify(params[:fields], :escape => false) if params[:fields]
-          params[:groups] = Utils.__listify(params[:groups], :escape => false) if params[:groups]
-
-          body   = nil
-
-          perform_request(method, path, params, body).body
-        end
+            :warmer ].freeze)
       end
     end
   end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/status.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/status.rb
@@ -34,18 +34,10 @@ module Elasticsearch
         # @see http://elasticsearch.org/guide/reference/api/admin-indices-status/
         #
         def status(arguments={})
-          valid_params = [
-            :ignore_indices,
-            :ignore_unavailable,
-            :allow_no_indices,
-            :expand_wildcards,
-            :recovery,
-            :snapshot ]
-
           method = HTTP_GET
           path   = Utils.__pathify Utils.__listify(arguments[:index]), '_status'
 
-          params = Utils.__validate_and_extract_params arguments, valid_params
+          params = Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
           body   = nil
 
           if Array(arguments[:ignore]).include?(404)
@@ -54,6 +46,17 @@ module Elasticsearch
             perform_request(method, path, params, body).body
           end
         end
+
+        # Register this action with its valid params when the module is loaded.
+        #
+        # @since 6.1.1
+        ParamsRegistry.register(:status, [
+            :ignore_indices,
+            :ignore_unavailable,
+            :allow_no_indices,
+            :expand_wildcards,
+            :recovery,
+            :snapshot ].freeze)
       end
     end
   end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/update_aliases.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/update_aliases.rb
@@ -32,8 +32,6 @@ module Elasticsearch
         #
         def update_aliases(arguments={})
           raise ArgumentError, "Required argument 'body' missing" unless arguments[:body]
-          valid_params = [ :timeout ]
-
           method = HTTP_POST
           path   = "_aliases"
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/update_aliases.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/update_aliases.rb
@@ -37,11 +37,16 @@ module Elasticsearch
           method = HTTP_POST
           path   = "_aliases"
 
-          params = Utils.__validate_and_extract_params arguments, valid_params
+          params = Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
           body   = arguments[:body]
 
           perform_request(method, path, params, body).body
         end
+
+        # Register this action with its valid params when the module is loaded.
+        #
+        # @since 6.1.1
+        ParamsRegistry.register(:update_aliases, [ :timeout ].freeze)
       end
     end
   end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/upgrade.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/upgrade.rb
@@ -19,19 +19,22 @@ module Elasticsearch
         # @see http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/indices-upgrade.html
         #
         def upgrade(arguments={})
-          valid_params = [
-            :ignore_unavailable,
-            :allow_no_indices,
-            :expand_wildcards,
-            :wait_for_completion ]
-
           method = HTTP_POST
           path   = "_upgrade"
-          params = Utils.__validate_and_extract_params arguments, valid_params
+          params = Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
           body   = nil
 
           perform_request(method, path, params, body).body
         end
+
+        # Register this action with its valid params when the module is loaded.
+        #
+        # @since 6.1.1
+        ParamsRegistry.register(:upgrade, [
+            :ignore_unavailable,
+            :allow_no_indices,
+            :expand_wildcards,
+            :wait_for_completion ].freeze)
       end
     end
   end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/validate_query.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/validate_query.rb
@@ -66,7 +66,21 @@ module Elasticsearch
         # @see http://www.elasticsearch.org/guide/reference/api/validate/
         #
         def validate_query(arguments={})
-          valid_params = [
+          method = HTTP_GET
+          path   = Utils.__pathify Utils.__listify(arguments[:index]),
+                                   Utils.__listify(arguments[:type]),
+                                   '_validate/query'
+
+          params = Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
+          body   = arguments[:body]
+
+          perform_request(method, path, params, body).body
+        end
+
+        # Register this action with its valid params when the module is loaded.
+        #
+        # @since 6.1.1
+        ParamsRegistry.register(:validate_query, [
             :rewrite,
             :explain,
             :ignore_unavailable,
@@ -79,18 +93,7 @@ module Elasticsearch
             :default_operator,
             :df,
             :lenient,
-            :lowercase_expanded_terms ]
-
-          method = HTTP_GET
-          path   = Utils.__pathify Utils.__listify(arguments[:index]),
-                                   Utils.__listify(arguments[:type]),
-                                   '_validate/query'
-
-          params = Utils.__validate_and_extract_params arguments, valid_params
-          body   = arguments[:body]
-
-          perform_request(method, path, params, body).body
-        end
+            :lowercase_expanded_terms ].freeze)
       end
     end
   end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/ingest/delete_pipeline.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/ingest/delete_pipeline.rb
@@ -13,16 +13,20 @@ module Elasticsearch
         #
         def delete_pipeline(arguments={})
           raise ArgumentError, "Required argument 'id' missing" unless arguments[:id]
-          valid_params = [
-            :master_timeout,
-            :timeout ]
           method = 'DELETE'
           path   = Utils.__pathify "_ingest/pipeline", Utils.__escape(arguments[:id])
-          params = Utils.__validate_and_extract_params arguments, valid_params
+          params = Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
           body   = nil
 
           perform_request(method, path, params, body).body
         end
+
+        # Register this action with its valid params when the module is loaded.
+        #
+        # @since 6.1.1
+        ParamsRegistry.register(:delete_pipeline, [
+            :master_timeout,
+            :timeout ].freeze)
       end
     end
   end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/ingest/get_pipeline.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/ingest/get_pipeline.rb
@@ -11,15 +11,18 @@ module Elasticsearch
         # @see https://www.elastic.co/guide/en/elasticsearch/plugins/master/ingest.html
         #
         def get_pipeline(arguments={})
-          valid_params = [
-            :master_timeout ]
           method = 'GET'
           path   = Utils.__pathify "_ingest/pipeline", Utils.__escape(arguments[:id])
-          params = Utils.__validate_and_extract_params arguments, valid_params
+          params = Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
           body   = nil
 
           perform_request(method, path, params, body).body
         end
+
+        # Register this action with its valid params when the module is loaded.
+        #
+        # @since 6.1.1
+        ParamsRegistry.register(:get_pipeline, [ :master_timeout ].freeze)
       end
     end
   end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/ingest/params_registry.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/ingest/params_registry.rb
@@ -1,0 +1,44 @@
+module Elasticsearch
+  module API
+    module Ingest
+      module Actions
+        module ParamsRegistry
+
+          extend self
+
+          # A Mapping of all the actions to their list of valid params.
+          #
+          # @since 6.1.1
+          PARAMS = {}
+
+          # Register an action with its list of valid params.
+          #
+          # @example Register the action.
+          #   ParamsRegistry.register(:benchmark, [ :verbose ])
+          #
+          # @param [ Symbol ] action The action to register.
+          # @param [ Array[Symbol] ] valid_params The list of valid params.
+          #
+          # @since 6.1.1
+          def register(action, valid_params)
+            PARAMS[action.to_sym] = valid_params
+          end
+
+          # Get the list of valid params for a given action.
+          #
+          # @example Get the list of valid params.
+          #   ParamsRegistry.get(:benchmark)
+          #
+          # @param [ Symbol ] action The action.
+          #
+          # @return [ Array<Symbol> ] The list of valid params for the action.
+          #
+          # @since 6.1.1
+          def get(action)
+            PARAMS.fetch(action, [])
+          end
+        end
+      end
+    end
+  end
+end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/ingest/put_pipeline.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/ingest/put_pipeline.rb
@@ -15,17 +15,21 @@ module Elasticsearch
         def put_pipeline(arguments={})
           raise ArgumentError, "Required argument 'id' missing" unless arguments[:id]
           raise ArgumentError, "Required argument 'body' missing" unless arguments[:body]
-          valid_params = [
-            :master_timeout,
-            :timeout ]
           method = 'PUT'
           path   = Utils.__pathify "_ingest/pipeline", Utils.__escape(arguments[:id])
 
-          params = Utils.__validate_and_extract_params arguments, valid_params
+          params = Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
           body   = arguments[:body]
 
           perform_request(method, path, params, body).body
         end
+
+        # Register this action with its valid params when the module is loaded.
+        #
+        # @since 6.1.1
+        ParamsRegistry.register(:put_pipeline, [
+            :master_timeout,
+            :timeout ].freeze)
       end
     end
   end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/ingest/simulate.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/ingest/simulate.rb
@@ -14,15 +14,18 @@ module Elasticsearch
         #
         def simulate(arguments={})
           raise ArgumentError, "Required argument 'body' missing" unless arguments[:body]
-          valid_params = [
-            :verbose ]
           method = 'GET'
           path   = Utils.__pathify "_ingest/pipeline", Utils.__escape(arguments[:id]), '_simulate'
-          params = Utils.__validate_and_extract_params arguments, valid_params
+          params = Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
           body   = arguments[:body]
 
           perform_request(method, path, params, body).body
         end
+
+        # Register this action with its valid params when the module is loaded.
+        #
+        # @since 6.1.1
+        ParamsRegistry.register(:simulate, [ :verbose ].freeze)
       end
     end
   end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/mget.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/mget.rb
@@ -46,8 +46,23 @@ module Elasticsearch
       #
       def mget(arguments={})
         raise ArgumentError, "Required argument 'body' missing" unless arguments[:body]
+        method = HTTP_GET
+        path   = Utils.__pathify Utils.__escape(arguments[:index]),
+                                 Utils.__escape(arguments[:type]),
+                                 '_mget'
 
-        valid_params = [
+        params = Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
+        body   = arguments[:body]
+
+        params[:fields] = Utils.__listify(params[:fields]) if params[:fields]
+
+        perform_request(method, path, params, body).body
+      end
+
+      # Register this action with its valid params when the module is loaded.
+      #
+      # @since 6.1.1
+      ParamsRegistry.register(:mget, [
           :fields,
           :parent,
           :preference,
@@ -57,20 +72,7 @@ module Elasticsearch
           :_source,
           :_source_include,
           :_source_exclude,
-          :stored_fields ]
-
-        method = HTTP_GET
-        path   = Utils.__pathify Utils.__escape(arguments[:index]),
-                                 Utils.__escape(arguments[:type]),
-                                 '_mget'
-
-        params = Utils.__validate_and_extract_params arguments, valid_params
-        body   = arguments[:body]
-
-        params[:fields] = Utils.__listify(params[:fields]) if params[:fields]
-
-        perform_request(method, path, params, body).body
-      end
+          :stored_fields ].freeze)
     end
   end
 end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/mlt.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/mlt.rb
@@ -85,8 +85,27 @@ module Elasticsearch
         raise ArgumentError, "Required argument 'index' missing" unless arguments[:index]
         raise ArgumentError, "Required argument 'type' missing"  unless arguments[:type]
         raise ArgumentError, "Required argument 'id' missing"    unless arguments[:id]
+        method = HTTP_GET
+        path   = Utils.__pathify Utils.__escape(arguments[:index]),
+                                 Utils.__escape(arguments[:type]),
+                                 Utils.__escape(arguments[:id]),
+                                 '_mlt'
 
-        valid_params = [
+        params = Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
+
+        [:mlt_fields, :search_indices, :search_types, :stop_words].each do |name|
+          params[name] = Utils.__listify(params[name]) if params[name]
+        end
+
+        body   = arguments[:body]
+
+        perform_request(method, path, params, body).body
+      end
+
+      # Register this action with its valid params when the module is loaded.
+      #
+      # @since 6.1.1
+      ParamsRegistry.register(:mlt, [
           :boost_terms,
           :max_doc_freq,
           :max_query_terms,
@@ -105,24 +124,7 @@ module Elasticsearch
           :search_source,
           :search_type,
           :search_types,
-          :stop_words ]
-
-        method = HTTP_GET
-        path   = Utils.__pathify Utils.__escape(arguments[:index]),
-                                 Utils.__escape(arguments[:type]),
-                                 Utils.__escape(arguments[:id]),
-                                 '_mlt'
-
-        params = Utils.__validate_and_extract_params arguments, valid_params
-
-        [:mlt_fields, :search_indices, :search_types, :stop_words].each do |name|
-          params[name] = Utils.__listify(params[name]) if params[name]
-        end
-
-        body   = arguments[:body]
-
-        perform_request(method, path, params, body).body
-      end
+          :stop_words ].freeze)
     end
   end
 end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/mpercolate.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/mpercolate.rb
@@ -31,16 +31,10 @@ module Elasticsearch
       #
       def mpercolate(arguments={})
         raise ArgumentError, "Required argument 'body' missing" unless arguments[:body]
-        valid_params = [
-          :ignore_unavailable,
-          :allow_no_indices,
-          :expand_wildcards,
-          :percolate_format ]
-
         method = HTTP_GET
         path   = "_mpercolate"
 
-        params = Utils.__validate_and_extract_params arguments, valid_params
+        params = Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
         body   = arguments[:body]
 
         case
@@ -54,6 +48,15 @@ module Elasticsearch
 
         perform_request(method, path, params, payload).body
       end
+
+      # Register this action with its valid params when the module is loaded.
+      #
+      # @since 6.1.1
+      ParamsRegistry.register(:mpercolate, [
+          :ignore_unavailable,
+          :allow_no_indices,
+          :expand_wildcards,
+          :percolate_format ].freeze)
     end
   end
 end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/msearch.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/msearch.rb
@@ -37,16 +37,10 @@ module Elasticsearch
       #
       def msearch(arguments={})
         raise ArgumentError, "Required argument 'body' missing" unless arguments[:body]
-
-         valid_params = [
-          :search_type,
-          :max_concurrent_searches,
-          :typed_keys ]
-
         method = HTTP_GET
         path   = Utils.__pathify( Utils.__listify(arguments[:index]), Utils.__listify(arguments[:type]), '_msearch' )
 
-        params = Utils.__validate_and_extract_params arguments, valid_params
+        params = Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
         body   = arguments[:body]
 
         case
@@ -73,6 +67,14 @@ module Elasticsearch
 
         perform_request(method, path, params, payload, {"Content-Type" => "application/x-ndjson"}).body
       end
+
+      # Register this action with its valid params when the module is loaded.
+      #
+      # @since 6.1.1
+      ParamsRegistry.register(:msearch, [
+          :search_type,
+          :max_concurrent_searches,
+          :typed_keys ].freeze)
     end
   end
 end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/msearch_template.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/msearch_template.rb
@@ -20,13 +20,11 @@ module Elasticsearch
       #
       def msearch_template(arguments={})
         raise ArgumentError, "Required argument 'body' missing" unless arguments[:body]
-
-        valid_params = [ :search_type ]
         method = HTTP_GET
         path   = Utils.__pathify Utils.__listify(arguments[:index]),
                                  Utils.__listify(arguments[:type]),
                                  '_msearch/template'
-        params = Utils.__validate_and_extract_params arguments, valid_params
+        params = Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
         body   = arguments[:body]
 
         case
@@ -40,6 +38,11 @@ module Elasticsearch
 
         perform_request(method, path, params, payload, {"Content-Type" => "application/x-ndjson"}).body
       end
+
+      # Register this action with its valid params when the module is loaded.
+      #
+      # @since 6.1.1
+      ParamsRegistry.register(:msearch_template, [ :search_type ].freeze)
     end
   end
 end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/mtermvectors.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/mtermvectors.rb
@@ -35,7 +35,28 @@ module Elasticsearch
       # @see #termvector
       #
       def mtermvectors(arguments={})
-        valid_params = [
+        ids = arguments.delete(:ids)
+
+        method = HTTP_GET
+        path   = Utils.__pathify Utils.__escape(arguments[:index]),
+                                 Utils.__escape(arguments[:type]),
+                                 '_mtermvectors'
+
+        params = Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
+
+        if ids
+          body = { :ids => ids }
+        else
+          body = arguments[:body]
+        end
+
+        perform_request(method, path, params, body).body
+      end
+
+      # Register this action with its valid params when the module is loaded.
+      #
+      # @since 6.1.1
+      ParamsRegistry.register(:mtermvectors, [
           :ids,
           :term_statistics,
           :field_statistics,
@@ -46,25 +67,7 @@ module Elasticsearch
           :preference,
           :realtime,
           :routing,
-          :parent ]
-
-        ids = arguments.delete(:ids)
-
-        method = HTTP_GET
-        path   = Utils.__pathify Utils.__escape(arguments[:index]),
-                                 Utils.__escape(arguments[:type]),
-                                 '_mtermvectors'
-
-        params = Utils.__validate_and_extract_params arguments, valid_params
-
-        if ids
-          body = { :ids => ids }
-        else
-          body = arguments[:body]
-        end
-
-        perform_request(method, path, params, body).body
-      end
+          :parent ].freeze)
     end
   end
 end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/nodes/hot_threads.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/nodes/hot_threads.rb
@@ -27,21 +27,24 @@ module Elasticsearch
         # @see http://www.elasticsearch.org/guide/reference/api/admin-cluster-nodes-hot-threads/
         #
         def hot_threads(arguments={})
-          valid_params = [
-            :interval,
-            :snapshots,
-            :threads,
-            :type,
-            :timeout ]
-
           method = HTTP_GET
           path   = Utils.__pathify '_nodes', Utils.__listify(arguments[:node_id]), 'hot_threads'
 
-          params = Utils.__validate_and_extract_params arguments, valid_params
+          params = Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
           body = nil
 
           perform_request(method, path, params, body).body
         end
+
+        # Register this action with its valid params when the module is loaded.
+        #
+        # @since 6.1.1
+        ParamsRegistry.register(:hot_threads, [
+            :interval,
+            :snapshots,
+            :threads,
+            :type,
+            :timeout ].freeze)
       end
     end
   end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/nodes/info.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/nodes/info.rb
@@ -43,8 +43,30 @@ module Elasticsearch
         def info(arguments={})
           arguments = arguments.clone
           metric    = arguments.delete(:metric)
+          method = HTTP_GET
+          if metric
+            parts = metric
+          else
+            parts = Utils.__extract_parts arguments, ParamsRegistry.get(:info_parts)
+          end
 
-          valid_parts = [
+          path   = Utils.__pathify '_nodes', Utils.__listify(arguments[:node_id]), Utils.__listify(parts)
+
+          params = Utils.__validate_and_extract_params arguments, ParamsRegistry.get(:info_params)
+          body   = nil
+
+          perform_request(method, path, params, body).body
+        end
+
+        # Register this action with its valid params when the module is loaded.
+        #
+        # @since 6.1.1
+        ParamsRegistry.register(:info_params, [ :flat_settings, :timeout ].freeze)
+
+        # Register this action with its valid parts when the module is loaded.
+        #
+        # @since 6.1.1
+        ParamsRegistry.register(:info_parts, [
             :_all,
             :http,
             :jvm,
@@ -55,25 +77,7 @@ module Elasticsearch
             :settings,
             :thread_pool,
             :transport,
-            :timeout ]
-
-          valid_params = [ :flat_settings, :timeout ]
-
-          method = HTTP_GET
-
-          if metric
-            parts = metric
-          else
-            parts = Utils.__extract_parts arguments, valid_parts
-          end
-
-          path   = Utils.__pathify '_nodes', Utils.__listify(arguments[:node_id]), Utils.__listify(parts)
-
-          params = Utils.__validate_and_extract_params arguments, valid_params
-          body   = nil
-
-          perform_request(method, path, params, body).body
-        end
+            :timeout ].freeze)
       end
     end
   end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/nodes/params_registry.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/nodes/params_registry.rb
@@ -1,0 +1,44 @@
+module Elasticsearch
+  module API
+    module Nodes
+      module Actions
+        module ParamsRegistry
+
+          extend self
+
+          # A Mapping of all the actions to their list of valid params.
+          #
+          # @since 6.1.1
+          PARAMS = {}
+
+          # Register an action with its list of valid params.
+          #
+          # @example Register the action.
+          #   ParamsRegistry.register(:benchmark, [ :verbose ])
+          #
+          # @param [ Symbol ] action The action to register.
+          # @param [ Array[Symbol] ] valid_params The list of valid params.
+          #
+          # @since 6.1.1
+          def register(action, valid_params)
+            PARAMS[action.to_sym] = valid_params
+          end
+
+          # Get the list of valid params for a given action.
+          #
+          # @example Get the list of valid params.
+          #   ParamsRegistry.get(:benchmark)
+          #
+          # @param [ Symbol ] action The action.
+          #
+          # @return [ Array<Symbol> ] The list of valid params for the action.
+          #
+          # @since 6.1.1
+          def get(action)
+            PARAMS.fetch(action, [])
+          end
+        end
+      end
+    end
+  end
+end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/nodes/shutdown.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/nodes/shutdown.rb
@@ -18,18 +18,21 @@ module Elasticsearch
         # @see http://elasticsearch.org/guide/reference/api/admin-cluster-nodes-shutdown/
         #
         def shutdown(arguments={})
-          valid_params = [
-            :delay,
-            :exit ]
-
           method = HTTP_POST
           path   = Utils.__pathify '_cluster/nodes', Utils.__listify(arguments[:node_id]), '_shutdown'
 
-          params = Utils.__validate_and_extract_params arguments, valid_params
+          params = Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
           body   = nil
 
           perform_request(method, path, params, body).body
         end
+
+        # Register this action with its valid params when the module is loaded.
+        #
+        # @since 6.1.1
+        ParamsRegistry.register(:shutdown, [
+            :delay,
+            :exit ].freeze)
       end
     end
   end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/nodes/stats.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/nodes/stats.rb
@@ -44,8 +44,29 @@ module Elasticsearch
         #
         def stats(arguments={})
           arguments = arguments.clone
+          node_id = arguments.delete(:node_id)
 
-          valid_params = [
+          path   = Utils.__pathify '_nodes',
+                                   Utils.__listify(node_id),
+                                   'stats',
+                                   Utils.__listify(arguments.delete(:metric)),
+                                   Utils.__listify(arguments.delete(:index_metric))
+
+          params = Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
+
+          [:completion_fields, :fielddata_fields, :fields, :groups, :types].each do |key|
+            params[key] = Utils.__listify(params[key]) if params[key]
+          end
+
+          body   = nil
+
+          perform_request(HTTP_GET, path, params, body).body
+        end
+
+        # Register this action with its valid params when the module is loaded.
+        #
+        # @since 6.1.1
+        ParamsRegistry.register(:stats, [
             :metric,
             :index_metric,
             :node_id,
@@ -57,26 +78,7 @@ module Elasticsearch
             :human,
             :level,
             :types,
-            :timeout ]
-
-          node_id = arguments.delete(:node_id)
-
-          path   = Utils.__pathify '_nodes',
-                                   Utils.__listify(node_id),
-                                   'stats',
-                                   Utils.__listify(arguments.delete(:metric)),
-                                   Utils.__listify(arguments.delete(:index_metric))
-
-          params = Utils.__validate_and_extract_params arguments, valid_params
-
-          [:completion_fields, :fielddata_fields, :fields, :groups, :types].each do |key|
-            params[key] = Utils.__listify(params[key]) if params[key]
-          end
-
-          body   = nil
-
-          perform_request(HTTP_GET, path, params, body).body
-        end
+            :timeout ].freeze)
       end
     end
   end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/params_registry.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/params_registry.rb
@@ -1,0 +1,42 @@
+module Elasticsearch
+  module API
+    module Actions
+      module ParamsRegistry
+
+        extend self
+
+        # A Mapping of all the actions to their list of valid params.
+        #
+        # @since 6.1.1
+        PARAMS = {}
+
+        # Register an action with its list of valid params.
+        #
+        # @example Register the action.
+        #   ParamsRegistry.register(:benchmark, [ :verbose ])
+        #
+        # @param [ Symbol ] action The action to register.
+        # @param [ Array[Symbol] ] valid_params The list of valid params.
+        #
+        # @since 6.1.1
+        def register(action, valid_params)
+          PARAMS[action.to_sym] = valid_params
+        end
+
+        # Get the list of valid params for a given action.
+        #
+        # @example Get the list of valid params.
+        #   ParamsRegistry.get(:benchmark)
+        #
+        # @param [ Symbol ] action The action.
+        #
+        # @return [ Array<Symbol> ] The list of valid params for the action.
+        #
+        # @since 6.1.1
+        def get(action)
+          PARAMS.fetch(action, [])
+        end
+      end
+    end
+  end
+end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/percolate.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/percolate.rb
@@ -42,8 +42,22 @@ module Elasticsearch
 
         raise ArgumentError, "Required argument 'index' missing" unless arguments[:index]
         raise ArgumentError, "Required argument 'type' missing"  unless arguments[:type]
+        method = HTTP_GET
+        path   = Utils.__pathify Utils.__escape(arguments[:index]),
+                                 Utils.__escape(arguments[:type]),
+                                 Utils.__escape(arguments[:id]),
+                                 '_percolate'
 
-        valid_params = [
+        params = Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
+        body   = arguments[:body]
+
+        perform_request(method, path, params, body).body
+      end
+
+      # Register this action with its valid params when the module is loaded.
+      #
+      # @since 6.1.1
+      ParamsRegistry.register(:percolate, [
           :routing,
           :preference,
           :ignore_unavailable,
@@ -53,19 +67,7 @@ module Elasticsearch
           :percolate_type,
           :percolate_format,
           :version,
-          :version_type ]
-
-        method = HTTP_GET
-        path   = Utils.__pathify Utils.__escape(arguments[:index]),
-                                 Utils.__escape(arguments[:type]),
-                                 Utils.__escape(arguments[:id]),
-                                 '_percolate'
-
-        params = Utils.__validate_and_extract_params arguments, valid_params
-        body   = arguments[:body]
-
-        perform_request(method, path, params, body).body
-      end
+          :version_type ].freeze)
     end
   end
 end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/put_script.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/put_script.rb
@@ -30,21 +30,23 @@ module Elasticsearch
       def put_script(arguments={})
         raise ArgumentError, "Required argument 'id' missing"   unless arguments[:id]
         raise ArgumentError, "Required argument 'body' missing" unless arguments[:body]
-
-        valid_params = [
-          :op_type,
-          :version,
-          :version_type ]
-
         method = HTTP_PUT
         path   = "_scripts/#{arguments.has_key?(:lang) ? "#{arguments.delete(:lang)}/" : ''}#{arguments[:id]}"
 
-        params = Utils.__validate_and_extract_params arguments, valid_params
+        params = Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
 
         body   = arguments[:body]
 
         perform_request(method, path, params, body).body
       end
+
+      # Register this action with its valid params when the module is loaded.
+      #
+      # @since 6.1.1
+      ParamsRegistry.register(:put_script, [
+          :op_type,
+          :version,
+          :version_type ].freeze)
     end
   end
 end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/reindex.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/reindex.rb
@@ -53,20 +53,24 @@ module Elasticsearch
       #
       def reindex(arguments={})
         raise ArgumentError, "Required argument 'body' missing" unless arguments[:body]
-        valid_params = [
+        method = 'POST'
+        path   = "_reindex"
+        params = Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
+        body   = arguments[:body]
+
+        perform_request(method, path, params, body).body
+      end
+
+      # Register this action with its valid params when the module is loaded.
+      #
+      # @since 6.1.1
+      ParamsRegistry.register(:reindex, [
           :refresh,
           :timeout,
           :consistency,
           :wait_for_completion,
           :requests_per_second,
-          :slices ]
-        method = 'POST'
-        path   = "_reindex"
-        params = Utils.__validate_and_extract_params arguments, valid_params
-        body   = arguments[:body]
-
-        perform_request(method, path, params, body).body
-      end
+          :slices ].freeze)
     end
   end
 end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/render_search_template.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/render_search_template.rb
@@ -15,11 +15,17 @@ module Elasticsearch
         ]
         method = 'GET'
         path   = "_render/template"
-        params = Utils.__validate_and_extract_params arguments, valid_params
+        params = Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
         body   = arguments[:body]
 
         perform_request(method, path, params, body).body
       end
+
+      # Register this action with its valid params when the module is loaded.
+      #
+      # @since 6.1.1
+      ParamsRegistry.register(:render_search_template, [
+          :id ].freeze)
     end
   end
 end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/render_search_template.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/render_search_template.rb
@@ -10,9 +10,6 @@ module Elasticsearch
       # @see http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/search-template.html
       #
       def render_search_template(arguments={})
-        valid_params = [
-          :id
-        ]
         method = 'GET'
         path   = "_render/template"
         params = Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)

--- a/elasticsearch-api/lib/elasticsearch/api/actions/scroll.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/scroll.rb
@@ -51,15 +51,18 @@ module Elasticsearch
       def scroll(arguments={})
         method = HTTP_GET
         path   = "_search/scroll"
-        valid_params = [
-          :scroll,
-          :scroll_id ]
-
-        params = Utils.__validate_and_extract_params arguments, valid_params
+        params = Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
         body   = arguments[:body]
 
         perform_request(method, path, params, body).body
       end
+
+      # Register this action with its valid params when the module is loaded.
+      #
+      # @since 6.1.1
+      ParamsRegistry.register(:scroll, [
+          :scroll,
+          :scroll_id ].freeze)
     end
   end
 end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/search_exists.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/search_exists.rb
@@ -33,7 +33,18 @@ module Elasticsearch
       # @see http://www.elastic.co/guide/en/elasticsearch/reference/master/search-exists.html
       #
       def search_exists(arguments={})
-        valid_params = [
+        method = 'POST'
+        path   = "_search/exists"
+        params = Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
+        body   = arguments[:body]
+
+        perform_request(method, path, params, body).body
+      end
+
+      # Register this action with its valid params when the module is loaded.
+      #
+      # @since 6.1.1
+      ParamsRegistry.register(:search_exists, [
           :ignore_unavailable,
           :allow_no_indices,
           :expand_wildcards,
@@ -46,14 +57,7 @@ module Elasticsearch
           :default_operator,
           :df,
           :lenient,
-          :lowercase_expanded_terms ]
-        method = 'POST'
-        path   = "_search/exists"
-        params = Utils.__validate_and_extract_params arguments, valid_params
-        body   = arguments[:body]
-
-        perform_request(method, path, params, body).body
-      end
+          :lowercase_expanded_terms ].freeze)
     end
   end
 end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/search_shards.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/search_shards.rb
@@ -22,20 +22,24 @@ module Elasticsearch
       # @see http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/search-shards.html
       #
       def search_shards(arguments={})
-        valid_params = [
+        method = HTTP_GET
+        path   = Utils.__pathify( Utils.__listify(arguments[:index]), Utils.__listify(arguments[:type]), '_search_shards' )
+        params = Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
+        body   = nil
+
+        perform_request(method, path, params, body).body
+      end
+
+      # Register this action with its valid params when the module is loaded.
+      #
+      # @since 6.1.1
+      ParamsRegistry.register(:search_shards, [
           :preference,
           :routing,
           :local,
           :ignore_unavailable,
           :allow_no_indices,
-          :expand_wildcards ]
-        method = HTTP_GET
-        path   = Utils.__pathify( Utils.__listify(arguments[:index]), Utils.__listify(arguments[:type]), '_search_shards' )
-        params = Utils.__validate_and_extract_params arguments, valid_params
-        body   = nil
-
-        perform_request(method, path, params, body).body
-      end
+          :expand_wildcards ].freeze)
     end
   end
 end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/search_template.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/search_template.rb
@@ -41,21 +41,25 @@ module Elasticsearch
       # @see http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/search-template.html
       #
       def search_template(arguments={})
-        valid_params = [
+        method = HTTP_GET
+        path   = Utils.__pathify( Utils.__listify(arguments[:index]), Utils.__listify(arguments[:type]), '_search/template' )
+        params = Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
+        body   = arguments[:body]
+
+        perform_request(method, path, params, body).body
+      end
+
+      # Register this action with its valid params when the module is loaded.
+      #
+      # @since 6.1.1
+      ParamsRegistry.register(:search_template, [
           :ignore_unavailable,
           :allow_no_indices,
           :expand_wildcards,
           :preference,
           :routing,
           :scroll,
-          :search_type ]
-        method = HTTP_GET
-        path   = Utils.__pathify( Utils.__listify(arguments[:index]), Utils.__listify(arguments[:type]), '_search/template' )
-        params = Utils.__validate_and_extract_params arguments, valid_params
-        body   = arguments[:body]
-
-        perform_request(method, path, params, body).body
-      end
+          :search_type ].freeze)
     end
   end
 end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/snapshot/create.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/snapshot/create.rb
@@ -27,21 +27,24 @@ module Elasticsearch
         def create(arguments={})
           raise ArgumentError, "Required argument 'repository' missing" unless arguments[:repository]
           raise ArgumentError, "Required argument 'snapshot' missing"   unless arguments[:snapshot]
-          valid_params = [
-            :master_timeout,
-            :wait_for_completion ]
-
           repository = arguments.delete(:repository)
           snapshot   = arguments.delete(:snapshot)
 
           method = HTTP_PUT
           path   = Utils.__pathify( '_snapshot', Utils.__escape(repository), Utils.__escape(snapshot) )
 
-          params = Utils.__validate_and_extract_params arguments, valid_params
+          params = Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
           body   = arguments[:body]
 
           perform_request(method, path, params, body).body
         end
+
+        # Register this action with its valid params when the module is loaded.
+        #
+        # @since 6.1.1
+        ParamsRegistry.register(:create, [
+            :master_timeout,
+            :wait_for_completion ].freeze)
       end
     end
   end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/snapshot/create_repository.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/snapshot/create_repository.rb
@@ -23,21 +23,24 @@ module Elasticsearch
         def create_repository(arguments={})
           raise ArgumentError, "Required argument 'repository' missing" unless arguments[:repository]
           raise ArgumentError, "Required argument 'body' missing"       unless arguments[:body]
-          valid_params = [
-            :repository,
-            :master_timeout,
-            :timeout ]
-
           repository = arguments.delete(:repository)
 
           method = HTTP_PUT
           path   = Utils.__pathify( '_snapshot', Utils.__escape(repository) )
 
-          params = Utils.__validate_and_extract_params arguments, valid_params
+          params = Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
           body   = arguments[:body]
 
           perform_request(method, path, params, body).body
         end
+
+        # Register this action with its valid params when the module is loaded.
+        #
+        # @since 6.1.1
+        ParamsRegistry.register(:create_repository, [
+            :repository,
+            :master_timeout,
+            :timeout ].freeze)
       end
     end
   end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/snapshot/delete.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/snapshot/delete.rb
@@ -21,17 +21,13 @@ module Elasticsearch
         def delete(arguments={})
           raise ArgumentError, "Required argument 'repository' missing" unless arguments[:repository]
           raise ArgumentError, "Required argument 'snapshot' missing"   unless arguments[:snapshot]
-
-          valid_params = [
-            :master_timeout ]
-
           repository = arguments.delete(:repository)
           snapshot   = arguments.delete(:snapshot)
 
           method = HTTP_DELETE
           path   = Utils.__pathify( '_snapshot', Utils.__escape(repository), Utils.__listify(snapshot) )
 
-          params = Utils.__validate_and_extract_params arguments, valid_params
+          params = Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
           body   = nil
 
           if Array(arguments[:ignore]).include?(404)
@@ -40,6 +36,11 @@ module Elasticsearch
             perform_request(method, path, params, body).body
           end
         end
+
+        # Register this action with its valid params when the module is loaded.
+        #
+        # @since 6.1.1
+        ParamsRegistry.register(:delete, [ :master_timeout ].freeze)
       end
     end
   end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/snapshot/delete_repository.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/snapshot/delete_repository.rb
@@ -18,17 +18,12 @@ module Elasticsearch
         #
         def delete_repository(arguments={})
           raise ArgumentError, "Required argument 'repository' missing" unless arguments[:repository]
-
-          valid_params = [
-            :master_timeout,
-            :timeout ]
-
           repository = arguments.delete(:repository)
 
           method = HTTP_DELETE
           path   = Utils.__pathify( '_snapshot', Utils.__listify(repository) )
 
-          params = Utils.__validate_and_extract_params arguments, valid_params
+          params = Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
           body   = nil
 
           if Array(arguments[:ignore]).include?(404)
@@ -37,6 +32,13 @@ module Elasticsearch
             perform_request(method, path, params, body).body
           end
         end
+
+        # Register this action with its valid params when the module is loaded.
+        #
+        # @since 6.1.1
+        ParamsRegistry.register(:delete_repository, [
+            :master_timeout,
+            :timeout ].freeze)
       end
     end
   end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/snapshot/get.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/snapshot/get.rb
@@ -28,19 +28,13 @@ module Elasticsearch
         def get(arguments={})
           raise ArgumentError, "Required argument 'repository' missing" unless arguments[:repository]
           raise ArgumentError, "Required argument 'snapshot' missing"   unless arguments[:snapshot]
-
-          valid_params = [
-            :ignore_unavailable,
-            :master_timeout,
-            :verbose ]
-
           repository = arguments.delete(:repository)
           snapshot   = arguments.delete(:snapshot)
 
           method = HTTP_GET
           path   = Utils.__pathify( '_snapshot', Utils.__escape(repository), Utils.__listify(snapshot) )
 
-          params = Utils.__validate_and_extract_params arguments, valid_params
+          params = Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
           body   = nil
 
           if Array(arguments[:ignore]).include?(404)
@@ -49,6 +43,14 @@ module Elasticsearch
             perform_request(method, path, params, body).body
           end
         end
+
+        # Register this action with its valid params when the module is loaded.
+        #
+        # @since 6.1.1
+        ParamsRegistry.register(:get, [
+            :ignore_unavailable,
+            :master_timeout,
+            :verbose ].freeze)
       end
     end
   end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/snapshot/get_repository.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/snapshot/get_repository.rb
@@ -23,16 +23,11 @@ module Elasticsearch
         # @see http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/modules-snapshots.html
         #
         def get_repository(arguments={})
-          valid_params = [
-            :master_timeout,
-            :local ]
-
           repository = arguments.delete(:repository)
-
           method = HTTP_GET
           path   = Utils.__pathify( '_snapshot', Utils.__escape(repository) )
 
-          params = Utils.__validate_and_extract_params arguments, valid_params
+          params = Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
           body   = nil
 
           if Array(arguments[:ignore]).include?(404)
@@ -41,6 +36,13 @@ module Elasticsearch
             perform_request(method, path, params, body).body
           end
         end
+
+        # Register this action with its valid params when the module is loaded.
+        #
+        # @since 6.1.1
+        ParamsRegistry.register(:get_repository, [
+            :master_timeout,
+            :local ].freeze)
       end
     end
   end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/snapshot/params_registry.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/snapshot/params_registry.rb
@@ -1,0 +1,44 @@
+module Elasticsearch
+  module API
+    module Snapshot
+      module Actions
+        module ParamsRegistry
+
+          extend self
+
+          # A Mapping of all the actions to their list of valid params.
+          #
+          # @since 6.1.1
+          PARAMS = {}
+
+          # Register an action with its list of valid params.
+          #
+          # @example Register the action.
+          #   ParamsRegistry.register(:benchmark, [ :verbose ])
+          #
+          # @param [ Symbol ] action The action to register.
+          # @param [ Array[Symbol] ] valid_params The list of valid params.
+          #
+          # @since 6.1.1
+          def register(action, valid_params)
+            PARAMS[action.to_sym] = valid_params
+          end
+
+          # Get the list of valid params for a given action.
+          #
+          # @example Get the list of valid params.
+          #   ParamsRegistry.get(:benchmark)
+          #
+          # @param [ Symbol ] action The action.
+          #
+          # @return [ Array<Symbol> ] The list of valid params for the action.
+          #
+          # @since 6.1.1
+          def get(action)
+            PARAMS.fetch(action, [])
+          end
+        end
+      end
+    end
+  end
+end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/snapshot/restore.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/snapshot/restore.rb
@@ -31,22 +31,24 @@ module Elasticsearch
         def restore(arguments={})
           raise ArgumentError, "Required argument 'repository' missing" unless arguments[:repository]
           raise ArgumentError, "Required argument 'snapshot' missing"   unless arguments[:snapshot]
-
-          valid_params = [
-            :master_timeout,
-            :wait_for_completion ]
-
           repository = arguments.delete(:repository)
           snapshot   = arguments.delete(:snapshot)
 
           method = HTTP_POST
           path   = Utils.__pathify( '_snapshot', Utils.__escape(repository), Utils.__escape(snapshot), '_restore' )
 
-          params = Utils.__validate_and_extract_params arguments, valid_params
+          params = Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
           body   = arguments[:body]
 
           perform_request(method, path, params, body).body
         end
+
+        # Register this action with its valid params when the module is loaded.
+        #
+        # @since 6.1.1
+        ParamsRegistry.register(:restore, [
+            :master_timeout,
+            :wait_for_completion ].freeze)
       end
     end
   end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/snapshot/status.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/snapshot/status.rb
@@ -22,17 +22,13 @@ module Elasticsearch
         # @see http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/modules-snapshots.html#_snapshot_status
         #
         def status(arguments={})
-          valid_params = [
-            :ignore_unavailable,
-            :master_timeout ]
-
           repository = arguments.delete(:repository)
           snapshot   = arguments.delete(:snapshot)
 
           method = HTTP_GET
 
           path   = Utils.__pathify( '_snapshot', Utils.__escape(repository), Utils.__escape(snapshot), '_status')
-          params = Utils.__validate_and_extract_params arguments, valid_params
+          params = Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
           body   = nil
 
           if Array(arguments[:ignore]).include?(404)
@@ -41,6 +37,13 @@ module Elasticsearch
             perform_request(method, path, params, body).body
           end
         end
+
+        # Register this action with its valid params when the module is loaded.
+        #
+        # @since 6.1.1
+        ParamsRegistry.register(:status, [
+            :ignore_unavailable,
+            :master_timeout ].freeze)
       end
     end
   end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/snapshot/verify_repository.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/snapshot/verify_repository.rb
@@ -25,7 +25,7 @@ module Elasticsearch
         # Register this action with its valid params when the module is loaded.
         #
         # @since 6.1.1
-        ParamsRegistry.register(:status, [
+        ParamsRegistry.register(:verify_repository, [
             :repository,
             :master_timeout,
             :timeout ].freeze)

--- a/elasticsearch-api/lib/elasticsearch/api/actions/snapshot/verify_repository.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/snapshot/verify_repository.rb
@@ -13,20 +13,22 @@ module Elasticsearch
         #
         def verify_repository(arguments={})
           raise ArgumentError, "Required argument 'repository' missing" unless arguments[:repository]
-
-          valid_params = [
-            :repository,
-            :master_timeout,
-            :timeout ]
-
           repository = arguments.delete(:repository)
           method = HTTP_POST
           path   = Utils.__pathify( '_snapshot', Utils.__escape(repository), '_verify' )
-          params = Utils.__validate_and_extract_params arguments, valid_params
+          params = Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
           body   = nil
 
           perform_request(method, path, params, body).body
         end
+
+        # Register this action with its valid params when the module is loaded.
+        #
+        # @since 6.1.1
+        ParamsRegistry.register(:status, [
+            :repository,
+            :master_timeout,
+            :timeout ].freeze)
       end
     end
   end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/suggest.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/suggest.rb
@@ -27,20 +27,23 @@ module Elasticsearch
       # @see http://elasticsearch.org/guide/reference/api/search/suggest/
       #
       def suggest(arguments={})
-        valid_params = [
-          :ignore_indices,
-          :preference,
-          :routing,
-          :source ]
-
         method = HTTP_POST
         path   = Utils.__pathify( Utils.__listify(arguments[:index]), '_suggest' )
 
-        params = Utils.__validate_and_extract_params arguments, valid_params
+        params = Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
         body   = arguments[:body]
 
         perform_request(method, path, params, body).body
       end
+
+      # Register this action with its valid params when the module is loaded.
+      #
+      # @since 6.1.1
+      ParamsRegistry.register(:suggest, [
+          :ignore_indices,
+          :preference,
+          :routing,
+          :source ].freeze)
     end
   end
 end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/tasks/cancel.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/tasks/cancel.rb
@@ -18,23 +18,25 @@ module Elasticsearch
         # @see http://www.elastic.co/guide/en/elasticsearch/reference/master/tasks-cancel.html
         #
         def cancel(arguments={})
-          valid_params = [
-            :node_id,
-            :actions,
-            :parent_node,
-            :parent_task ]
-
           arguments = arguments.clone
-
           task_id = arguments.delete(:task_id)
 
           method = 'POST'
           path   = Utils.__pathify( '_tasks', Utils.__escape(task_id), '_cancel' )
-          params = Utils.__validate_and_extract_params arguments, valid_params
+          params = Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
           body   = nil
 
           perform_request(method, path, params, body).body
         end
+
+        # Register this action with its valid params when the module is loaded.
+        #
+        # @since 6.1.1
+        ParamsRegistry.register(:cancel, [
+            :node_id,
+            :actions,
+            :parent_node,
+            :parent_task ].freeze)
       end
     end
   end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/tasks/get.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/tasks/get.rb
@@ -24,7 +24,7 @@ module Elasticsearch
         # Register this action with its valid params when the module is loaded.
         #
         # @since 6.1.1
-        ParamsRegistry.register(:cancel, [ :wait_for_completion ].freeze)
+        ParamsRegistry.register(:get, [ :wait_for_completion ].freeze)
       end
     end
   end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/tasks/get.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/tasks/get.rb
@@ -11,19 +11,20 @@ module Elasticsearch
         # @see http://www.elastic.co/guide/en/elasticsearch/reference/master/tasks.html
         #
         def get(arguments={})
-          valid_params = [ :wait_for_completion ]
-
           arguments = arguments.clone
-
           task_id = arguments.delete(:task_id)
-
           method = HTTP_GET
           path   = Utils.__pathify '_tasks', Utils.__escape(task_id)
-          params = Utils.__validate_and_extract_params arguments, valid_params
+          params = Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
           body   = nil
 
           perform_request(method, path, params, body).body
         end
+
+        # Register this action with its valid params when the module is loaded.
+        #
+        # @since 6.1.1
+        ParamsRegistry.register(:cancel, [ :wait_for_completion ].freeze)
       end
     end
   end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/tasks/list.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/tasks/list.rb
@@ -22,26 +22,28 @@ module Elasticsearch
         # @see http://www.elastic.co/guide/en/elasticsearch/reference/master/tasks-list.html
         #
         def list(arguments={})
-          valid_params = [
+          arguments = arguments.clone
+          task_id = arguments.delete(:task_id)
+
+          method = 'GET'
+          path   = Utils.__pathify( '_tasks', Utils.__escape(task_id) )
+          params = Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
+          body   = nil
+
+          perform_request(method, path, params, body).body
+        end
+
+        # Register this action with its valid params when the module is loaded.
+        #
+        # @since 6.1.1
+        ParamsRegistry.register(:list, [
             :node_id,
             :actions,
             :detailed,
             :parent_node,
             :parent_task,
             :group_by,
-            :wait_for_completion ]
-
-          arguments = arguments.clone
-
-          task_id = arguments.delete(:task_id)
-
-          method = 'GET'
-          path   = Utils.__pathify( '_tasks', Utils.__escape(task_id) )
-          params = Utils.__validate_and_extract_params arguments, valid_params
-          body   = nil
-
-          perform_request(method, path, params, body).body
-        end
+            :wait_for_completion ].freeze)
       end
     end
   end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/tasks/params_registry.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/tasks/params_registry.rb
@@ -1,0 +1,44 @@
+module Elasticsearch
+  module API
+    module Tasks
+      module Actions
+        module ParamsRegistry
+
+          extend self
+
+          # A Mapping of all the actions to their list of valid params.
+          #
+          # @since 6.1.1
+          PARAMS = {}
+
+          # Register an action with its list of valid params.
+          #
+          # @example Register the action.
+          #   ParamsRegistry.register(:benchmark, [ :verbose ])
+          #
+          # @param [ Symbol ] action The action to register.
+          # @param [ Array[Symbol] ] valid_params The list of valid params.
+          #
+          # @since 6.1.1
+          def register(action, valid_params)
+            PARAMS[action.to_sym] = valid_params
+          end
+
+          # Get the list of valid params for a given action.
+          #
+          # @example Get the list of valid params.
+          #   ParamsRegistry.get(:benchmark)
+          #
+          # @param [ Symbol ] action The action.
+          #
+          # @return [ Array<Symbol> ] The list of valid params for the action.
+          #
+          # @since 6.1.1
+          def get(action)
+            PARAMS.fetch(action, [])
+          end
+        end
+      end
+    end
+  end
+end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/termvectors.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/termvectors.rb
@@ -60,19 +60,6 @@ module Elasticsearch
       def termvectors(arguments={})
         raise ArgumentError, "Required argument 'index' missing" unless arguments[:index]
         raise ArgumentError, "Required argument 'type' missing" unless arguments[:type]
-
-        valid_params = [
-          :term_statistics,
-          :field_statistics,
-          :fields,
-          :offsets,
-          :positions,
-          :payloads,
-          :preference,
-          :realtime,
-          :routing,
-          :parent ]
-
         method = HTTP_GET
         endpoint = arguments.delete(:endpoint) || '_termvectors'
 
@@ -81,7 +68,7 @@ module Elasticsearch
                                  arguments[:id],
                                  endpoint
 
-        params = Utils.__validate_and_extract_params arguments, valid_params
+        params = Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
         body   = arguments[:body]
 
         perform_request(method, path, params, body).body
@@ -92,6 +79,21 @@ module Elasticsearch
       def termvector(arguments={})
         termvectors(arguments.merge :endpoint => '_termvector')
       end
+
+      # Register this action with its valid params when the module is loaded.
+      #
+      # @since 6.1.1
+      ParamsRegistry.register(:termvectors, [
+          :term_statistics,
+          :field_statistics,
+          :fields,
+          :offsets,
+          :positions,
+          :payloads,
+          :preference,
+          :realtime,
+          :routing,
+          :parent ].freeze)
     end
   end
 end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/update.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/update.rb
@@ -69,8 +69,28 @@ module Elasticsearch
         raise ArgumentError, "Required argument 'index' missing" unless arguments[:index]
         raise ArgumentError, "Required argument 'type' missing"  unless arguments[:type]
         raise ArgumentError, "Required argument 'id' missing"    unless arguments[:id]
+        method = HTTP_POST
+        path   = Utils.__pathify Utils.__escape(arguments[:index]),
+                                 Utils.__escape(arguments[:type]),
+                                 Utils.__escape(arguments[:id]),
+                                 '_update'
 
-        valid_params = [
+        params = Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
+        body   = arguments[:body]
+
+        params[:fields] = Utils.__listify(params[:fields]) if params[:fields]
+
+        if Array(arguments[:ignore]).include?(404)
+          Utils.__rescue_from_not_found { perform_request(method, path, params, body).body }
+        else
+          perform_request(method, path, params, body).body
+        end
+      end
+
+      # Register this action with its valid params when the module is loaded.
+      #
+      # @since 6.1.1
+      ParamsRegistry.register(:update, [
           :consistency,
           :fields,
           :lang,
@@ -88,25 +108,7 @@ module Elasticsearch
           :timestamp,
           :ttl,
           :version,
-          :version_type ]
-
-        method = HTTP_POST
-        path   = Utils.__pathify Utils.__escape(arguments[:index]),
-                                 Utils.__escape(arguments[:type]),
-                                 Utils.__escape(arguments[:id]),
-                                 '_update'
-
-        params = Utils.__validate_and_extract_params arguments, valid_params
-        body   = arguments[:body]
-
-        params[:fields] = Utils.__listify(params[:fields]) if params[:fields]
-
-        if Array(arguments[:ignore]).include?(404)
-          Utils.__rescue_from_not_found { perform_request(method, path, params, body).body }
-        else
-          perform_request(method, path, params, body).body
-        end
-      end
+          :version_type ].freeze)
     end
   end
 end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/update_by_query.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/update_by_query.rb
@@ -67,8 +67,23 @@ module Elasticsearch
       #
       def update_by_query(arguments={})
         raise ArgumentError, "Required argument 'index' missing" unless arguments[:index]
+        method = HTTP_POST
 
-        valid_params = [
+        path   = Utils.__pathify Utils.__listify(arguments[:index]),
+                                 Utils.__listify(arguments[:type]),
+                                 '/_update_by_query'
+
+        params = Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
+
+        body   = arguments[:body]
+
+        perform_request(method, path, params, body).body
+      end
+
+      # Register this action with its valid params when the module is loaded.
+      #
+      # @since 6.1.1
+      ParamsRegistry.register(:update_by_query, [
           :analyzer,
           :analyze_wildcard,
           :default_operator,
@@ -111,20 +126,7 @@ module Elasticsearch
           :scroll_size,
           :wait_for_completion,
           :requests_per_second,
-          :slices ]
-
-        method = HTTP_POST
-
-        path   = Utils.__pathify Utils.__listify(arguments[:index]),
-                                 Utils.__listify(arguments[:type]),
-                                 '/_update_by_query'
-
-        params = Utils.__validate_and_extract_params arguments, valid_params
-
-        body   = arguments[:body]
-
-        perform_request(method, path, params, body).body
-      end
+          :slices ].freeze)
     end
   end
 end


### PR DESCRIPTION
(This is a duplicate pull request because the first one is not triggering Travis builds. Perhaps it's related to GitHub's persistence issues today)

This pull request introduces a `ParamsRegistry` for each api namespace so that valid params can be looked up instead of defined as a new array every time a method is called.