### PR TITLE
[ci] Use runbld for jenkins benchmarking jobs

### DIFF
--- a/.ci/jobs/elastic+elasticsearch-ruby+benchmark-start-elasticsearch+master.yml
+++ b/.ci/jobs/elastic+elasticsearch-ruby+benchmark-start-elasticsearch+master.yml
@@ -10,7 +10,7 @@
     node: macrobenchmark-target
     builders:
     - shell: |-
-        #!/usr/bin/env bash
+        #!/usr/local/bin/runbld --script-only
         set -eo pipefail
         set -x
 

--- a/.ci/jobs/elastic+elasticsearch-ruby+benchmark-stop-elasticsearch+master.yml
+++ b/.ci/jobs/elastic+elasticsearch-ruby+benchmark-stop-elasticsearch+master.yml
@@ -10,7 +10,7 @@
     node: macrobenchmark-target
     builders:
     - shell: |-
-        #!/usr/bin/env bash
+        #!/usr/local/bin/runbld --script-only
         set -eo pipefail
         set -x
 


### PR DESCRIPTION
Now that `runbld` supports jobs that do not check out a repository, use
it for the benchmarking start and stop jobs.