### PR TITLE
Create ping job

### DIFF
--- a/.ci/jobs/elastic+elasticsearch-ruby+ping-testing.yml
+++ b/.ci/jobs/elastic+elasticsearch-ruby+ping-testing.yml
@@ -1,0 +1,26 @@
+---
+- job:
+    project-type: freestyle
+    name: elastic+elasticsearch-ruby+ping-testing
+    concurrent: false
+    display-name: 'elastic / elasticsearch-ruby ping-testing'
+    description: Recording network latency from a dynamic worker to static machines.
+    node: 'immutable && ubuntu-16.04'
+    triggers:
+      - timed: '@hourly'
+    builders:
+      - shell: |-
+          #!/usr/local/bin/runbld --script-only
+          set -eo pipefail
+          set -x
+          ping -c 20 worker-954083.build.fsn1-dc3.hetzner.elasticnet.co
+          ping -c 20 clients-ci.elastic.co
+
+    # override default
+    publishers: null
+    # override default
+    yaml-strategy: null
+    # override default
+    axes: null
+    # override default
+    scm: null


### PR DESCRIPTION
Create a job for recording network latency from a dynamic worker to
static machines.

For https://github.com/elastic/infra/issues/10046