### PR TITLE
Update elasticsearch.gemspec

### DIFF
--- a/elasticsearch/elasticsearch.gemspec
+++ b/elasticsearch/elasticsearch.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |s|
   s.email         = ["karel.minarik@elasticsearch.org"]
   s.summary       = "Ruby integrations for Elasticsearch"
   s.homepage      = "http://github.com/elasticsearch/elasticsearch-ruby"
-  s.license       = "Apache 2"
+  s.license       = "Apache-2.0"
 
   s.files         = `git ls-files`.split($/)
   s.executables   = s.files.grep(%r{^bin/}) { |f| File.basename(f) }


### PR DESCRIPTION
When specifying licenses, we should use the proper name for the license so that projects like https://github.com/github/licensed can correctly identify the license.