### PR TITLE
Create benchmarking job

### DIFF
--- a/.ci/jobs/elastic+elasticsearch-ruby+benchmark-multijob-wip+master.yml
+++ b/.ci/jobs/elastic+elasticsearch-ruby+benchmark-multijob-wip+master.yml
@@ -1,0 +1,43 @@
+---
+- job:
+    project-type: multijob
+    name: elastic+elasticsearch-ruby+benchmark-multijob+master
+    concurrent: false
+    display-name: 'elastic / elasticsearch-ruby benchmark-multijob # master'
+    description: Benchmarking the elasticsearch-ruby master branch.
+    node: flyweight
+    # trigger on demand while work in progress
+    triggers: null
+    builders:
+      # override default
+      - shell: null
+      - multijob:
+          name: start-elasticsearch
+          condition: SUCCESSFUL
+          projects:
+            - name: elastic+elasticsearch-ruby+benchmark-start-elasticsearch+master
+      - multijob:
+          name: run-tests
+          # continue to next phase to clean up even if this phase fails
+          condition: ALWAYS
+          projects:
+            - name: elastic+elasticsearch-ruby+benchmark-tests+master
+      - multijob:
+          name: stop-elasticsearch
+          condition: SUCCESSFUL
+          projects:
+            - name: elastic+elasticsearch-ruby+benchmark-stop-elasticsearch+master
+    # override default
+    publishers: null
+    # override default
+    yaml-strategy: null
+    # override default
+    axes: null
+    # override default
+    scm: null
+    properties:
+      - lockable-resources:
+          # clients-ci uses this lockable resource to ensure only one benchmarking job
+          # is using the shared elasticsearch instance at a time
+          resources: benchmarking-elasticsearch-instance
+

--- a/.ci/jobs/elastic+elasticsearch-ruby+benchmark-start-elasticsearch+master.yml
+++ b/.ci/jobs/elastic+elasticsearch-ruby+benchmark-start-elasticsearch+master.yml
@@ -1,0 +1,26 @@
+---
+- job:
+    project-type: freestyle
+    name: elastic+elasticsearch-ruby+benchmark-start-elasticsearch+master
+    concurrent: false
+    display-name: 'elastic / elasticsearch-ruby benchmark-start-elasticsearch # master'
+    description: Start elasticsearch for use with benchmarking tests.
+    # only multijob workflow should trigger
+    triggers: null
+    node: macrobenchmark-target
+    builders:
+    - shell: |-
+        #!/usr/bin/env bash
+        set -eo pipefail
+        set -x
+
+        sudo /usr/local/sbin/start-elasticsearch-for-benchmarking
+
+    # override default
+    publishers: null
+    # override default
+    yaml-strategy: null
+    # override default
+    axes: null
+    # override default
+    scm: null

--- a/.ci/jobs/elastic+elasticsearch-ruby+benchmark-stop-elasticsearch+master.yml
+++ b/.ci/jobs/elastic+elasticsearch-ruby+benchmark-stop-elasticsearch+master.yml
@@ -1,0 +1,26 @@
+---
+- job:
+    project-type: freestyle
+    name: elastic+elasticsearch-ruby+benchmark-stop-elasticsearch+master
+    concurrent: false
+    display-name: 'elastic / elasticsearch-ruby benchmark-stop-elasticsearch # master'
+    description: Stop elasticsearch for use with benchmarking tests.
+    # only multijob workflow should trigger
+    triggers: null
+    node: macrobenchmark-target
+    builders:
+    - shell: |-
+        #!/usr/bin/env bash
+        set -eo pipefail
+        set -x
+
+        sudo /usr/local/sbin/stop-elasticsearch-for-benchmarking
+
+    # override default
+    publishers: null
+    # override default
+    yaml-strategy: null
+    # override default
+    axes: null
+    # override default
+    scm: null

--- a/.ci/jobs/elastic+elasticsearch-ruby+benchmark-tests+master.yml
+++ b/.ci/jobs/elastic+elasticsearch-ruby+benchmark-tests+master.yml
@@ -1,0 +1,61 @@
+---
+- job:
+    project-type: freestyle
+    name: elastic+elasticsearch-ruby+benchmark-tests+master
+    concurrent: false
+    display-name: 'elastic / elasticsearch-ruby benchmark-tests # master'
+    description: Run elasticsearch-ruby benchmarking tests.
+    # only multijob workflow should trigger
+    triggers: null
+    vault:
+      url: https://secrets.elastic.co:8200
+      # vault read auth/approle/role/clients-ci/role-id
+      role_id: ddbd0d44-0e51-105b-177a-c8fdfd445126
+    node: macrobenchmarks
+    parameters:
+    - string:
+        name: branch_specifier
+        default: refs/heads/master
+        description: the Git branch specifier to build (&lt;branchName&gt;, &lt;tagName&gt;,
+          &lt;commitId&gt;, etc.)
+    builders:
+    - shell: |-
+        #!/usr/local/bin/runbld
+        set -eo pipefail
+
+        # drop caches
+        sudo /usr/local/sbin/drop-caches
+
+        set +x
+        source /usr/local/bin/bash_standard_lib.sh
+
+        # VAULT_ROLE_ID and VAULT_SECRET_ID are injected by jjbb
+        VAULT_TOKEN=$(retry 5 vault write -field=token auth/approle/login role_id="$VAULT_ROLE_ID" secret_id="$VAULT_SECRET_ID")
+        export VAULT_TOKEN
+        unset VAULT_ROLE_ID VAULT_SECRET_ID
+
+        ES_RESULT_CLUSTER_USERNAME=$(retry 5 vault read -field username secret/clients-ci/benchmarking-cluster)
+        export ES_RESULT_CLUSTER_USERNAME
+        ES_RESULT_CLUSTER_PASSWORD=$(retry 5 vault read -field password secret/clients-ci/benchmarking-cluster)
+        export ES_RESULT_CLUSTER_PASSWORD
+        ES_RESULT_CLUSTER_URL=$(retry 5 vault read -field url secret/clients-ci/benchmarking-cluster)
+        export ES_RESULT_CLUSTER_URL
+
+        unset VAULT_TOKEN
+        set -x
+
+        export PATH="$HOME/.rbenv/bin:$PATH"
+        eval "$(rbenv init -)"
+        rbenv local 2.6.1
+
+        bundle install
+
+        export ELASTICSEARCH_URL=http://worker-954083.build.fsn1-dc3.hetzner.elasticnet.co:9200
+        bundle exec rake benchmark:simple:ping
+
+    # override default
+    publishers: null
+    # override default
+    yaml-strategy: null
+    # override default
+    axes: null

--- a/.ci/views/views.yml
+++ b/.ci/views/views.yml
@@ -1,0 +1,20 @@
+- view:
+    name: 'Main'
+    regex: '^.*$'
+    view-type: list
+- view:
+    name: 'Benchmark'
+    regex: '^.*benchmark.*$'
+    view-type: list
+- view:
+    name: 'Ruby'
+    regex: '^.*elasticsearch-ruby.*$'
+    view-type: list
+- view:
+    name: 'Javascript'
+    regex: '^.*elasticsearch-js.*$'
+    view-type: list
+- view:
+    name: 'Python'
+    regex: '^.*elasticsearch-py.*$'
+    view-type: list


### PR DESCRIPTION
Create a benchmarking job which starts by running a job to install,
start, and configure Elasticsearch on the `macrobenchmark-target`
machine. Then the client benchmark tests are run on the `macrobenchmark`
machine, pointed to the `macrobenchmark-target` Elasticsearch instance.
Pass or fail a clean up job is run on the `macrobenchmark-target` to
stop Elasticsearch and clean things up.