### PR TITLE
Use Monotonic time for benchmark measurements 

### DIFF
--- a/profile/benchmarking/complex.rb
+++ b/profile/benchmarking/complex.rb
@@ -48,7 +48,7 @@ module Elasticsearch
         end
 
         with_cleanup do
-          start = Time.now
+          start = Process.clock_gettime(Process::CLOCK_MONOTONIC)
           results = measured_repetitions.times.collect do
             Benchmark.realtime do
               slices.each do |slice|
@@ -56,7 +56,7 @@ module Elasticsearch
               end
             end
           end
-          end_time = Time.now
+          end_time = Process.clock_gettime(Process::CLOCK_MONOTONIC)
           results
         end
 
@@ -96,13 +96,13 @@ module Elasticsearch
             client.search(request)
           end
 
-          start = Time.now
+          start = Process.clock_gettime(Process::CLOCK_MONOTONIC)
           results = measured_repetitions.times.collect do
             Benchmark.realtime do
               client.search(request)
             end
           end
-          end_time = Time.now
+          end_time = Process.clock_gettime(Process::CLOCK_MONOTONIC)
           results
         end
 

--- a/profile/benchmarking/complex.rb
+++ b/profile/benchmarking/complex.rb
@@ -48,7 +48,7 @@ module Elasticsearch
         end
 
         with_cleanup do
-          start = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+          start = current_time
           results = measured_repetitions.times.collect do
             Benchmark.realtime do
               slices.each do |slice|
@@ -56,7 +56,7 @@ module Elasticsearch
               end
             end
           end
-          end_time = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+          end_time = current_time
           results
         end
 
@@ -96,13 +96,13 @@ module Elasticsearch
             client.search(request)
           end
 
-          start = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+          start = current_time
           results = measured_repetitions.times.collect do
             Benchmark.realtime do
               client.search(request)
             end
           end
-          end_time = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+          end_time = current_time
           results
         end
 

--- a/profile/benchmarking/measurable.rb
+++ b/profile/benchmarking/measurable.rb
@@ -282,6 +282,11 @@ module Elasticsearch
           Elasticsearch::Client.new(opts)
         end
       end
+
+      def current_time
+        # Use monotonic time to provide problems with leap seconds, time changes, syncs etc.
+        Process.clock_gettime(Process::CLOCK_MONOTONIC)
+      end
     end
   end
 end

--- a/profile/benchmarking/simple.rb
+++ b/profile/benchmarking/simple.rb
@@ -45,7 +45,7 @@ module Elasticsearch
 
         warmup_repetitions.times { client.ping }
 
-        start = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+        start = current_time
         results = measured_repetitions.times.collect do
           Benchmark.realtime do
             action_iterations.times do
@@ -53,7 +53,7 @@ module Elasticsearch
             end
           end
         end
-        end_time = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+        end_time = current_time
 
         options = { duration: end_time - start,
                     operation: __method__,
@@ -82,7 +82,7 @@ module Elasticsearch
         end
 
         with_cleanup do
-          start = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+          start = current_time
           results = measured_repetitions.times.collect do
             Benchmark.realtime do
               action_iterations.times do
@@ -90,7 +90,7 @@ module Elasticsearch
               end
             end
           end
-          end_time = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+          end_time = current_time
           results
         end
 
@@ -122,7 +122,7 @@ module Elasticsearch
         end
 
         with_cleanup do
-          start = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+          start = current_time
           results = measured_repetitions.times.collect do
             Benchmark.realtime do
               action_iterations.times do
@@ -130,7 +130,7 @@ module Elasticsearch
               end
             end
           end
-          end_time = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+          end_time = current_time
           results
         end
 
@@ -165,7 +165,7 @@ module Elasticsearch
         end
 
         with_cleanup do
-          start = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+          start = current_time
           results = measured_repetitions.times.collect do
             Benchmark.realtime do
               action_iterations.times do
@@ -173,7 +173,7 @@ module Elasticsearch
               end
             end
           end
-          end_time = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+          end_time = current_time
           results
         end
 
@@ -208,7 +208,7 @@ module Elasticsearch
             client.get(index: INDEX, id: id)
           end
 
-          start = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+          start = current_time
           results = measured_repetitions.times.collect do
             Benchmark.realtime do
               action_iterations.times do
@@ -216,7 +216,7 @@ module Elasticsearch
               end
             end
           end
-          end_time = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+          end_time = current_time
           results
         end
 
@@ -251,7 +251,7 @@ module Elasticsearch
             client.get(index: INDEX, id: id)
           end
 
-          start = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+          start = current_time
           results = measured_repetitions.times.collect do
             Benchmark.realtime do
               action_iterations.times do
@@ -259,7 +259,7 @@ module Elasticsearch
               end
             end
           end
-          end_time = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+          end_time = current_time
         end
 
         options = { duration: end_time - start,
@@ -301,7 +301,7 @@ module Elasticsearch
             client.search(request)
           end
 
-          start = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+          start = current_time
           results = measured_repetitions.times.collect do
             Benchmark.realtime do
               action_iterations.times do
@@ -309,7 +309,7 @@ module Elasticsearch
               end
             end
           end
-          end_time = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+          end_time = current_time
         end
 
         options = { duration: end_time - start,
@@ -350,7 +350,7 @@ module Elasticsearch
             client.search(request)
           end
 
-          start = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+          start = current_time
           results = measured_repetitions.times.collect do
             Benchmark.realtime do
               action_iterations.times do
@@ -358,7 +358,7 @@ module Elasticsearch
               end
             end
           end
-          end_time = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+          end_time = current_time
           results
         end
 
@@ -398,7 +398,7 @@ module Elasticsearch
                           body: { doc: { field:  "#{document[field]}-#{i}" } })
           end
 
-          start = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+          start = current_time
           results = measured_repetitions.times.collect do
             Benchmark.realtime do
               action_iterations.times do |i|
@@ -408,7 +408,7 @@ module Elasticsearch
               end
             end
           end
-          end_time = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+          end_time = current_time
           results
         end
 

--- a/profile/benchmarking/simple.rb
+++ b/profile/benchmarking/simple.rb
@@ -46,14 +46,14 @@ module Elasticsearch
         warmup_repetitions.times { client.ping }
 
         results = measured_repetitions.times.collect do
-          start = Time.now
+          start = Process.clock_gettime(Process::CLOCK_MONOTONIC)
           Benchmark.realtime do
             action_iterations.times do
               client.ping
             end
           end
         end
-        end_time = Time.now
+        end_time = Process.clock_gettime(Process::CLOCK_MONOTONIC)
 
         options = { duration: end_time - start,
                     operation: __method__,
@@ -82,7 +82,7 @@ module Elasticsearch
         end
 
         with_cleanup do
-          start = Time.now
+          start = Process.clock_gettime(Process::CLOCK_MONOTONIC)
           results = measured_repetitions.times.collect do
             Benchmark.realtime do
               action_iterations.times do
@@ -90,7 +90,7 @@ module Elasticsearch
               end
             end
           end
-          end_time = Time.now
+          end_time = Process.clock_gettime(Process::CLOCK_MONOTONIC)
           results
         end
 
@@ -122,7 +122,7 @@ module Elasticsearch
         end
 
         with_cleanup do
-          start = Time.now
+          start = Process.clock_gettime(Process::CLOCK_MONOTONIC)
           results = measured_repetitions.times.collect do
             Benchmark.realtime do
               action_iterations.times do
@@ -130,7 +130,7 @@ module Elasticsearch
               end
             end
           end
-          end_time = Time.now
+          end_time = Process.clock_gettime(Process::CLOCK_MONOTONIC)
           results
         end
 
@@ -165,7 +165,7 @@ module Elasticsearch
         end
 
         with_cleanup do
-          start = Time.now
+          start = Process.clock_gettime(Process::CLOCK_MONOTONIC)
           results = measured_repetitions.times.collect do
             Benchmark.realtime do
               action_iterations.times do
@@ -173,7 +173,7 @@ module Elasticsearch
               end
             end
           end
-          end_time = Time.now
+          end_time = Process.clock_gettime(Process::CLOCK_MONOTONIC)
           results
         end
 
@@ -208,7 +208,7 @@ module Elasticsearch
             client.get(index: INDEX, id: id)
           end
 
-          start = Time.now
+          start = Process.clock_gettime(Process::CLOCK_MONOTONIC)
           results = measured_repetitions.times.collect do
             Benchmark.realtime do
               action_iterations.times do
@@ -216,7 +216,7 @@ module Elasticsearch
               end
             end
           end
-          end_time = Time.now
+          end_time = Process.clock_gettime(Process::CLOCK_MONOTONIC)
           results
         end
 
@@ -251,7 +251,7 @@ module Elasticsearch
             client.get(index: INDEX, id: id)
           end
 
-          start = Time.now
+          start = Process.clock_gettime(Process::CLOCK_MONOTONIC)
           results = measured_repetitions.times.collect do
             Benchmark.realtime do
               action_iterations.times do
@@ -259,7 +259,7 @@ module Elasticsearch
               end
             end
           end
-          end_time = Time.now
+          end_time = Process.clock_gettime(Process::CLOCK_MONOTONIC)
         end
 
         options = { duration: end_time - start,
@@ -301,7 +301,7 @@ module Elasticsearch
             client.search(request)
           end
 
-          start = Time.now
+          start = Process.clock_gettime(Process::CLOCK_MONOTONIC)
           results = measured_repetitions.times.collect do
             Benchmark.realtime do
               action_iterations.times do
@@ -309,7 +309,7 @@ module Elasticsearch
               end
             end
           end
-          end_time = Time.now
+          end_time = Process.clock_gettime(Process::CLOCK_MONOTONIC)
         end
 
         options = { duration: end_time - start,
@@ -350,7 +350,7 @@ module Elasticsearch
             client.search(request)
           end
 
-          start = Time.now
+          start = Process.clock_gettime(Process::CLOCK_MONOTONIC)
           results = measured_repetitions.times.collect do
             Benchmark.realtime do
               action_iterations.times do
@@ -358,7 +358,7 @@ module Elasticsearch
               end
             end
           end
-          end_time = Time.now
+          end_time = Process.clock_gettime(Process::CLOCK_MONOTONIC)
           results
         end
 
@@ -398,7 +398,7 @@ module Elasticsearch
                           body: { doc: { field:  "#{document[field]}-#{i}" } })
           end
 
-          start = Time.now
+          start = Process.clock_gettime(Process::CLOCK_MONOTONIC)
           results = measured_repetitions.times.collect do
             Benchmark.realtime do
               action_iterations.times do |i|
@@ -408,7 +408,7 @@ module Elasticsearch
               end
             end
           end
-          end_time = Time.now
+          end_time = Process.clock_gettime(Process::CLOCK_MONOTONIC)
           results
         end
 

--- a/profile/benchmarking/simple.rb
+++ b/profile/benchmarking/simple.rb
@@ -45,8 +45,8 @@ module Elasticsearch
 
         warmup_repetitions.times { client.ping }
 
+        start = Process.clock_gettime(Process::CLOCK_MONOTONIC)
         results = measured_repetitions.times.collect do
-          start = Process.clock_gettime(Process::CLOCK_MONOTONIC)
           Benchmark.realtime do
             action_iterations.times do
               client.ping


### PR DESCRIPTION
It's not as important as the real samples are taken using `Benchmark.realtime` (which I really hope uses monotonic time itself :) ) so this only affects the reported duration value.

Leap Seconds, time zone changes, clock syncing can all mess with
results/make time jump backwards or forward. Monotonic time
is monotonically increasing and hence not prone to these
problems.

Bit longer explanation here: https://stackoverflow.com/a/45483168

Also fixed a small bug where the `start` variable hopped into a loop where it shouldn't be :)