### PR TITLE
Support Faraday default_connection_options

### DIFF
--- a/elasticsearch-transport/lib/elasticsearch/transport/transport/http/faraday.rb
+++ b/elasticsearch-transport/lib/elasticsearch/transport/transport/http/faraday.rb
@@ -51,7 +51,7 @@ module Elasticsearch
           # @return [Connections::Connection]
           #
           def __build_connection(host, options={}, block=nil)
-            client = ::Faraday::Connection.new(__full_url(host), options, &block)
+            client = ::Faraday.new(__full_url(host), options, &block)
             Connections::Connection.new :host => host, :connection => client
           end
 


### PR DESCRIPTION
The way Faraday connections are instantiated now does not take into account any `Faraday.default_connection_options` which may have been set. The fix is to use `::Faraday.new` instead of `::Faraday::Connection.new` - they both create a `Faraday::Connection` but the former takes into account any `default_connection_options` which may be present.