### PR TITLE
Update elasticsearch-dsl.gemspec

### DIFF
--- a/elasticsearch-dsl/elasticsearch-dsl.gemspec
+++ b/elasticsearch-dsl/elasticsearch-dsl.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |s|
   s.description   = %q{A Ruby DSL builder for Elasticsearch}
   s.summary       = s.description
   s.homepage      = "https://github.com/elasticsearch/elasticsearch-ruby/tree/master/elasticsearch-dsl"
-  s.license       = "Apache 2"
+  s.license       = "Apache-2.0"
 
   s.files         = `git ls-files`.split($/)
   s.executables   = s.files.grep(%r{^bin/}) { |f| File.basename(f) }


### PR DESCRIPTION
When specifying licenses, we should use the proper name for the license so that projects like https://github.com/github/licensed can correctly identify the license.