### PR TITLE
Replace `IO.pipe` with `IO.popen` in `Elasticsearch::Extensions::Test::Cluster#__determine_version`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,6 +41,10 @@ matrix:
       jdk: oraclejdk8
       env: QUIET=y ELASTICSEARCH_HOSTS=localhost:9250,localhost:9251 TEST_SUITE=integration
 
+    - rvm: jruby-9.2.5.0
+      jdk: oraclejdk8
+      env: QUIET=y ELASTICSEARCH_HOSTS=localhost:9250,localhost:9251 TEST_SUITE=integration
+
   allow_failures:
     - rvm: ruby-head
       jdk: oraclejdk8

--- a/elasticsearch-extensions/lib/elasticsearch/extensions/test/cluster.rb
+++ b/elasticsearch-extensions/lib/elasticsearch/extensions/test/cluster.rb
@@ -501,15 +501,14 @@ module Elasticsearch
               begin
                 # First, try the new `--version` syntax...
                 __log "Running [#{arguments[:command]} --version] to determine version" if ENV['DEBUG']
-                rout, wout = IO.pipe
-                pid = Process.spawn("#{arguments[:command]} --version", out: wout)
+                io = IO.popen("#{arguments[:command]} --version")
+                pid = io.pid
 
                 Timeout::timeout(arguments[:timeout_version]) do
                   Process.wait(pid)
-                  wout.close unless wout.closed?
-                  output = rout.read unless rout.closed?
-                  rout.close unless rout.closed?
+                  output = io.read
                 end
+
               rescue Timeout::Error
                 # ...else, the old `-v` syntax
                 __log "Running [#{arguments[:command]} -v] to determine version" if ENV['DEBUG']
@@ -518,8 +517,7 @@ module Elasticsearch
                 if pid
                   Process.kill('INT', pid) rescue Errno::ESRCH # Most likely the process has terminated already
                 end
-                wout.close unless wout.closed?
-                rout.close unless rout.closed?
+                io.close unless io.closed?
               end
 
               STDERR.puts "> #{output}" if ENV['DEBUG']

--- a/elasticsearch-extensions/test/test/cluster/unit/cluster_test.rb
+++ b/elasticsearch-extensions/test/test/cluster/unit/cluster_test.rb
@@ -278,12 +278,15 @@ class Elasticsearch::Extensions::TestClusterTest < Elasticsearch::Test::UnitTest
           File.expects(:exist?).with('/foo/bar/bin/../lib/').returns(false)
           File.expects(:exist?).with('/foo/bar/bin/elasticsearch').returns(true)
 
-          Process.stubs(:wait)
-          Process.expects(:spawn).returns(123)
-          Process.expects(:kill).with('INT', 123)
+          io = mock('IO')
+          io.expects(:pid).returns(123)
+          io.expects(:read).returns('Version: 2.3.0-SNAPSHOT, Build: d1c86b0/2016-03-30T10:43:20Z, JVM: 1.8.0_60')
+          io.expects(:closed?).returns(false)
+          io.expects(:close)
+          IO.expects(:popen).returns(io)
 
-          IO.any_instance.expects(:read)
-            .returns('Version: 2.3.0-SNAPSHOT, Build: d1c86b0/2016-03-30T10:43:20Z, JVM: 1.8.0_60')
+          Process.stubs(:wait)
+          Process.expects(:kill).with('INT', 123)
 
           assert_equal '2.0', @subject.__determine_version
         end
@@ -305,11 +308,15 @@ class Elasticsearch::Extensions::TestClusterTest < Elasticsearch::Test::UnitTest
           File.expects(:exist?).with('/foo/bar/bin/../lib/').returns(false)
           File.expects(:exist?).with('/foo/bar/bin/elasticsearch').returns(true)
 
-          Process.stubs(:wait)
-          Process.expects(:spawn).returns(123)
-          Process.expects(:kill).with('INT', 123)
+          io = mock('IO')
+          io.expects(:pid).returns(123)
+          io.expects(:read).returns('Version: FOOBAR')
+          io.expects(:closed?).returns(false)
+          io.expects(:close)
+          IO.expects(:popen).returns(io)
 
-          IO.any_instance.expects(:read).returns('Version: FOOBAR')
+          Process.stubs(:wait)
+          Process.expects(:kill).with('INT', 123)
 
           assert_raise(RuntimeError) { @subject.__determine_version }
         end


### PR DESCRIPTION
This change fixes #587 where `Elasticsearch::Extensions::Test::Cluster` fails to determine Elasticsearch version on JRuby.