### PR TITLE
Use URI::Generic to avoid edge-cases with ports

### DIFF
--- a/elasticsearch-transport/lib/elasticsearch/transport/client.rb
+++ b/elasticsearch-transport/lib/elasticsearch/transport/client.rb
@@ -194,17 +194,16 @@ module Elasticsearch
         host_parts = case host
         when String
           if host =~ /^[a-z]+\:\/\//
-            uri = URI.parse(host)
-
-            # Handle when port is not specified
-            port = uri.port unless uri.port == uri.default_port
+            # Construct a new `URI::Generic` directly from the array returned by URI::split.
+            # This avoids `URI::HTTP` and `URI::HTTPS`, which supply default ports.
+            uri = URI::Generic.new(*URI.split(host))
 
             { :scheme => uri.scheme,
               :user => uri.user,
               :password => uri.password,
               :host => uri.host,
               :path => uri.path,
-              :port => port }
+              :port => uri.port }
           else
             host, port = host.split(':')
             { :host => host,

--- a/elasticsearch-transport/spec/elasticsearch/transport/client_spec.rb
+++ b/elasticsearch-transport/spec/elasticsearch/transport/client_spec.rb
@@ -314,6 +314,26 @@ describe Elasticsearch::Transport::Client do
         end
       end
 
+      context 'when there is one host with a protocol and the default http port explicitly provided' do
+        let(:host) do
+          ['http://myhost:80']
+        end
+
+        it 'respects the explicit port' do
+          expect(hosts[0][:port]).to be(80)
+        end
+      end
+
+      context 'when there is one host with a protocol and the default https port explicitly provided' do
+        let(:host) do
+          ['https://myhost:443']
+        end
+
+        it 'respects the explicit port' do
+          expect(hosts[0][:port]).to be(443)
+        end
+      end
+
       context 'when there is one host with a scheme, protocol and no port' do
 
         let(:host) do


### PR DESCRIPTION
When the current implementation is provided a host that explicitly states a port number that is normally the default for its protocol (e.g., `80` on `http` or `443` on `https`), it overrides that explicit value with a `nil`, effectively ignoring the explicit value and causing the client to attempt to connect on `9200` instead.

This PR uses `URI::split` to split the string into its component parts and immediately uses them to construct a `URI::Generic`, which is not opinionated about ports and does not substitute default values. This eliminates the need to conditionally include the port.

Resolves: https://github.com/elastic/elasticsearch-ruby/issues/625