### PR TITLE
Add deprecated endpoints that were removed in gem version 6.3.0

### DIFF
--- a/elasticsearch-api/lib/elasticsearch/api/actions/delete_template.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/delete_template.rb
@@ -1,0 +1,21 @@
+module Elasticsearch
+  module API
+    module Actions
+
+      # Retrieve an indexed template from Elasticsearch
+      #
+      # @option arguments [String] :id Template ID
+      #
+      # @see http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/search-template.html
+      #
+      def delete_template(arguments={})
+        method = HTTP_DELETE
+        path   = "_search/template/#{arguments[:id]}"
+        params = {}
+        body   = nil
+
+        perform_request(method, path, params, body).body
+      end
+    end
+  end
+end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/field_stats.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/field_stats.rb
@@ -1,0 +1,36 @@
+module Elasticsearch
+  module API
+    module Actions
+
+      # Returns statistical information about a field without executing a search.
+      #
+      # @option arguments [List] :index A comma-separated list of index names; use `_all` or empty string to perform the operation on all indices
+      # @option arguments [List] :fields A comma-separated list of fields for to get field statistics for (min value, max value, and more)
+      # @option arguments [String] :level Defines if field stats should be returned on a per index level or on a cluster wide level (options: indices, cluster)
+      # @option arguments [Boolean] :ignore_unavailable Whether specified concrete indices should be ignored when unavailable (missing or closed)
+      # @option arguments [Boolean] :allow_no_indices Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)
+      # @option arguments [String] :expand_wildcards Whether to expand wildcard expression to concrete indices that are open, closed or both. (options: open, closed, none, all)
+      #
+      # @see http://www.elastic.co/guide/en/elasticsearch/reference/master/search-field-stats.html
+      #
+      def field_stats(arguments={})
+        method = 'GET'
+        path   = Utils.__pathify Utils.__escape(arguments[:index]), "_field_stats"
+        params = Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
+        body   = arguments[:body]
+
+        perform_request(method, path, params, body).body
+      end
+
+      # Register this action with its valid params when the module is loaded.
+      #
+      # @since 6.2.0
+      ParamsRegistry.register(:field_stats, [
+          :fields,
+          :level,
+          :ignore_unavailable,
+          :allow_no_indices,
+          :expand_wildcards ].freeze)
+    end
+  end
+end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/get_template.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/get_template.rb
@@ -1,0 +1,27 @@
+module Elasticsearch
+  module API
+    module Actions
+
+      # Retrieve an indexed script from Elasticsearch
+      #
+      # @option arguments [String] :id Template ID (*Required*)
+      # @option arguments [Hash] :body The document
+      #
+      # @see http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/search-template.html
+      #
+      def get_template(arguments={})
+        raise ArgumentError, "Required argument 'id' missing" unless arguments[:id]
+        method = HTTP_GET
+        path   = "_scripts/#{arguments[:id]}"
+        params = {}
+        body   = arguments[:body]
+
+        if Array(arguments[:ignore]).include?(404)
+          Utils.__rescue_from_not_found { perform_request(method, path, params, body).body }
+        else
+          perform_request(method, path, params, body).body
+        end
+      end
+    end
+  end
+end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/delete_mapping.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/delete_mapping.rb
@@ -1,0 +1,26 @@
+module Elasticsearch
+  module API
+    module Indices
+      module Actions
+
+        # Delete all documents and mapping for a specific document type.
+        #
+        # @option arguments [List] :index A comma-separated list of index names; use `_all` for all indices (*Required*)
+        # @option arguments [String] :type The name of the document type to delete (*Required*)
+        #
+        # @see http://www.elasticsearch.org/guide/reference/api/admin-indices-delete-mapping/
+        #
+        def delete_mapping(arguments={})
+          raise ArgumentError, "Required argument 'index' missing" unless arguments[:index]
+          raise ArgumentError, "Required argument 'type' missing"  unless arguments[:type]
+          method = HTTP_DELETE
+          path   = Utils.__pathify Utils.__listify(arguments[:index]), Utils.__escape(arguments[:type])
+          params = {}
+          body   = nil
+
+          perform_request(method, path, params, body).body
+        end
+      end
+    end
+  end
+end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/delete_warmer.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/delete_warmer.rb
@@ -1,0 +1,32 @@
+module Elasticsearch
+  module API
+    module Indices
+      module Actions
+
+        # Delete one or more warmers for a list of indices.
+        #
+        # @example Delete a warmer named _mywarmer_ for index named _myindex_
+        #
+        #     client.indices.delete_warmer index: 'myindex', name: 'mywarmer'
+        #
+        # @option arguments [List] :index A comma-separated list of index names to register warmer for; use `_all`
+        #                                 or empty string to perform the operation on all indices (*Required*)
+        # @option arguments [String] :name The name of the warmer (supports wildcards); leave empty to delete all warmers
+        # @option arguments [List] :type A comma-separated list of document types to register warmer for; use `_all`
+        #                                or empty string to perform the operation on all types
+        #
+        # @see http://www.elasticsearch.org/guide/reference/api/admin-indices-warmers/
+        #
+        def delete_warmer(arguments={})
+          raise ArgumentError, "Required argument 'index' missing" unless arguments[:index]
+          method = HTTP_DELETE
+          path   = Utils.__pathify Utils.__listify(arguments[:index]), '_warmer', Utils.__listify(arguments[:name])
+          params = {}
+          body = nil
+
+          perform_request(method, path, params, body).body
+        end
+      end
+    end
+  end
+end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/get_aliases.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/get_aliases.rb
@@ -1,0 +1,37 @@
+module Elasticsearch
+  module API
+    module Indices
+      module Actions
+
+        # Get a list of all aliases, or aliases for a specific index.
+        #
+        # @example Get a list of all aliases
+        #
+        #     client.indices.get_aliases
+        #
+        # @option arguments [List] :index A comma-separated list of index names to filter aliases
+        # @option arguments [List] :name A comma-separated list of alias names to filter
+        # @option arguments [Time] :timeout Explicit timestamp for the document
+        # @option arguments [Boolean] :local Return local information,
+        #                                    do not retrieve the state from master node (default: false)
+        #
+        # @see http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/indices-aliases.html
+        #
+        def get_aliases(arguments={})
+          method = HTTP_GET
+          path   = Utils.__pathify Utils.__listify(arguments[:index]), '_aliases', Utils.__listify(arguments[:name])
+
+          params = Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
+          body   = nil
+
+          perform_request(method, path, params, body).body
+        end
+
+        # Register this action with its valid params when the module is loaded.
+        #
+        # @since 6.2.0
+        ParamsRegistry.register(:get_aliases, [ :timeout, :local ].freeze)
+      end
+    end
+  end
+end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/get_warmer.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/get_warmer.rb
@@ -1,0 +1,62 @@
+module Elasticsearch
+  module API
+    module Indices
+      module Actions
+
+        # Get one or more warmers for an index.
+        #
+        # @example Get all warmers
+        #
+        #     client.indices.get_warmer index: '_all'
+        #
+        # @example Get all warmers matching a wildcard expression
+        #
+        #     client.indices.get_warmer index: '_all', name: 'ba*'
+        #
+        # @example Get all warmers for a single index
+        #
+        #     client.indices.get_warmer index: 'foo'
+        #
+        # @example Get a specific warmer
+        #
+        #     client.indices.get_warmer index: 'foo', name: 'bar'
+        #
+        # @option arguments [List] :index A comma-separated list of index names to restrict the operation;
+        #                                 use `_all` to perform the operation on all indices (*Required*)
+        # @option arguments [String] :name The name of the warmer (supports wildcards); leave empty to get all warmers
+        # @option arguments [List] :type A comma-separated list of document types to restrict the operation;
+        #                                leave empty to perform the operation on all types
+        # @option arguments [Boolean] :allow_no_indices Whether to ignore if a wildcard indices expression resolves into
+        #                                               no concrete indices. (This includes `_all` string or when no
+        #                                               indices have been specified)
+        # @option arguments [String] :expand_wildcards Whether to expand wildcard expression to concrete indices that
+        #                                              are open, closed or both. (options: open, closed)
+        # @option arguments [String] :ignore_indices When performed on multiple indices, allows to ignore
+        #                                            `missing` ones (options: none, missing) @until 1.0
+        # @option arguments [Boolean] :ignore_unavailable Whether specified concrete indices should be ignored when
+        #                                                 unavailable (missing, closed, etc)
+        #
+        # @see http://www.elasticsearch.org/guide/reference/api/admin-indices-warmers/
+        #
+        def get_warmer(arguments={})
+          method = HTTP_GET
+          path   = Utils.__pathify( Utils.__listify(arguments[:index]), '_warmer', Utils.__escape(arguments[:name]) )
+          params = Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
+          body   = nil
+
+          perform_request(method, path, params, body).body
+        end
+
+        # Register this action with its valid params when the module is loaded.
+        #
+        # @since 6.2.0
+        ParamsRegistry.register(:get_warmer, [
+            :ignore_indices,
+            :ignore_unavailable,
+            :allow_no_indices,
+            :expand_wildcards,
+            :local ].freeze)
+      end
+    end
+  end
+end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/optimize.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/optimize.rb
@@ -1,0 +1,77 @@
+module Elasticsearch
+  module API
+    module Indices
+      module Actions
+
+        # Perform an index optimization.
+        #
+        # The "optimize" operation merges the index segments, increasing search performance.
+        # It corresponds to a Lucene "merge" operation.
+        #
+        # @deprecated The "optimize" action has been deprecated in favor of forcemerge [https://github.com/elastic/elasticsearch/pull/13778]
+        #
+        # @example Fully optimize an index (merge to one segment)
+        #
+        #     client.indices.optimize index: 'foo', max_num_segments: 1, wait_for_merge: false
+        #
+        # @note The optimize operation is handled automatically by Elasticsearch, you don't need to perform it manually.
+        #       The operation is expensive in terms of resources (I/O, CPU, memory) and can take a long time to
+        #       finish, potentially reducing operability of your cluster; schedule the manual optimization accordingly.
+        #
+        # @option arguments [List] :index A comma-separated list of index names; use `_all`
+        #                                 or empty string to perform the operation on all indices
+        # @option arguments [Boolean] :allow_no_indices Whether to ignore if a wildcard indices expression resolves into
+        #                                               no concrete indices. (This includes `_all` string or when no
+        #                                               indices have been specified)
+        # @option arguments [String] :expand_wildcards Whether to expand wildcard expression to concrete indices that
+        #                                              are open, closed or both. (options: open, closed)
+        # @option arguments [Boolean] :flush Specify whether the index should be flushed after performing the operation
+        #                                    (default: true)
+        # @option arguments [Boolean] :force Force a merge operation to run, even when the index has a single segment
+        #                                    (default: true)
+        # @option arguments [String] :ignore_indices When performed on multiple indices, allows to ignore
+        #                                            `missing` ones (options: none, missing) @until 1.0
+        # @option arguments [Boolean] :ignore_unavailable Whether specified concrete indices should be ignored when
+        #                                                 unavailable (missing, closed, etc)
+        # @option arguments [Number] :max_num_segments The number of segments the index should be merged into
+        #                                              (default: dynamic)
+        # @option arguments [Time] :master_timeout Specify timeout for connection to master
+        # @option arguments [Boolean] :only_expunge_deletes Specify whether the operation should only expunge
+        #                                                   deleted documents
+        # @option arguments [Boolean] :refresh Specify whether the index should be refreshed after performing the operation
+        #                                      (default: true)
+        # @option arguments [Boolean] :wait_for_merge Specify whether the request should block until the merge process
+        #                                             is finished (default: true)
+        #
+        # @see http://www.elasticsearch.org/guide/reference/api/admin-indices-optimize/
+        #
+        def optimize(arguments={})
+          method = HTTP_POST
+          path   = Utils.__pathify Utils.__listify(arguments[:index]), '_optimize'
+
+          params = Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
+          body = nil
+
+          perform_request(method, path, params, body).body
+        end
+
+        # Register this action with its valid params when the module is loaded.
+        #
+        # @since 6.2.0
+        ParamsRegistry.register(:optimize, [
+            :ignore_indices,
+            :ignore_unavailable,
+            :allow_no_indices,
+            :expand_wildcards,
+            :flush,
+            :force,
+            :master_timeout,
+            :max_num_segments,
+            :only_expunge_deletes,
+            :operation_threading,
+            :refresh,
+            :wait_for_merge ].freeze)
+      end
+    end
+  end
+end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/put_warmer.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/put_warmer.rb
@@ -1,0 +1,65 @@
+module Elasticsearch
+  module API
+    module Indices
+      module Actions
+
+        # Create or update an index warmer.
+        #
+        # An index warmer will run before an index is refreshed, ie. available for search.
+        # It allows you to register "heavy" queries with popular filters, facets or sorts,
+        # increasing performance when the index is searched for the first time.
+        #
+        # @example Register a warmer which will populate the caches for `published` filter and sorting on `created_at`
+        #
+        #     client.indices.put_warmer index: 'myindex',
+        #                               name: 'main',
+        #                               body: {
+        #                                 query: { filtered: { filter: { term: { published: true } } } },
+        #                                 sort:  [ "created_at" ]
+        #                               }
+        #
+        # @option arguments [List] :index A comma-separated list of index names to register the warmer for; use `_all`
+        #                                 or empty string to perform the operation on all indices (*Required*)
+        # @option arguments [String] :name The name of the warmer (*Required*)
+        # @option arguments [List] :type A comma-separated list of document types to register the warmer for;
+        #                                leave empty to perform the operation on all types
+        # @option arguments [Hash] :body The search request definition for the warmer
+        #                                (query, filters, facets, sorting, etc) (*Required*)
+        # @option arguments [Boolean] :allow_no_indices Whether to ignore if a wildcard indices expression resolves into
+        #                                               no concrete indices. (This includes `_all` string or when no
+        #                                               indices have been specified)
+        # @option arguments [String] :expand_wildcards Whether to expand wildcard expression to concrete indices that
+        #                                              are open, closed or both. (options: open, closed)
+        # @option arguments [String] :ignore_indices When performed on multiple indices, allows to ignore
+        #                                            `missing` ones (options: none, missing) @until 1.0
+        # @option arguments [Boolean] :ignore_unavailable Whether specified concrete indices should be ignored when
+        #                                                 unavailable (missing, closed, etc)
+        #
+        # @see http://www.elasticsearch.org/guide/reference/api/admin-indices-warmers/
+        #
+        def put_warmer(arguments={})
+          raise ArgumentError, "Required argument 'name' missing"  unless arguments[:name]
+          raise ArgumentError, "Required argument 'body' missing"  unless arguments[:body]
+          method = HTTP_PUT
+          path   = Utils.__pathify( Utils.__listify(arguments[:index]),
+                                    Utils.__listify(arguments[:type]),
+                                    '_warmer',
+                                    Utils.__listify(arguments[:name]) )
+          params = Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
+          body   = arguments[:body]
+
+          perform_request(method, path, params, body).body
+        end
+
+        # Register this action with its valid params when the module is loaded.
+        #
+        # @since 6.2.0
+        ParamsRegistry.register(:put_warmer, [
+            :ignore_indices,
+            :ignore_unavailable,
+            :allow_no_indices,
+            :expand_wildcards ].freeze)
+      end
+    end
+  end
+end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/seal.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/seal.rb
@@ -1,0 +1,24 @@
+module Elasticsearch
+  module API
+    module Indices
+      module Actions
+
+        # "Seal" and index or indices for faster recovery
+        #
+        # @option arguments [List] :index A comma-separated list of index names;
+        #                                 use `_all` or empty string for all indices
+        #
+        # @see http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-seal.html
+        #
+        def seal(arguments={})
+          method = 'POST'
+          path   = Utils.__pathify Utils.__listify(arguments[:index]), '_seal'
+          params = {}
+          body   = nil
+
+          perform_request(method, path, params, body).body
+        end
+      end
+    end
+  end
+end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/snapshot_index.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/snapshot_index.rb
@@ -1,0 +1,44 @@
+module Elasticsearch
+  module API
+    module Indices
+      module Actions
+
+        # When using the shared storage gateway, manually trigger the snapshot operation.
+        #
+        # @deprecated The shared gateway has been deprecated [https://github.com/elasticsearch/elasticsearch/issues/2458]
+        #
+        # @option arguments [List] :index A comma-separated list of index names; use `_all` or empty string
+        #                                to perform the operation on all indices
+        # @option arguments [Boolean] :allow_no_indices Whether to ignore if a wildcard indices expression resolves into
+        #                                               no concrete indices. (This includes `_all` string or when no
+        #                                               indices have been specified)
+        # @option arguments [String] :expand_wildcards Whether to expand wildcard expression to concrete indices that
+        #                                              are open, closed or both. (options: open, closed)
+        # @option arguments [String] :ignore_indices When performed on multiple indices, allows to ignore
+        #                                            `missing` ones (options: none, missing) @until 1.0
+        # @option arguments [Boolean] :ignore_unavailable Whether specified concrete indices should be ignored when
+        #                                                 unavailable (missing, closed, etc)
+        #
+        # @see http://www.elasticsearch.org/guide/reference/api/admin-indices-gateway-snapshot/
+        #
+        def snapshot_index(arguments={})
+          method = HTTP_POST
+          path   = Utils.__pathify Utils.__listify(arguments[:index]), '_gateway/snapshot'
+          params = Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
+          body   = nil
+
+          perform_request(method, path, params, body).body
+        end
+
+        # Register this action with its valid params when the module is loaded.
+        #
+        # @since 6.2.0
+        ParamsRegistry.register(:snapshot_index, [
+            :ignore_indices,
+            :ignore_unavailable,
+            :allow_no_indices,
+            :expand_wildcards ].freeze)
+      end
+    end
+  end
+end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/status.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/status.rb
@@ -1,0 +1,63 @@
+module Elasticsearch
+  module API
+    module Indices
+      module Actions
+
+        # Return information about one or more indices
+        #
+        # @example Get information about all indices
+        #
+        #     client.indices.status
+        #
+        # @example Get information about a specific index
+        #
+        #     client.indices.status index: 'foo'
+        #
+        # @example Get information about shard recovery for a specific index
+        #
+        #     client.indices.status index: 'foo', recovery: true
+        #
+        # @option arguments [List] :index A comma-separated list of index names; use `_all` or empty string
+        #                                 to perform the operation on all indices
+        # @option arguments [Boolean] :allow_no_indices Whether to ignore if a wildcard indices expression resolves into
+        #                                               no concrete indices. (This includes `_all` string or when no
+        #                                               indices have been specified)
+        # @option arguments [String] :expand_wildcards Whether to expand wildcard expression to concrete indices that
+        #                                              are open, closed or both. (options: open, closed)
+        # @option arguments [String] :ignore_indices When performed on multiple indices, allows to ignore
+        #                                            `missing` ones (options: none, missing) @until 1.0
+        # @option arguments [Boolean] :ignore_unavailable Whether specified concrete indices should be ignored when
+        #                                                 unavailable (missing, closed, etc)
+        # @option arguments [Boolean] :recovery Return information about shard recovery (progress, size, etc)
+        # @option arguments [Boolean] :snapshot Return information about snapshots (when shared gateway is used)
+        #
+        # @see http://elasticsearch.org/guide/reference/api/admin-indices-status/
+        #
+        def status(arguments={})
+          method = HTTP_GET
+          path   = Utils.__pathify Utils.__listify(arguments[:index]), '_status'
+
+          params = Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
+          body   = nil
+
+          if Array(arguments[:ignore]).include?(404)
+            Utils.__rescue_from_not_found { perform_request(method, path, params, body).body }
+          else
+            perform_request(method, path, params, body).body
+          end
+        end
+
+        # Register this action with its valid params when the module is loaded.
+        #
+        # @since 6.2.0
+        ParamsRegistry.register(:status, [
+            :ignore_indices,
+            :ignore_unavailable,
+            :allow_no_indices,
+            :expand_wildcards,
+            :recovery,
+            :snapshot ].freeze)
+      end
+    end
+  end
+end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/list_benchmarks.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/list_benchmarks.rb
@@ -1,0 +1,27 @@
+module Elasticsearch
+  module API
+    module Actions
+
+      # Return a list of running benchmarks
+      #
+      # @example
+      #
+      #     client.list_benchmarks
+      #
+      # @option arguments [List] :index A comma-separated list of index names; use `_all` or empty string
+      #                                 to perform the operation on all indices
+      # @option arguments [String] :type The name of the document type
+      #
+      # @see http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/search-benchmark.html
+      #
+      def list_benchmarks(arguments={})
+        method = HTTP_GET
+        path   = "_bench"
+        params = {}
+        body   = nil
+
+        perform_request(method, path, params, body).body
+      end
+    end
+  end
+end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/mlt.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/mlt.rb
@@ -1,0 +1,130 @@
+module Elasticsearch
+  module API
+    module Actions
+
+      # Return documents similar to the specified one.
+      #
+      # Performs a `more_like_this` query with the specified document as the input.
+      #
+      # @example Search for similar documents using the `title` property of document `myindex/mytype/1`
+      #
+      #     # First, let's setup a synonym-aware analyzer ("quick" <=> "fast")
+      #     client.indices.create index: 'myindex', body: {
+      #       settings: {
+      #         analysis: {
+      #           filter: {
+      #             synonyms: {
+      #               type: 'synonym',
+      #               synonyms: [ "quick,fast" ]
+      #             }
+      #           },
+      #           analyzer: {
+      #             title_synonym: {
+      #               type: 'custom',
+      #               tokenizer: 'whitespace',
+      #               filter: ['lowercase', 'stop', 'snowball', 'synonyms']
+      #             }
+      #           }
+      #         }
+      #       },
+      #       mappings: {
+      #         mytype: {
+      #           properties: {
+      #             title: {
+      #               type: 'string',
+      #               analyzer: 'title_synonym'
+      #             }
+      #           }
+      #         }
+      #       }
+      #     }
+      #
+      #     # Index three documents
+      #     client.index index: 'myindex', type: 'mytype', id: 1, body: { title: 'Quick Brown Fox'   }
+      #     client.index index: 'myindex', type: 'mytype', id: 2, body: { title: 'Slow Black Dog'    }
+      #     client.index index: 'myindex', type: 'mytype', id: 3, body: { title: 'Fast White Rabbit' }
+      #     client.indices.refresh index: 'myindex'
+      #
+      #     client.mlt index: 'myindex', type: 'mytype', id: 1, mlt_fields: 'title', min_doc_freq: 1, min_term_freq: 1
+      #     # => { ... {"title"=>"Fast White Rabbit"}}]}}
+      #
+      # @option arguments [String] :id The document ID (*Required*)
+      # @option arguments [String] :index The name of the index (*Required*)
+      # @option arguments [String] :type The type of the document (use `_all` to fetch
+      #                                  the first document matching the ID across all types) (*Required*)
+      # @option arguments [Hash] :body A specific search request definition
+      # @option arguments [Number] :boost_terms The boost factor
+      # @option arguments [Number] :max_doc_freq The word occurrence frequency as count: words with higher occurrence
+      #                                          in the corpus will be ignored
+      # @option arguments [Number] :max_query_terms The maximum query terms to be included in the generated query
+      # @option arguments [Number] :max_word_len The minimum length of the word: longer words will be ignored
+      # @option arguments [Number] :min_doc_freq The word occurrence frequency as count: words with lower occurrence
+      #                                          in the corpus will be ignored
+      # @option arguments [Number] :min_term_freq The term frequency as percent: terms with lower occurence
+      #                                           in the source document will be ignored
+      # @option arguments [Number] :min_word_len The minimum length of the word: shorter words will be ignored
+      # @option arguments [List] :mlt_fields Specific fields to perform the query against
+      # @option arguments [Number] :percent_terms_to_match How many terms have to match in order to consider
+      #                                                    the document a match (default: 0.3)
+      # @option arguments [String] :routing Specific routing value
+      # @option arguments [Number] :search_from The offset from which to return results
+      # @option arguments [List] :search_indices A comma-separated list of indices to perform the query against
+      #                                          (default: the index containing the document)
+      # @option arguments [String] :search_query_hint The search query hint
+      # @option arguments [String] :search_scroll A scroll search request definition
+      # @option arguments [Number] :search_size The number of documents to return (default: 10)
+      # @option arguments [String] :search_source A specific search request definition (instead of using the request body)
+      # @option arguments [String] :search_type Specific search type (eg. `dfs_then_fetch`, `count`, etc)
+      # @option arguments [List] :search_types A comma-separated list of types to perform the query against
+      #                                        (default: the same type as the document)
+      # @option arguments [List] :stop_words A list of stop words to be ignored
+      #
+      # @see http://elasticsearch.org/guide/reference/api/more-like-this/
+      #
+      def mlt(arguments={})
+        raise ArgumentError, "Required argument 'index' missing" unless arguments[:index]
+        raise ArgumentError, "Required argument 'type' missing"  unless arguments[:type]
+        raise ArgumentError, "Required argument 'id' missing"    unless arguments[:id]
+        method = HTTP_GET
+        path   = Utils.__pathify Utils.__escape(arguments[:index]),
+                                 Utils.__escape(arguments[:type]),
+                                 Utils.__escape(arguments[:id]),
+                                 '_mlt'
+
+        params = Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
+
+        [:mlt_fields, :search_indices, :search_types, :stop_words].each do |name|
+          params[name] = Utils.__listify(params[name]) if params[name]
+        end
+
+        body   = arguments[:body]
+
+        perform_request(method, path, params, body).body
+      end
+
+      # Register this action with its valid params when the module is loaded.
+      #
+      # @since 6.2.0
+      ParamsRegistry.register(:mlt, [
+          :boost_terms,
+          :max_doc_freq,
+          :max_query_terms,
+          :max_word_len,
+          :min_doc_freq,
+          :min_term_freq,
+          :min_word_len,
+          :mlt_fields,
+          :percent_terms_to_match,
+          :routing,
+          :search_from,
+          :search_indices,
+          :search_query_hint,
+          :search_scroll,
+          :search_size,
+          :search_source,
+          :search_type,
+          :search_types,
+          :stop_words ].freeze)
+    end
+  end
+end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/mpercolate.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/mpercolate.rb
@@ -1,0 +1,62 @@
+module Elasticsearch
+  module API
+    module Actions
+
+      # Perform multiple percolate operations in a single request, similar to the {#msearch} API
+      #
+      # Pass the percolate definitions as header-body pairs in the `:body` argument, as an Array of Hashes.
+      #
+      # @example Perform two different percolations in a single request
+      #
+      #     client.mpercolate \
+      #         body: [
+      #           { percolate: { index: "my-index", type: "my-type" } },
+      #           { doc: { message: "foo bar" } },
+      #           { percolate: { index: "my-other-index", type: "my-other-type", id: "1" } },
+      #           { }
+      #         ]
+      #
+      # @option arguments [String] :index The index of the document being count percolated to use as default
+      # @option arguments [String] :type The type of the document being percolated to use as default.
+      # @option arguments [Array<Hash>]  The percolate request definitions (header & body pairs) (*Required*)
+      # @option arguments [Boolean] :ignore_unavailable Whether specified concrete indices should be ignored when
+      #                                                 unavailable (missing or closed)
+      # @option arguments [Boolean] :allow_no_indices Whether to ignore if a wildcard indices expression resolves into
+      #                                               no concrete indices. (This includes `_all` string or when no
+      #                                               indices have been specified)
+      # @option arguments [String] :expand_wildcards Whether to expand wildcard expression to concrete indices that are
+      #                                              open, closed or both. (options: open, closed)
+      #
+      # @see http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/search-percolate.html
+      #
+      def mpercolate(arguments={})
+        raise ArgumentError, "Required argument 'body' missing" unless arguments[:body]
+        method = HTTP_GET
+        path   = "_mpercolate"
+
+        params = Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
+        body   = arguments[:body]
+
+        case
+        when body.is_a?(Array)
+          payload = body.map { |d| d.is_a?(String) ? d : Elasticsearch::API.serializer.dump(d) }
+          payload << "" unless payload.empty?
+          payload = payload.join("\n")
+        else
+          payload = body
+        end
+
+        perform_request(method, path, params, payload).body
+      end
+
+      # Register this action with its valid params when the module is loaded.
+      #
+      # @since 6.2.0
+      ParamsRegistry.register(:mpercolate, [
+          :ignore_unavailable,
+          :allow_no_indices,
+          :expand_wildcards,
+          :percolate_format ].freeze)
+    end
+  end
+end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/nodes/shutdown.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/nodes/shutdown.rb
@@ -1,0 +1,39 @@
+module Elasticsearch
+  module API
+    module Nodes
+      module Actions
+
+        # Shutdown one or all nodes
+        #
+        # @example Shut down node named _Bloke_
+        #
+        #     client.nodes.shutdown node_id: 'Bloke'
+        #
+        # @option arguments [List] :node_id A comma-separated list of node IDs or names to perform the operation on; use
+        #                                   `_local` to shutdown the node you're connected to, leave empty to
+        #                                   shutdown all nodes
+        # @option arguments [Time] :delay Set the delay for the operation (default: 1s)
+        # @option arguments [Boolean] :exit Exit the JVM as well (default: true)
+        #
+        # @see http://elasticsearch.org/guide/reference/api/admin-cluster-nodes-shutdown/
+        #
+        def shutdown(arguments={})
+          method = HTTP_POST
+          path   = Utils.__pathify '_cluster/nodes', Utils.__listify(arguments[:node_id]), '_shutdown'
+
+          params = Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
+          body   = nil
+
+          perform_request(method, path, params, body).body
+        end
+
+        # Register this action with its valid params when the module is loaded.
+        #
+        # @since 6.2.0
+        ParamsRegistry.register(:shutdown, [
+            :delay,
+            :exit ].freeze)
+      end
+    end
+  end
+end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/percolate.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/percolate.rb
@@ -1,0 +1,73 @@
+module Elasticsearch
+  module API
+    module Actions
+
+      # Return names of queries matching a document.
+      #
+      # Percolator allows you to register queries and then evaluate a document against them:
+      # the IDs of matching queries are returned in the response.
+      #
+      # @deprecated The `_percolate` API has been deprecated in favour of a special field mapping and the
+      #             `percolate` query;
+      #             see https://www.elastic.co/guide/en/elasticsearch/reference/5.5/breaking_50_percolator.html
+      #
+      # See full example for Elasticsearch 5.x and higher in <https://github.com/elastic/elasticsearch-ruby/blob/master/examples/percolator/percolator_alerts.rb>
+      #
+      # @option arguments [String] :index The index of the document being percolated. (*Required*)
+      # @option arguments [String] :type The type of the document being percolated. (*Required*)
+      # @option arguments [String] :id Fetch the document specified by index/type/id and
+      #                                use it instead of the passed `doc`
+      # @option arguments [Hash] :body The percolator request definition using the percolate DSL
+      # @option arguments [List] :routing A comma-separated list of specific routing values
+      # @option arguments [String] :preference Specify the node or shard the operation should be performed on
+      #                                        (default: random)
+      # @option arguments [Boolean] :ignore_unavailable Whether specified concrete indices should be ignored when
+      #                                                 unavailable (missing or closed)
+      # @option arguments [Boolean] :allow_no_indices Whether to ignore if a wildcard indices expression resolves into
+      #                                               no concrete indices. (This includes `_all` string or when no
+      #                                               indices have been specified)
+      # @option arguments [String] :expand_wildcards Whether to expand wildcard expression to concrete indices that are
+      #                                              open, closed or both. (options: open, closed)
+      # @option arguments [String] :percolate_index The index to percolate the document into. Defaults to passed `index`.
+      # @option arguments [String] :percolate_format Return an array of matching query IDs instead of objects.
+      #                                              (options: ids)
+      # @option arguments [String] :percolate_type The type to percolate document into. Defaults to passed `type`.
+      # @option arguments [Number] :version Explicit version number for concurrency control
+      # @option arguments [String] :version_type Specific version type (options: internal, external, external_gte, force)
+      #
+      # @see http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/search-percolate.html
+      #
+      def percolate(arguments={})
+        Utils.__report_unsupported_method :percolate
+
+        raise ArgumentError, "Required argument 'index' missing" unless arguments[:index]
+        raise ArgumentError, "Required argument 'type' missing"  unless arguments[:type]
+        method = HTTP_GET
+        path   = Utils.__pathify Utils.__escape(arguments[:index]),
+                                 Utils.__escape(arguments[:type]),
+                                 Utils.__escape(arguments[:id]),
+                                 '_percolate'
+
+        params = Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
+        body   = arguments[:body]
+
+        perform_request(method, path, params, body).body
+      end
+
+      # Register this action with its valid params when the module is loaded.
+      #
+      # @since 6.2.0
+      ParamsRegistry.register(:percolate, [
+          :routing,
+          :preference,
+          :ignore_unavailable,
+          :allow_no_indices,
+          :expand_wildcards,
+          :percolate_index,
+          :percolate_type,
+          :percolate_format,
+          :version,
+          :version_type ].freeze)
+    end
+  end
+end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/put_template.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/put_template.rb
@@ -1,0 +1,25 @@
+module Elasticsearch
+  module API
+    module Actions
+
+      # Store a template for the search definition in Elasticsearch,
+      # to be later used with the `search_template` method
+      #
+      # @option arguments [String] :id Template ID (*Required*)
+      # @option arguments [Hash] :body The document (*Required*)
+      #
+      # @see http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/search-template.html
+      #
+      def put_template(arguments={})
+        raise ArgumentError, "Required argument 'id' missing"   unless arguments[:id]
+        raise ArgumentError, "Required argument 'body' missing" unless arguments[:body]
+        method = HTTP_POST
+        path   = "_scripts/#{arguments[:id]}"
+        params = {}
+        body   = arguments[:body]
+
+        perform_request(method, path, params, body).body
+      end
+    end
+  end
+end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/remote/info.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/remote/info.rb
@@ -1,0 +1,21 @@
+module Elasticsearch
+  module API
+    module Remote
+      module Actions
+
+        # Returns all of the configured remote cluster information
+        #
+        # @see http://www.elastic.co/guide/en/elasticsearch/reference/master/remote-info.html
+        #
+        def info(arguments={})
+          method = HTTP_GET
+          path   = "_remote/info"
+          params = {}
+          body   = nil
+
+          perform_request(method, path, params, body).body
+        end
+      end
+    end
+  end
+end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/search_exists.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/search_exists.rb
@@ -1,0 +1,63 @@
+module Elasticsearch
+  module API
+    module Actions
+
+      # Return whether documents exists for a particular query
+      #
+      # @option arguments [List] :index A comma-separated list of indices to restrict the results
+      # @option arguments [List] :type A comma-separated list of types to restrict the results
+      # @option arguments [Hash] :body A query to restrict the results specified with the Query DSL (optional)
+      # @option arguments [Boolean] :ignore_unavailable Whether specified concrete indices should be ignored when
+      #                                                 unavailable (missing or closed)
+      # @option arguments [Boolean] :allow_no_indices Whether to ignore if a wildcard indices expression resolves
+      #                                               into no concrete indices.
+      # @option arguments [String] :expand_wildcards Whether to expand wildcard expression to concrete indices
+      #                                              that are open, closed or both.
+      #                                              (options: open, closed, none, all)
+      # @option arguments [Number] :min_score Include only documents with a specific `_score` value in the result
+      # @option arguments [String] :preference Specify the node or shard the operation should be performed on
+      #                                        (default: random)
+      # @option arguments [String] :routing Specific routing value
+      # @option arguments [String] :q Query in the Lucene query string syntax
+      # @option arguments [String] :analyzer The analyzer to use for the query string
+      # @option arguments [Boolean] :analyze_wildcard Specify whether wildcard and prefix queries should be
+      #                                               analyzed (default: false)
+      # @option arguments [String] :default_operator The default operator for query string query (AND or OR)
+      #                                              (options: AND, OR)
+      # @option arguments [String] :df The field to use as default where no field prefix is given
+      #                                in the query string
+      # @option arguments [Boolean] :lenient Specify whether format-based query failures
+      #                                      (such as providing text to a numeric field) should be ignored
+      # @option arguments [Boolean] :lowercase_expanded_terms Specify whether query terms should be lowercased
+      #
+      # @see http://www.elastic.co/guide/en/elasticsearch/reference/master/search-exists.html
+      #
+      def search_exists(arguments={})
+        method = 'POST'
+        path   = "_search/exists"
+        params = Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
+        body   = arguments[:body]
+
+        perform_request(method, path, params, body).body
+      end
+
+      # Register this action with its valid params when the module is loaded.
+      #
+      # @since 6.2.0
+      ParamsRegistry.register(:search_exists, [
+          :ignore_unavailable,
+          :allow_no_indices,
+          :expand_wildcards,
+          :min_score,
+          :preference,
+          :routing,
+          :q,
+          :analyzer,
+          :analyze_wildcard,
+          :default_operator,
+          :df,
+          :lenient,
+          :lowercase_expanded_terms ].freeze)
+    end
+  end
+end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/suggest.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/suggest.rb
@@ -1,0 +1,49 @@
+module Elasticsearch
+  module API
+    module Actions
+
+      # Return query terms suggestions based on provided text and configuration.
+      #
+      # Pass the request definition in the `:body` argument.
+      #
+      # @example Return query terms suggestions ("auto-correction")
+      #
+      #     client.suggest index: 'myindex',
+      #                    body: { my_suggest: { text: 'tset', term: { field: 'title' } } }
+      #     # => { ... "my_suggest"=>[ {"text"=>"tset", ... "options"=>[{"text"=>"test", "score"=>0.75, "freq"=>5}] }]}
+      #
+      # @option arguments [List] :index A comma-separated list of index names to restrict the operation;
+      #                                 use `_all` or empty string to perform the operation on all indices
+      # @option arguments [Hash] :body The request definition
+      # @option arguments [String] :ignore_indices When performed on multiple indices, allows to ignore `missing` ones
+      #                                            (options: none, missing)
+      # @option arguments [String] :preference Specify the node or shard the operation should be performed on
+      #                                        (default: random)
+      # @option arguments [String] :routing Specific routing value
+      # @option arguments [String] :source The URL-encoded request definition (instead of using request body)
+      #
+      # @since 0.90
+      #
+      # @see http://elasticsearch.org/guide/reference/api/search/suggest/
+      #
+      def suggest(arguments={})
+        method = HTTP_POST
+        path   = Utils.__pathify( Utils.__listify(arguments[:index]), '_suggest' )
+
+        params = Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
+        body   = arguments[:body]
+
+        perform_request(method, path, params, body).body
+      end
+
+      # Register this action with its valid params when the module is loaded.
+      #
+      # @since 6.2.0
+      ParamsRegistry.register(:suggest, [
+          :ignore_indices,
+          :preference,
+          :routing,
+          :source ].freeze)
+    end
+  end
+end

--- a/elasticsearch-api/spec/elasticsearch/api/actions/delete_template_spec.rb
+++ b/elasticsearch-api/spec/elasticsearch/api/actions/delete_template_spec.rb
@@ -1,0 +1,17 @@
+require 'spec_helper'
+
+describe 'client#delete_template' do
+
+  let(:expected_args) do
+    [
+        'DELETE',
+        '_search/template/foo',
+        {},
+        nil
+    ]
+  end
+
+  it 'performs the request' do
+    expect(client_double.delete_template(id: 'foo')).to eq({})
+  end
+end

--- a/elasticsearch-api/spec/elasticsearch/api/actions/field_stats_spec.rb
+++ b/elasticsearch-api/spec/elasticsearch/api/actions/field_stats_spec.rb
@@ -1,0 +1,17 @@
+require 'spec_helper'
+
+describe 'client#field_stats' do
+
+  let(:expected_args) do
+    [
+        'GET',
+        '_field_stats',
+        { },
+        nil
+    ]
+  end
+
+  it 'performs the request' do
+    expect(client_double.field_stats).to eq({})
+  end
+end

--- a/elasticsearch-api/spec/elasticsearch/api/actions/get_template_spec.rb
+++ b/elasticsearch-api/spec/elasticsearch/api/actions/get_template_spec.rb
@@ -1,0 +1,52 @@
+require 'spec_helper'
+
+describe 'client#get_template' do
+
+  let(:expected_args) do
+    [
+        'GET',
+        url,
+        params,
+        nil
+    ]
+  end
+
+  let(:params) do
+    { }
+  end
+
+  let(:client) do
+    Class.new { include Elasticsearch::API }.new
+  end
+
+  context 'when the `lang` parameter is specified' do
+
+    let(:url) do
+      '_scripts/foo'
+    end
+
+    it 'performs the request' do
+      expect(client_double.get_template(id: 'foo')).to eq({})
+    end
+  end
+
+  context 'when the request raises a NotFound exception' do
+
+    before do
+      expect(client).to receive(:perform_request).and_raise(NotFound)
+    end
+
+    it 'raises the exception' do
+      expect {
+        client.get_template(id: 'foo')
+      }.to raise_exception(NotFound)
+    end
+
+    context 'when the ignore parameter is specified' do
+
+      it 'returns false' do
+        expect(client.get_template(id: 'foo', ignore: 404)).to eq(false)
+      end
+    end
+  end
+end

--- a/elasticsearch-api/spec/elasticsearch/api/actions/indices/delete_mapping_spec.rb
+++ b/elasticsearch-api/spec/elasticsearch/api/actions/indices/delete_mapping_spec.rb
@@ -1,0 +1,77 @@
+require 'spec_helper'
+
+describe 'client.indices#delete_mapping' do
+
+  let(:expected_args) do
+    [
+        'DELETE',
+        url,
+        params,
+        nil,
+        nil
+    ]
+  end
+
+  let(:params) do
+    {}
+  end
+
+  context 'when there is no index specified' do
+
+    let(:client) do
+      Class.new { include Elasticsearch::API }.new
+    end
+
+    it 'raises an exception' do
+      expect {
+        client.indices.delete_mapping(type: 'foo')
+      }.to raise_exception(ArgumentError)
+    end
+  end
+
+  context 'when there is no type specified' do
+
+    let(:client) do
+      Class.new { include Elasticsearch::API }.new
+    end
+
+    it 'raises an exception' do
+      expect {
+        client.indices.delete_mapping(index: 'foo')
+      }.to raise_exception(ArgumentError)
+    end
+  end
+
+  context 'when an index and type are specified' do
+
+    let(:url) do
+      'foo/bar'
+    end
+
+    it 'performs the request' do
+      expect(client_double.indices.delete_mapping(index: 'foo', type: 'bar')).to eq({})
+    end
+  end
+
+  context 'when multiple indices are specified' do
+
+    let(:url) do
+      'foo,bar/baz'
+    end
+
+    it 'performs the request' do
+      expect(client_double.indices.delete_mapping(index: ['foo','bar'], type: 'baz')).to eq({})
+    end
+  end
+
+  context 'when the path must be URL-escaped' do
+
+    let(:url) do
+      'foo%5Ebar/bar%2Fbam'
+    end
+
+    it 'performs the request' do
+      expect(client_double.indices.delete_mapping(index: 'foo^bar', type: 'bar/bam')).to eq({})
+    end
+  end
+end

--- a/elasticsearch-api/spec/elasticsearch/api/actions/indices/delete_warmer_spec.rb
+++ b/elasticsearch-api/spec/elasticsearch/api/actions/indices/delete_warmer_spec.rb
@@ -1,0 +1,86 @@
+require 'spec_helper'
+
+describe 'client.indices#delete_warmer' do
+
+  let(:expected_args) do
+    [
+        'DELETE',
+        url,
+        params,
+        nil,
+        nil
+    ]
+  end
+
+  let(:params) do
+    {}
+  end
+
+  context 'when an index is not specified' do
+
+    let(:client) do
+      Class.new { include Elasticsearch::API }.new
+    end
+
+    it 'raises an exception' do
+      expect {
+        client.indices.delete_warmer
+      }.to raise_exception(ArgumentError)
+    end
+  end
+
+  context 'when an index is specified' do
+
+    let(:url) do
+      'foo/_warmer'
+    end
+
+    it 'performs the request' do
+      expect(client_double.indices.delete_warmer(index: 'foo')).to eq({})
+    end
+  end
+
+  context 'when multiple indices are specified' do
+
+    let(:url) do
+      'foo,bar/_warmer'
+    end
+
+    it 'performs the request' do
+      expect(client_double.indices.delete_warmer(index: ['foo', 'bar'])).to eq({})
+    end
+  end
+
+  context 'when a single warmer is specified' do
+
+    let(:url) do
+      'foo/_warmer/bar'
+    end
+
+    it 'performs the request' do
+      expect(client_double.indices.delete_warmer(index: 'foo', name: 'bar')).to eq({})
+    end
+  end
+
+  context 'when a multiple warmers are specified' do
+
+    let(:url) do
+      'foo/_warmer/bar,baz'
+    end
+
+    it 'performs the request' do
+      expect(client_double.indices.delete_warmer(index: 'foo', name: ['bar', 'baz'])).to eq({})
+    end
+  end
+
+  context 'when the path needs to be URL-escaped' do
+
+    let(:url) do
+      'foo%5Ebar/_warmer/bar%2Fbam'
+    end
+
+    it 'performs the request' do
+      expect(client_double.indices.delete_warmer(index: 'foo^bar', name: 'bar/bam')).to eq({})
+    end
+  end
+end

--- a/elasticsearch-api/spec/elasticsearch/api/actions/indices/get_aliases_spec.rb
+++ b/elasticsearch-api/spec/elasticsearch/api/actions/indices/get_aliases_spec.rb
@@ -1,0 +1,55 @@
+require 'spec_helper'
+
+describe 'client.cluster#get_aliases' do
+
+  let(:expected_args) do
+    [
+        'GET',
+        url,
+        {},
+        nil,
+        nil
+    ]
+  end
+
+  let(:url) do
+    '_aliases'
+  end
+
+  it 'performs the request' do
+    expect(client_double.indices.get_aliases).to eq({})
+  end
+
+  context 'when an index is specified' do
+
+    let(:url) do
+      'foo/_aliases'
+    end
+
+    it 'performs the request' do
+      expect(client_double.indices.get_aliases(index: 'foo')).to eq({})
+    end
+  end
+
+  context 'when a specified alias is specified' do
+
+    let(:url) do
+      'foo/_aliases/bar'
+    end
+
+    it 'performs the request' do
+      expect(client_double.indices.get_aliases(index: 'foo', name: 'bar')).to eq({})
+    end
+  end
+
+  context 'when the path needs to be URL-escaped' do
+
+    let(:url) do
+      'foo%5Ebar/_aliases'
+    end
+
+    it 'performs the request' do
+      expect(client_double.indices.get_aliases(index: 'foo^bar')).to eq({})
+    end
+  end
+end

--- a/elasticsearch-api/spec/elasticsearch/api/actions/indices/get_warmer_spec.rb
+++ b/elasticsearch-api/spec/elasticsearch/api/actions/indices/get_warmer_spec.rb
@@ -1,0 +1,48 @@
+require 'spec_helper'
+
+describe 'client.indices#get_warmer' do
+
+  let(:expected_args) do
+    [
+        'GET',
+        url,
+        params,
+        nil,
+        nil
+    ]
+  end
+
+  let(:params) do
+    {}
+  end
+
+  let(:url) do
+    '_all/_warmer'
+  end
+
+  it 'performs the request' do
+    expect(client_double.indices.get_warmer(index: '_all')).to eq({})
+  end
+
+  context 'when a specified warmer is specified' do
+
+    let(:url) do
+      'foo/_warmer/bar'
+    end
+
+    it 'performs the request' do
+      expect(client_double.indices.get_warmer(index: 'foo', name: 'bar')).to eq({})
+    end
+  end
+
+  context 'when the path must be URL-escaped' do
+
+    let(:url) do
+      'foo%5Ebar/_warmer/bar%2Fbam'
+    end
+
+    it 'performs the request' do
+      expect(client_double.indices.get_warmer(index: 'foo^bar', name: 'bar/bam')).to eq({})
+    end
+  end
+end

--- a/elasticsearch-api/spec/elasticsearch/api/actions/indices/optimize_spec.rb
+++ b/elasticsearch-api/spec/elasticsearch/api/actions/indices/optimize_spec.rb
@@ -1,0 +1,63 @@
+require 'spec_helper'
+
+describe 'client.indices#optimize' do
+
+  let(:expected_args) do
+    [
+        'POST',
+        url,
+        params,
+        nil,
+        nil
+    ]
+  end
+
+  let(:params) do
+    {}
+  end
+
+  let(:url) do
+    '_optimize'
+  end
+
+  it 'performs the request' do
+    expect(client_double.indices.optimize).to eq({})
+  end
+
+  context 'when multiple indices are specified' do
+
+    let(:url) do
+      'foo,bar/_optimize'
+    end
+
+    it 'performs the request' do
+      expect(client_double.indices.optimize(index: ['foo', 'bar'])).to eq({})
+    end
+  end
+
+  context 'when parameters are specified' do
+
+    let(:params) do
+      { max_num_segments: 1 }
+    end
+
+    let(:url) do
+      'foo/_optimize'
+    end
+
+    it 'performs the request' do
+      expect(client_double.indices.optimize(index: 'foo', max_num_segments: 1)).to eq({})
+    end
+  end
+
+  context 'when the path must be URL-escaped' do
+
+    let(:url) do
+      'foo%5Ebar/_optimize'
+    end
+
+    it 'performs the request' do
+      expect(client_double.indices.optimize(index: 'foo^bar')).to eq({})
+    end
+  end
+end

--- a/elasticsearch-api/spec/elasticsearch/api/actions/indices/put_warmer_spec.rb
+++ b/elasticsearch-api/spec/elasticsearch/api/actions/indices/put_warmer_spec.rb
@@ -1,0 +1,101 @@
+require 'spec_helper'
+
+describe 'client.cluster#put_warmer' do
+
+  let(:expected_args) do
+    [
+        'PUT',
+        url,
+        params,
+        body,
+        nil
+    ]
+  end
+
+  let(:url) do
+    'foo/_warmer/bar'
+  end
+
+  let(:body) do
+    { query: { match_all: {} } }
+  end
+
+  let(:params) do
+    {}
+  end
+
+  it 'performs the request' do
+    expect(client_double.indices.put_warmer(index: 'foo', name: 'bar', body: { query: { match_all: {} } })).to eq({})
+  end
+
+  context 'when there is no name specified' do
+
+    let(:client) do
+      Class.new { include Elasticsearch::API }.new
+    end
+
+    it 'raises an exception' do
+      expect {
+        client.indices.put_warmer(body: {})
+      }.to raise_exception(ArgumentError)
+    end
+  end
+
+  context 'when there is no body specified' do
+
+    let(:client) do
+      Class.new { include Elasticsearch::API }.new
+    end
+
+    it 'raises an exception' do
+      expect {
+        client.indices.put_warmer(name: 'foo')
+      }.to raise_exception(ArgumentError)
+    end
+  end
+
+  context 'when multiple indices are specified' do
+
+    let(:url) do
+      'foo,bar/_warmer/xul'
+    end
+
+    let(:body) do
+      {}
+    end
+
+    it 'performs the request' do
+      expect(client_double.indices.put_warmer(index: ['foo', 'bar'], name: 'xul', body: {})).to eq({})
+    end
+  end
+
+  context 'when a type is specified' do
+
+    let(:url) do
+      'foo/bar/_warmer/xul'
+    end
+
+    let(:body) do
+      {}
+    end
+
+    it 'performs the request' do
+      expect(client_double.indices.put_warmer(index: 'foo', type: 'bar', name: 'xul', body: {})).to eq({})
+    end
+  end
+
+  context 'when the path needs to be URL-escaped' do
+
+    let(:url) do
+      'foo%5Ebar/bar%2Fbam/_warmer/qu+uz'
+    end
+
+    let(:body) do
+      {}
+    end
+
+    it 'performs the request' do
+      expect(client_double.indices.put_warmer(index: 'foo^bar', type: 'bar/bam', name: 'qu uz', body: {})).to eq({})
+    end
+  end
+end

--- a/elasticsearch-api/spec/elasticsearch/api/actions/indices/seal_spec.rb
+++ b/elasticsearch-api/spec/elasticsearch/api/actions/indices/seal_spec.rb
@@ -1,0 +1,18 @@
+require 'spec_helper'
+
+describe 'client.cluster#seal' do
+
+  let(:expected_args) do
+    [
+        'POST',
+        'foo/_seal',
+        {},
+        nil,
+        nil
+    ]
+  end
+
+  it 'performs the request' do
+    expect(client_double.indices.seal(index: 'foo')).to eq({})
+  end
+end

--- a/elasticsearch-api/spec/elasticsearch/api/actions/indices/snapshot_index_spec.rb
+++ b/elasticsearch-api/spec/elasticsearch/api/actions/indices/snapshot_index_spec.rb
@@ -1,0 +1,89 @@
+require 'spec_helper'
+
+describe 'client.cluster#snapshot_index' do
+
+  let(:expected_args) do
+    [
+        'POST',
+        url,
+        params,
+        body,
+        nil
+    ]
+  end
+
+  let(:url) do
+    '_gateway/snapshot'
+  end
+
+  let(:body) do
+    nil
+  end
+
+  let(:params) do
+    {}
+  end
+
+  it 'performs the request' do
+    expect(client_double.indices.snapshot_index).to eq({})
+  end
+
+  context 'when an index is specified' do
+
+    let(:url) do
+      'foo/_gateway/snapshot'
+    end
+
+    it 'performs the request' do
+      expect(client_double.indices.snapshot_index(index: 'foo')).to eq({})
+    end
+  end
+
+  context 'when multiple indicies are specified as a list' do
+
+    let(:url) do
+      'foo,bar/_gateway/snapshot'
+    end
+
+    it 'performs the request' do
+      expect(client_double.indices.snapshot_index(index: ['foo', 'bar'])).to eq({})
+    end
+  end
+
+  context 'when multiple indicies are specified as a string' do
+
+    let(:url) do
+      'foo,bar/_gateway/snapshot'
+    end
+
+    it 'performs the request' do
+      expect(client_double.indices.snapshot_index(index: 'foo,bar')).to eq({})
+    end
+  end
+
+  context 'when parameters are specified' do
+
+    let(:params) do
+      { ignore_indices: 'missing' }
+    end
+
+    let(:url) do
+      'foo/_gateway/snapshot'
+    end
+
+    it 'performs the request' do
+      expect(client_double.indices.snapshot_index(index: 'foo', ignore_indices: 'missing')).to eq({})
+    end
+  end
+
+  context 'when the path needs to be URL-escaped' do
+
+    let(:url) do
+      'foo%5Ebar/_gateway/snapshot'
+    end
+
+    it 'performs the request' do
+      expect(client_double.indices.snapshot_index(index: 'foo^bar')).to eq({})
+    end
+  end
+end

--- a/elasticsearch-api/spec/elasticsearch/api/actions/indices/status_spec.rb
+++ b/elasticsearch-api/spec/elasticsearch/api/actions/indices/status_spec.rb
@@ -1,0 +1,92 @@
+require 'spec_helper'
+
+describe 'client.cluster#status' do
+
+  let(:expected_args) do
+    [
+        'GET',
+        url,
+        params,
+        body,
+        nil
+    ]
+  end
+
+  let(:url) do
+    '_status'
+  end
+
+  let(:body) do
+    nil
+  end
+
+  let(:params) do
+    {}
+  end
+
+  it 'performs the request' do
+    expect(client_double.indices.status).to eq({})
+  end
+
+  context 'when an index is specified' do
+
+    let(:url) do
+      'foo/_status'
+    end
+
+    it 'performs the request' do
+      expect(client_double.indices.status(index: 'foo')).to eq({})
+    end
+  end
+
+  context 'when multiple indicies are specified as a list' do
+
+    let(:url) do
+      'foo,bar/_status'
+    end
+
+    it 'performs the request' do
+      expect(client_double.indices.status(index: ['foo', 'bar'])).to eq({})
+    end
+  end
+
+  context 'when multiple indicies are specified as a string' do
+
+
+    let(:url) do
+      'foo,bar/_status'
+    end
+
+    it 'performs the request' do
+      expect(client_double.indices.status(index: 'foo,bar')).to eq({})
+    end
+  end
+
+  context 'when parameters are specified' do
+
+    let(:params) do
+      { recovery: true }
+    end
+
+    let(:url) do
+      'foo/_status'
+    end
+
+    it 'performs the request' do
+      expect(client_double.indices.status(index: 'foo', recovery: true)).to eq({})
+    end
+  end
+
+  context 'when a \'not found\' exception is raised' do
+
+    let(:client) do
+      Class.new { include Elasticsearch::API }.new.tap do |_client|
+        expect(_client).to receive(:perform_request).and_raise(NotFound)
+      end
+    end
+
+    it 'does not raise the exception' do
+      expect(client.indices.status(index: 'foo', ignore: 404)).to eq(false)
+    end
+  end
+end

--- a/elasticsearch-api/spec/elasticsearch/api/actions/list_benchmarks_spec.rb
+++ b/elasticsearch-api/spec/elasticsearch/api/actions/list_benchmarks_spec.rb
@@ -1,0 +1,17 @@
+require 'spec_helper'
+
+describe 'client#list_benchmarks' do
+
+  let(:expected_args) do
+    [
+        'GET',
+        '_bench',
+        { },
+        nil
+    ]
+  end
+
+  it 'performs the request' do
+    expect(client_double.list_benchmarks).to eq({})
+  end
+end

--- a/elasticsearch-api/spec/elasticsearch/api/actions/mlt_spec.rb
+++ b/elasticsearch-api/spec/elasticsearch/api/actions/mlt_spec.rb
@@ -1,0 +1,130 @@
+module Elasticsearch
+  module API
+    module Actions
+
+      # Return documents similar to the specified one.
+      #
+      # Performs a `more_like_this` query with the specified document as the input.
+      #
+      # @example Search for similar documents using the `title` property of document `myindex/mytype/1`
+      #
+      #     # First, let's setup a synonym-aware analyzer ("quick" <=> "fast")
+      #     client.indices.create index: 'myindex', body: {
+      #       settings: {
+      #         analysis: {
+      #           filter: {
+      #             synonyms: {
+      #               type: 'synonym',
+      #               synonyms: [ "quick,fast" ]
+      #             }
+      #           },
+      #           analyzer: {
+      #             title_synonym: {
+      #               type: 'custom',
+      #               tokenizer: 'whitespace',
+      #               filter: ['lowercase', 'stop', 'snowball', 'synonyms']
+      #             }
+      #           }
+      #         }
+      #       },
+      #       mappings: {
+      #         mytype: {
+      #           properties: {
+      #             title: {
+      #               type: 'string',
+      #               analyzer: 'title_synonym'
+      #             }
+      #           }
+      #         }
+      #       }
+      #     }
+      #
+      #     # Index three documents
+      #     client.index index: 'myindex', type: 'mytype', id: 1, body: { title: 'Quick Brown Fox'   }
+      #     client.index index: 'myindex', type: 'mytype', id: 2, body: { title: 'Slow Black Dog'    }
+      #     client.index index: 'myindex', type: 'mytype', id: 3, body: { title: 'Fast White Rabbit' }
+      #     client.indices.refresh index: 'myindex'
+      #
+      #     client.mlt index: 'myindex', type: 'mytype', id: 1, mlt_fields: 'title', min_doc_freq: 1, min_term_freq: 1
+      #     # => { ... {"title"=>"Fast White Rabbit"}}]}}
+      #
+      # @option arguments [String] :id The document ID (*Required*)
+      # @option arguments [String] :index The name of the index (*Required*)
+      # @option arguments [String] :type The type of the document (use `_all` to fetch
+      #                                  the first document matching the ID across all types) (*Required*)
+      # @option arguments [Hash] :body A specific search request definition
+      # @option arguments [Number] :boost_terms The boost factor
+      # @option arguments [Number] :max_doc_freq The word occurrence frequency as count: words with higher occurrence
+      #                                          in the corpus will be ignored
+      # @option arguments [Number] :max_query_terms The maximum query terms to be included in the generated query
+      # @option arguments [Number] :max_word_len The minimum length of the word: longer words will be ignored
+      # @option arguments [Number] :min_doc_freq The word occurrence frequency as count: words with lower occurrence
+      #                                          in the corpus will be ignored
+      # @option arguments [Number] :min_term_freq The term frequency as percent: terms with lower occurence
+      #                                           in the source document will be ignored
+      # @option arguments [Number] :min_word_len The minimum length of the word: shorter words will be ignored
+      # @option arguments [List] :mlt_fields Specific fields to perform the query against
+      # @option arguments [Number] :percent_terms_to_match How many terms have to match in order to consider
+      #                                                    the document a match (default: 0.3)
+      # @option arguments [String] :routing Specific routing value
+      # @option arguments [Number] :search_from The offset from which to return results
+      # @option arguments [List] :search_indices A comma-separated list of indices to perform the query against
+      #                                          (default: the index containing the document)
+      # @option arguments [String] :search_query_hint The search query hint
+      # @option arguments [String] :search_scroll A scroll search request definition
+      # @option arguments [Number] :search_size The number of documents to return (default: 10)
+      # @option arguments [String] :search_source A specific search request definition (instead of using the request body)
+      # @option arguments [String] :search_type Specific search type (eg. `dfs_then_fetch`, `count`, etc)
+      # @option arguments [List] :search_types A comma-separated list of types to perform the query against
+      #                                        (default: the same type as the document)
+      # @option arguments [List] :stop_words A list of stop words to be ignored
+      #
+      # @see http://elasticsearch.org/guide/reference/api/more-like-this/
+      #
+      def mlt(arguments={})
+        raise ArgumentError, "Required argument 'index' missing" unless arguments[:index]
+        raise ArgumentError, "Required argument 'type' missing"  unless arguments[:type]
+        raise ArgumentError, "Required argument 'id' missing"    unless arguments[:id]
+        method = HTTP_GET
+        path   = Utils.__pathify Utils.__escape(arguments[:index]),
+                                 Utils.__escape(arguments[:type]),
+                                 Utils.__escape(arguments[:id]),
+                                 '_mlt'
+
+        params = Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
+
+        [:mlt_fields, :search_indices, :search_types, :stop_words].each do |name|
+          params[name] = Utils.__listify(params[name]) if params[name]
+        end
+
+        body   = arguments[:body]
+
+        perform_request(method, path, params, body).body
+      end
+
+      # Register this action with its valid params when the module is loaded.
+      #
+      # @since 6.2.0
+      ParamsRegistry.register(:mlt, [
+          :boost_terms,
+          :max_doc_freq,
+          :max_query_terms,
+          :max_word_len,
+          :min_doc_freq,
+          :min_term_freq,
+          :min_word_len,
+          :mlt_fields,
+          :percent_terms_to_match,
+          :routing,
+          :search_from,
+          :search_indices,
+          :search_query_hint,
+          :search_scroll,
+          :search_size,
+          :search_source,
+          :search_type,
+          :search_types,
+          :stop_words ].freeze)
+    end
+  end
+end

--- a/elasticsearch-api/spec/elasticsearch/api/actions/mpercolate_spec.rb
+++ b/elasticsearch-api/spec/elasticsearch/api/actions/mpercolate_spec.rb
@@ -1,0 +1,49 @@
+require 'spec_helper'
+
+describe 'client#mpercolate' do
+
+  let(:expected_args) do
+    [
+        'GET',
+        '_mpercolate',
+        params,
+        body
+    ]
+  end
+
+  let(:body) do
+    nil
+  end
+
+  let(:params) do
+    {}
+  end
+
+  context 'when a body is provided as a document' do
+
+    let(:body) do
+      "{\"percolate\":{\"index\":\"my-index\",\"type\":\"my-type\"}}\n{\"doc\":{\"message\":\"foo bar\"}}\n" +
+          "{\"percolate\":{\"index\":\"my-other-index\",\"type\":\"my-other-type\",\"id\":\"1\"}}\n{}\n"
+    end
+
+    it 'performs the request' do
+      expect(client_double.mpercolate(body: [
+          { percolate: { index: "my-index", type: "my-type" } },
+          { doc: { message: "foo bar" } },
+          { percolate: { index: "my-other-index", type: "my-other-type", id: "1" } },
+          { }
+      ])).to eq({})
+    end
+  end
+
+  context 'when a body is provided as a string' do
+
+    let(:body) do
+      %Q|{"foo":"bar"}\n{"moo":"lam"}|
+    end
+
+    it 'performs the request' do
+      expect(client_double.mpercolate(body: %Q|{"foo":"bar"}\n{"moo":"lam"}|)).to eq({})
+    end
+  end
+end

--- a/elasticsearch-api/spec/elasticsearch/api/actions/nodes/shutdown_spec.rb
+++ b/elasticsearch-api/spec/elasticsearch/api/actions/nodes/shutdown_spec.rb
@@ -1,0 +1,59 @@
+require 'spec_helper'
+
+describe 'client.nodes#shutdown' do
+
+  let(:expected_args) do
+    [
+        'POST',
+        url,
+        params,
+        nil,
+        nil
+    ]
+  end
+
+  let(:url) do
+    '_cluster/nodes/_shutdown'
+  end
+
+  it 'performs the request' do
+    expect(client_double.nodes.shutdown).to eq({})
+  end
+
+  let(:params) do
+    {}
+  end
+
+  context 'when the node id is specified' do
+
+    let(:url) do
+      '_cluster/nodes/foo/_shutdown'
+    end
+
+    it 'performs the request' do
+      expect(client_double.nodes.shutdown(node_id: 'foo')).to eq({})
+    end
+  end
+
+  context 'when multiple node ids are specified as a list' do
+
+    let(:url) do
+      '_cluster/nodes/A,B,C/_shutdown'
+    end
+
+    it 'performs the request' do
+      expect(client_double.nodes.shutdown(node_id: ['A', 'B', 'C'])).to eq({})
+    end
+  end
+
+  context 'when multiple node ids are specified as a String' do
+
+    let(:url) do
+      '_cluster/nodes/A,B,C/_shutdown'
+    end
+
+    it 'performs the request' do
+      expect(client_double.nodes.shutdown(node_id: 'A,B,C')).to eq({})
+    end
+  end
+end

--- a/elasticsearch-api/spec/elasticsearch/api/actions/percolate_spec.rb
+++ b/elasticsearch-api/spec/elasticsearch/api/actions/percolate_spec.rb
@@ -1,0 +1,67 @@
+require 'spec_helper'
+
+describe 'client#percolate' do
+
+  let(:expected_args) do
+    [
+        'GET',
+        url,
+        { },
+        body
+    ]
+  end
+
+  let(:body) do
+    { doc: { foo: 'bar' }}
+  end
+
+  let(:url) do
+    'foo/bar/_percolate'
+  end
+
+  let(:client) do
+    Class.new { include Elasticsearch::API }.new
+  end
+
+  it 'requires the :index argument' do
+    expect {
+      client.percolate(type: 'bar', body: {})
+    }.to raise_exception(ArgumentError)
+  end
+
+  it 'requires the :type argument' do
+    expect {
+      client.percolate(index: 'foo', body: {})
+    }.to raise_exception(ArgumentError)
+  end
+
+  it 'performs the request' do
+    expect(client_double.percolate(index: 'foo', type: 'bar', body: { doc: { foo: 'bar' } })).to eq({})
+  end
+
+  context 'when the request needs to be URL-escaped' do
+
+    let(:url) do
+      'foo%5Ebar/bar%2Fbam/_percolate'
+    end
+
+    it 'URL-escapes the parts' do
+      expect(client_double.percolate(index: 'foo^bar', type: 'bar/bam', body: { doc: { foo: 'bar' } })).to eq({})
+    end
+  end
+
+  context 'when the document id needs to be URL-escaped' do
+
+    let(:url) do
+      'foo%5Ebar/bar%2Fbam/some%2Fid/_percolate'
+    end
+
+    let(:body) do
+      nil
+    end
+
+    it 'URL-escapes the id' do
+      expect(client_double.percolate(index: 'foo^bar', type: 'bar/bam', id: 'some/id')).to eq({})
+    end
+  end
+end

--- a/elasticsearch-api/spec/elasticsearch/api/actions/put_template_spec.rb
+++ b/elasticsearch-api/spec/elasticsearch/api/actions/put_template_spec.rb
@@ -1,0 +1,17 @@
+require 'spec_helper'
+
+describe 'client#put_template' do
+
+  let(:expected_args) do
+    [
+        'POST',
+        '_scripts/foo',
+        { },
+        { }
+    ]
+  end
+
+  it 'performs the request' do
+    expect(client_double.put_template(id: 'foo', body: { })).to eq({})
+  end
+end

--- a/elasticsearch-api/spec/elasticsearch/api/actions/remote/info_spec.rb
+++ b/elasticsearch-api/spec/elasticsearch/api/actions/remote/info_spec.rb
@@ -1,0 +1,18 @@
+require 'spec_helper'
+
+describe 'client.remote#info' do
+
+  let(:expected_args) do
+    [
+        'GET',
+        '_remote/info',
+        {},
+        nil,
+        nil
+    ]
+  end
+
+  it 'performs the request' do
+    expect(client_double.remote.info).to eq({})
+  end
+end

--- a/elasticsearch-api/spec/elasticsearch/api/actions/search_exists_spec.rb
+++ b/elasticsearch-api/spec/elasticsearch/api/actions/search_exists_spec.rb
@@ -1,0 +1,63 @@
+module Elasticsearch
+  module API
+    module Actions
+
+      # Return whether documents exists for a particular query
+      #
+      # @option arguments [List] :index A comma-separated list of indices to restrict the results
+      # @option arguments [List] :type A comma-separated list of types to restrict the results
+      # @option arguments [Hash] :body A query to restrict the results specified with the Query DSL (optional)
+      # @option arguments [Boolean] :ignore_unavailable Whether specified concrete indices should be ignored when
+      #                                                 unavailable (missing or closed)
+      # @option arguments [Boolean] :allow_no_indices Whether to ignore if a wildcard indices expression resolves
+      #                                               into no concrete indices.
+      # @option arguments [String] :expand_wildcards Whether to expand wildcard expression to concrete indices
+      #                                              that are open, closed or both.
+      #                                              (options: open, closed, none, all)
+      # @option arguments [Number] :min_score Include only documents with a specific `_score` value in the result
+      # @option arguments [String] :preference Specify the node or shard the operation should be performed on
+      #                                        (default: random)
+      # @option arguments [String] :routing Specific routing value
+      # @option arguments [String] :q Query in the Lucene query string syntax
+      # @option arguments [String] :analyzer The analyzer to use for the query string
+      # @option arguments [Boolean] :analyze_wildcard Specify whether wildcard and prefix queries should be
+      #                                               analyzed (default: false)
+      # @option arguments [String] :default_operator The default operator for query string query (AND or OR)
+      #                                              (options: AND, OR)
+      # @option arguments [String] :df The field to use as default where no field prefix is given
+      #                                in the query string
+      # @option arguments [Boolean] :lenient Specify whether format-based query failures
+      #                                      (such as providing text to a numeric field) should be ignored
+      # @option arguments [Boolean] :lowercase_expanded_terms Specify whether query terms should be lowercased
+      #
+      # @see http://www.elastic.co/guide/en/elasticsearch/reference/master/search-exists.html
+      #
+      def search_exists(arguments={})
+        method = 'POST'
+        path   = "_search/exists"
+        params = Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
+        body   = arguments[:body]
+
+        perform_request(method, path, params, body).body
+      end
+
+      # Register this action with its valid params when the module is loaded.
+      #
+      # @since 6.2.0
+      ParamsRegistry.register(:search_exists, [
+          :ignore_unavailable,
+          :allow_no_indices,
+          :expand_wildcards,
+          :min_score,
+          :preference,
+          :routing,
+          :q,
+          :analyzer,
+          :analyze_wildcard,
+          :default_operator,
+          :df,
+          :lenient,
+          :lowercase_expanded_terms ].freeze)
+    end
+  end
+end

--- a/elasticsearch-api/spec/elasticsearch/api/actions/suggest_spec.rb
+++ b/elasticsearch-api/spec/elasticsearch/api/actions/suggest_spec.rb
@@ -1,0 +1,77 @@
+require 'spec_helper'
+
+describe 'client#suggest' do
+
+  let(:expected_args) do
+    [
+        'POST',
+        url,
+        params,
+        body
+    ]
+  end
+
+  let(:url) do
+    '_suggest'
+  end
+
+  let(:params) do
+    {}
+  end
+
+  let(:body) do
+    {}
+  end
+
+  it 'performs the request' do
+    expect(client_double.suggest(body: {})).to eq({})
+  end
+
+  context 'when an index is specified' do
+
+    let(:url) do
+      'foo/_suggest'
+    end
+
+    it 'performs the request' do
+      expect(client_double.suggest(index: 'foo', body: {}))
+    end
+  end
+
+  context 'when there are URL params specified' do
+
+    let(:url) do
+      'foo/_suggest'
+    end
+
+    let(:params) do
+      { routing: 'abc123' }
+    end
+
+    it 'performs the request' do
+      expect(client_double.suggest(index: 'foo', routing: 'abc123', body: {}))
+    end
+  end
+
+  context 'when the request must be URL-escaped' do
+
+    let(:url) do
+      'foo%5Ebar/_suggest'
+    end
+
+    it 'performs the request' do
+      expect(client_double.suggest(index: 'foo^bar', body: {}))
+    end
+  end
+
+  context 'when the request definition is specified in the body' do
+
+    let(:body) do
+      { my_suggest: { text: 'test' } }
+    end
+
+    it 'performs the request' do
+      expect(client_double.suggest(body: { my_suggest: { text: 'test' } } ))
+    end
+  end
+end


### PR DESCRIPTION
Version 6.3.0 of the Ruby client supports Elasticsearch server 6.7.0. Some endpoints were removed from `elasticsearch-api`. This breaks semver so this pull request adds them back in.