### PR TITLE
Update elasticsearch-transport.gemspec

### DIFF
--- a/elasticsearch-transport/elasticsearch-transport.gemspec
+++ b/elasticsearch-transport/elasticsearch-transport.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |s|
   s.email         = ["karel.minarik@elasticsearch.org"]
   s.summary       = "Ruby client for Elasticsearch."
   s.homepage      = "https://github.com/elasticsearch/elasticsearch-ruby/tree/master/elasticsearch-transport"
-  s.license       = "Apache 2"
+  s.license       = "Apache-2.0"
 
   s.files         = `git ls-files`.split($/)
   s.executables   = s.files.grep(%r{^bin/}) { |f| File.basename(f) }


### PR DESCRIPTION
When specifying licenses, we should use the proper name for the license so that projects like https://github.com/github/licensed can correctly identify the license.