### PR TITLE
[CLIENT] Ensure that password is not printed in logged error messages

### DIFF
--- a/elasticsearch-transport/lib/elasticsearch/transport.rb
+++ b/elasticsearch-transport/lib/elasticsearch/transport.rb
@@ -32,6 +32,7 @@ require "elasticsearch/transport/transport/connections/connection"
 require "elasticsearch/transport/transport/connections/collection"
 require "elasticsearch/transport/transport/http/faraday"
 require "elasticsearch/transport/client"
+require "elasticsearch/transport/redacted"
 
 require "elasticsearch/transport/version"
 

--- a/elasticsearch-transport/lib/elasticsearch/transport/redacted.rb
+++ b/elasticsearch-transport/lib/elasticsearch/transport/redacted.rb
@@ -1,0 +1,75 @@
+# Licensed to Elasticsearch B.V. under one or more contributor
+# license agreements. See the NOTICE file distributed with
+# this work for additional information regarding copyright
+# ownership. Elasticsearch B.V. licenses this file to you under
+# the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#	http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+module Elasticsearch
+  module Transport
+
+    # Class for wrapping a hash that could have sensitive data.
+    # When printed, the sensitive values will be redacted.
+    #
+    # @since 7.0.0
+    class Redacted < ::Hash
+
+      def initialize(elements = nil)
+        super()
+        (elements || {}).each_pair{ |key, value| self[key] = value }
+      end
+
+      # The keys whose values will be redacted.
+      #
+      # @since 7.0.0
+      SENSITIVE_KEYS = [ :password,
+                         :pwd ].freeze
+
+      # The replacement string used in place of the value for sensitive keys.
+      #
+      # @since 7.0.0
+      STRING_REPLACEMENT = '<REDACTED>'.freeze
+
+      # Get a string representation of the hash.
+      #
+      # @return [ String ] The string representation of the hash.
+      #
+      # @since 7.0.0
+      def inspect
+        redacted_string(:inspect)
+      end
+
+      # Get a string representation of the hash.
+      #
+      # @return [ String ] The string representation of the hash.
+      #
+      # @since 7.0.0
+      def to_s
+        redacted_string(:to_s)
+      end
+
+      private
+
+      def redacted_string(method)
+        '{' + reduce([]) do |list, (k, v)|
+          list << "#{k.send(method)}=>#{redact(k, v, method)}"
+        end.join(', ') + '}'
+      end
+
+      def redact(k, v, method)
+        return STRING_REPLACEMENT if SENSITIVE_KEYS.include?(k.to_sym)
+        v.send(method)
+      end
+    end
+  end
+end

--- a/elasticsearch-transport/lib/elasticsearch/transport/redacted.rb
+++ b/elasticsearch-transport/lib/elasticsearch/transport/redacted.rb
@@ -21,7 +21,7 @@ module Elasticsearch
     # Class for wrapping a hash that could have sensitive data.
     # When printed, the sensitive values will be redacted.
     #
-    # @since 7.0.0
+    # @since 6.1.1
     class Redacted < ::Hash
 
       def initialize(elements = nil)
@@ -31,20 +31,20 @@ module Elasticsearch
 
       # The keys whose values will be redacted.
       #
-      # @since 7.0.0
+      # @since 6.1.1
       SENSITIVE_KEYS = [ :password,
                          :pwd ].freeze
 
       # The replacement string used in place of the value for sensitive keys.
       #
-      # @since 7.0.0
+      # @since 6.1.1
       STRING_REPLACEMENT = '<REDACTED>'.freeze
 
       # Get a string representation of the hash.
       #
       # @return [ String ] The string representation of the hash.
       #
-      # @since 7.0.0
+      # @since 6.1.1
       def inspect
         redacted_string(:inspect)
       end
@@ -53,7 +53,7 @@ module Elasticsearch
       #
       # @return [ String ] The string representation of the hash.
       #
-      # @since 7.0.0
+      # @since 6.1.1
       def to_s
         redacted_string(:to_s)
       end

--- a/elasticsearch-transport/lib/elasticsearch/transport/transport/connections/connection.rb
+++ b/elasticsearch-transport/lib/elasticsearch/transport/transport/connections/connection.rb
@@ -39,11 +39,10 @@ module Elasticsearch
           # @option arguments [Object] :connection The transport-specific physical connection or "session"
           # @option arguments [Hash]   :options    Options (usually passed in from transport)
           #
-          def initialize(arguments = Redacted.new)
-            args = Redacted.new(arguments)
-            @host       = args[:host]
-            @connection = args[:connection]
-            @options    = args[:options] || {}
+          def initialize(arguments={})
+            @host       = arguments[:host].is_a?(Hash) ? Redacted.new(arguments[:host]) : arguments[:host]
+            @connection = arguments[:connection]
+            @options    = arguments[:options] || {}
             @state_mutex = Mutex.new
 
             @options[:resurrect_timeout] ||= DEFAULT_RESURRECT_TIMEOUT

--- a/elasticsearch-transport/lib/elasticsearch/transport/transport/connections/connection.rb
+++ b/elasticsearch-transport/lib/elasticsearch/transport/transport/connections/connection.rb
@@ -39,10 +39,11 @@ module Elasticsearch
           # @option arguments [Object] :connection The transport-specific physical connection or "session"
           # @option arguments [Hash]   :options    Options (usually passed in from transport)
           #
-          def initialize(arguments={})
-            @host       = arguments[:host]
-            @connection = arguments[:connection]
-            @options    = arguments[:options] || {}
+          def initialize(arguments = Redacted.new)
+            args = Redacted.new(arguments)
+            @host       = args[:host]
+            @connection = args[:connection]
+            @options    = args[:options] || {}
             @state_mutex = Mutex.new
 
             @options[:resurrect_timeout] ||= DEFAULT_RESURRECT_TIMEOUT

--- a/elasticsearch-transport/lib/elasticsearch/transport/transport/http/faraday.rb
+++ b/elasticsearch-transport/lib/elasticsearch/transport/transport/http/faraday.rb
@@ -37,11 +37,10 @@ module Elasticsearch
             super do |connection, url|
               headers = headers || connection.connection.headers
 
-              response = connection.connection.run_request \
-                method.downcase.to_sym,
-                url,
-                ( body ? __convert_to_json(body) : nil ),
-                headers
+              response = connection.connection.run_request(method.downcase.to_sym,
+                                                           url,
+                                                           ( body ? __convert_to_json(body) : nil ),
+                                                           headers)
 
               Response.new response.status, response.body, response.headers
             end

--- a/elasticsearch-transport/spec/elasticsearch/transport/base_spec.rb
+++ b/elasticsearch-transport/spec/elasticsearch/transport/base_spec.rb
@@ -1,0 +1,52 @@
+# Licensed to Elasticsearch B.V. under one or more contributor
+# license agreements. See the NOTICE file distributed with
+# this work for additional information regarding copyright
+# ownership. Elasticsearch B.V. licenses this file to you under
+# the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#	http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+require 'spec_helper'
+
+describe Elasticsearch::Transport::Transport::Base do
+
+  context 'when a host is printed in a logged message' do
+
+    context 'when the host info contains a password' do
+
+      let(:client) do
+        Elasticsearch::Transport::Client.new(hosts: 'fake',
+                                             logger: logger,
+                                             password: 'secret_password',
+                                             user: 'test')
+      end
+
+      let(:logger) do
+        double('logger', error?: true, error: '')
+      end
+
+      it 'does not include the password in the logged string' do
+        expect(logger).not_to receive(:error).with(/secret_password/)
+        expect {
+          client.cluster.stats
+        }.to raise_exception(Faraday::ConnectionFailed)
+      end
+
+      it 'replaces the password with the string \'REDACTED\'' do
+        expect(logger).to receive(:error).with(/REDACTED/)
+        expect {
+          client.cluster.stats
+        }.to raise_exception(Faraday::ConnectionFailed)
+      end
+    end
+  end
+end

--- a/elasticsearch-transport/spec/elasticsearch/transport/base_spec.rb
+++ b/elasticsearch-transport/spec/elasticsearch/transport/base_spec.rb
@@ -21,13 +21,10 @@ describe Elasticsearch::Transport::Transport::Base do
 
   context 'when a host is printed in a logged message' do
 
-    context 'when the host info contains a password' do
+    shared_examples_for 'a redacted string' do
 
       let(:client) do
-        Elasticsearch::Transport::Client.new(hosts: 'fake',
-                                             logger: logger,
-                                             password: 'secret_password',
-                                             user: 'test')
+        Elasticsearch::Transport::Client.new(arguments)
       end
 
       let(:logger) do
@@ -47,6 +44,38 @@ describe Elasticsearch::Transport::Transport::Base do
           client.cluster.stats
         }.to raise_exception(Faraday::ConnectionFailed)
       end
+    end
+
+    context 'when the user and password are provided as separate arguments' do
+
+      let(:arguments) do
+        { hosts: 'fake',
+          logger: logger,
+          password: 'secret_password',
+          user: 'test' }
+      end
+
+      it_behaves_like 'a redacted string'
+    end
+
+    context 'when the user and password are provided in the string URI' do
+
+      let(:arguments) do
+        { hosts: 'http://test:secret_password@fake.com',
+          logger: logger }
+      end
+
+      it_behaves_like 'a redacted string'
+    end
+
+    context 'when the user and password are provided in the URI object' do
+
+      let(:arguments) do
+        { hosts: URI.parse('http://test:secret_password@fake.com'),
+          logger: logger }
+      end
+
+      it_behaves_like 'a redacted string'
     end
   end
 end

--- a/elasticsearch-transport/spec/spec_helper.rb
+++ b/elasticsearch-transport/spec/spec_helper.rb
@@ -3,6 +3,7 @@ require 'elasticsearch-transport'
 require 'logger'
 require 'ansi/code'
 require 'hashie/mash'
+require 'pry-nav'
 
 # The hosts to use for creating a elasticsearch client.
 #


### PR DESCRIPTION
This pull request is to address https://github.com/elastic/elasticsearch-ruby/issues/495
The password was being printed when an error was encountered and logged in connecting the client.

This PR wraps the host info in a `Redacted` object inherited from Hash. It will put a `<REDACTED>` string in place of the password value when `#inspect` or `#to_s` is called on the Hash.

Eventually, more of the client codebase will use the `Redacted` object.