### PR TITLE
[CLIENT] Support options specified with String keys

### DIFF
--- a/elasticsearch-transport/lib/elasticsearch/transport/client.rb
+++ b/elasticsearch-transport/lib/elasticsearch/transport/client.rb
@@ -105,8 +105,8 @@ module Elasticsearch
       # @yield [faraday] Access and configure the `Faraday::Connection` instance directly with a block
       #
       def initialize(arguments={}, &block)
-        @options = arguments
-        @arguments = arguments
+        @options = arguments.inject({}){|args,(k,v)| args[k.to_sym] = v; args}
+        @arguments = @options
         @arguments[:logger] ||= @arguments[:log]   ? DEFAULT_LOGGER.call() : nil
         @arguments[:tracer] ||= @arguments[:trace] ? DEFAULT_TRACER.call() : nil
         @arguments[:reload_connections] ||= false

--- a/elasticsearch-transport/lib/elasticsearch/transport/client.rb
+++ b/elasticsearch-transport/lib/elasticsearch/transport/client.rb
@@ -105,7 +105,7 @@ module Elasticsearch
       # @yield [faraday] Access and configure the `Faraday::Connection` instance directly with a block
       #
       def initialize(arguments={}, &block)
-        @options = arguments.inject({}){|args,(k,v)| args[k.to_sym] = v; args}
+        @options = arguments.each_with_object({}){ |(k,v), args| args[k.to_sym] = v }
         @arguments = @options
         @arguments[:logger] ||= @arguments[:log]   ? DEFAULT_LOGGER.call() : nil
         @arguments[:tracer] ||= @arguments[:trace] ? DEFAULT_TRACER.call() : nil


### PR DESCRIPTION
Use case here: https://github.com/elastic/elasticsearch-ruby/issues/555
Configuration can be loaded from a YAML file in Rails and the resulting hash would have String keys.