### PR TITLE
Revert "handle IPv6 host"

### DIFF
--- a/elasticsearch-transport/lib/elasticsearch/transport/client.rb
+++ b/elasticsearch-transport/lib/elasticsearch/transport/client.rb
@@ -201,10 +201,6 @@ module Elasticsearch
               :host => uri.host,
               :path => uri.path,
               :port => uri.port }
-          elsif host =~ /^\[[a-z0-9:]+\]:[0-9]+/
-            host, sep, port = host.rpartition(':')
-            {:host => host,
-             :port => port}
           else
             host, port = host.split(':')
             { :host => host,

--- a/elasticsearch-transport/spec/elasticsearch/transport/client_spec.rb
+++ b/elasticsearch-transport/spec/elasticsearch/transport/client_spec.rb
@@ -126,19 +126,6 @@ describe Elasticsearch::Transport::Client do
         expect(hosts[0][:port]).to be(9200)
       end
 
-      context 'when ipv6 is specified' do
-
-        let(:host) do
-          '[fd95:ff55:7fb8:f1e5:f816:3eff:feed:ce5b]:9200'
-        end
-
-        it 'extracts the host' do
-          expect(hosts[0][:host]).to eq('[fd95:ff55:7fb8:f1e5:f816:3eff:feed:ce5b]')
-          expect(hosts[0][:scheme]).to eq('http')
-          expect(hosts[0][:port]).to be(9200)
-        end
-      end
-
       context 'when a path is specified' do
 
         let(:host) do


### PR DESCRIPTION
Reverts elastic/elasticsearch-ruby#614

The tests aren't passing on Jenkins for these changes: https://clients-ci.elastic.co/job/elastic+elasticsearch-ruby+master/103/