### PR TITLE
Update CHANGELOG with missing 1.x and 2.x versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -160,6 +160,25 @@ Elasticsearch 6.0 compatibility.
 
 * Added deprecation notices to API methods and arguments not supported on Elasticsearch 1.x
 
+## 2.0.2
+
+### Client
+
+* * Fixed the bug with `nil` value of `retry_on_status`
+
+### API
+
+* * Added, that `_all` is used as default index in "Search Exists" API
+* * Added, that `index` and `type` parameters are respected in the "Search Exists" API
+
+## EXT:2.0.2
+
+* * Updated the `Test::Cluster` extension
+
+## 2.0.0
+
+* Added deprecation notices to API methods and parameters not supported on Elasticsearch 2.x
+
 ## DSL:0.1.4
 
 * Added correct implementation of `Sort#empty?`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -147,6 +147,19 @@ Elasticsearch 6.0 compatibility.
 * Improved the documentation and error messsages for the test cluster
 * Updated the "Reindex" extension for Elasticsearch 5.x
 
+## 1.1.3
+
+### Client
+
+* Fixed MRI 2.4 compatibility for 1.x
+* Fixed failing integration test for keeping existing collections
+
+## 1.1.0
+
+### API
+
+* Added deprecation notices to API methods and arguments not supported on Elasticsearch 1.x
+
 ## DSL:0.1.4
 
 * Added correct implementation of `Sort#empty?`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+_Note: Up-to-date changelogs for each version can be found in their respective branches
+(e.g. [1.x/CHANGELOG.md](https://github.com/elastic/elasticsearch-ruby/blob/1.x/CHANGELOG.md))_
+
 ## 6.0.0
 
 Elasticsearch 6.0 compatibility.


### PR DESCRIPTION
Found myself confused looking for the changelog for versions 1.1.0 and 1.1.3. Added them to `master`'s changelog, and added a comment to the top just in case older versions get out of sync in the future.