### PR TITLE
Update search.rb example code

### DIFF
--- a/elasticsearch-dsl/lib/elasticsearch/dsl/search.rb
+++ b/elasticsearch-dsl/lib/elasticsearch/dsl/search.rb
@@ -32,14 +32,16 @@ module Elasticsearch
       #         match title: 'test'
       #       end
       #     end
+      #     definition.to_hash
+      #     => {:query=>{:match=>{:title=>"test"}}}
       #
       # @example Using the class imperatively
       #
       #     definition = Search.new
-      #     query = Query.new
+      #     query = Queries::Match.new title: 'test'
       #     definition.query query
       #     definition.to_hash
-      #     # => => {:query=>{:match=>{:title=>"Test"}}}
+      #     # => {:query=>{:match=>{:title=>"test"}}}
       #
       # @see http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/search.html
       #


### PR DESCRIPTION
Thank you for making a wonderful gem.
Fixed two places where you were interested reading code. Please confirm.

* I made `@example Building a search definition declaratively` easier to understand based on README
* `@example Using the class imperatively` Execution as described in example resulted in the following result

```
require 'elasticsearch/dsl'
include Elasticsearch::DSL

definition = Search.new
query = Query.new
definition.query query
definition.to_hash
# => {:query=>{}}
```

This also made it easier to understand based on the README

FIY: Use Version is elasticsearch-dsl (0.1.6)