### PR TITLE
Swap more links elasticsearch.org->elastic.co

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ time rake test:all
 
 This software is licensed under the Apache 2 license, quoted below.
 
-    Copyright (c) 2013 Elasticsearch <http://www.elasticsearch.org>
+    Copyright (c) 2013 Elasticsearch <http://www.elastic.co>
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/elasticsearch-api/lib/elasticsearch/api/actions/cluster/get_settings.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/cluster/get_settings.rb
@@ -30,7 +30,7 @@ module Elasticsearch
         # @option arguments [Boolean] :include_defaults Whether to return all default clusters setting
         #                                               (default: false)
         #
-        # @see http://elasticsearch.org/guide/reference/api/admin-cluster-update-settings/
+        # @see https://www.elastic.co/guide/reference/api/admin-cluster-update-settings/
         #
         def get_settings(arguments={})
           method = HTTP_GET

--- a/elasticsearch-api/lib/elasticsearch/api/actions/cluster/health.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/cluster/health.rb
@@ -50,7 +50,7 @@ module Elasticsearch
         # @option arguments [List] :wait_for_events Wait until all currently queued events with the given priorty
         #                                           are processed (immediate, urgent, high, normal, low, languid)
         #
-        # @see http://elasticsearch.org/guide/reference/api/admin-cluster-health/
+        # @see https://www.elastic.co/guide/reference/api/admin-cluster-health/
         #
         def health(arguments={})
           arguments = arguments.clone

--- a/elasticsearch-api/lib/elasticsearch/api/actions/cluster/put_settings.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/cluster/put_settings.rb
@@ -29,7 +29,7 @@ module Elasticsearch
         # @option arguments [Hash] :body The settings to be updated. Can be either `transient` or `persistent`
         #                                (survives cluster restart).
         #
-        # @see http://elasticsearch.org/guide/reference/api/admin-cluster-update-settings/
+        # @see https://www.elastic.co/guide/reference/api/admin-cluster-update-settings/
         #
         def put_settings(arguments={})
           method = HTTP_PUT

--- a/elasticsearch-api/lib/elasticsearch/api/actions/cluster/reroute.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/cluster/reroute.rb
@@ -46,7 +46,7 @@ module Elasticsearch
         # @option arguments [Boolean] :retry_failed Retries allocation of shards that are blocked due to too many
         #                                           subsequent allocation failures
         #
-        # @see http://elasticsearch.org/guide/reference/api/admin-cluster-reroute/
+        # @see https://www.elastic.co/guide/reference/api/admin-cluster-reroute/
         #
         def reroute(arguments={})
           method = HTTP_POST

--- a/elasticsearch-api/lib/elasticsearch/api/actions/cluster/state.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/cluster/state.rb
@@ -42,7 +42,7 @@ module Elasticsearch
         # @option arguments [Boolean] :ignore_unavailable Whether specified concrete indices should be ignored when
         #                                                 unavailable (missing, closed, etc)
         #
-        # @see http://elasticsearch.org/guide/reference/api/admin-cluster-state/
+        # @see https://www.elastic.co/guide/reference/api/admin-cluster-state/
         #
         def state(arguments={})
           arguments = arguments.clone

--- a/elasticsearch-api/lib/elasticsearch/api/actions/delete.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/delete.rb
@@ -42,7 +42,7 @@ module Elasticsearch
       # @option arguments [Number] :version Explicit version number for concurrency control
       # @option arguments [String] :version_type Specific version type (options: internal, external, external_gte, force)
       #
-      # @see http://elasticsearch.org/guide/reference/api/delete/
+      # @see https://www.elastic.co/guide/reference/api/delete/
       #
       def delete(arguments={})
         raise ArgumentError, "Required argument 'index' missing" unless arguments[:index]

--- a/elasticsearch-api/lib/elasticsearch/api/actions/exists.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/exists.rb
@@ -41,7 +41,7 @@ module Elasticsearch
       # @option arguments [String] :version_type Specific version type (options: internal, external, external_gte, force)
 
       #
-      # @see http://elasticsearch.org/guide/reference/api/get/
+      # @see https://www.elastic.co/guide/reference/api/get/
       #
       def exists(arguments={})
         raise ArgumentError, "Required argument 'id' missing"    unless arguments[:id]

--- a/elasticsearch-api/lib/elasticsearch/api/actions/explain.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/explain.rb
@@ -50,7 +50,7 @@ module Elasticsearch
       # @option arguments [List] :_source_excludes A list of fields to exclude from the returned _source field
       # @option arguments [List] :_source_includes A list of fields to extract and return from the _source field
       #
-      # @see http://elasticsearch.org/guide/reference/api/explain/
+      # @see https://www.elastic.co/guide/reference/api/explain/
       #
       def explain(arguments={})
         raise ArgumentError, "Required argument 'index' missing" unless arguments[:index]

--- a/elasticsearch-api/lib/elasticsearch/api/actions/get.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/get.rb
@@ -44,7 +44,7 @@ module Elasticsearch
       # @option arguments [Number] :version Explicit version number for concurrency control
       # @option arguments [String] :version_type Specific version type (options: internal, external, external_gte, force)
       #
-      # @see http://elasticsearch.org/guide/reference/api/get/
+      # @see https://www.elastic.co/guide/reference/api/get/
       #
       def get(arguments={})
         raise ArgumentError, "Required argument 'index' missing" unless arguments[:index]

--- a/elasticsearch-api/lib/elasticsearch/api/actions/get_source.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/get_source.rb
@@ -41,7 +41,7 @@ module Elasticsearch
       # @option arguments [Number] :version Explicit version number for concurrency control
       # @option arguments [String] :version_type Specific version type (options: internal, external, external_gte, force)
       #
-      # @see http://elasticsearch.org/guide/reference/api/get/
+      # @see https://www.elastic.co/guide/reference/api/get/
       #
       # @since 0.90.1
       #

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/segments.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/segments.rb
@@ -31,7 +31,7 @@ module Elasticsearch
         # @option arguments [String] :expand_wildcards Whether to expand wildcard expression to concrete indices that are open, closed or both. (options: open, closed, none, all)
         # @option arguments [Boolean] :verbose Includes detailed memory usage by Lucene.
         #
-        # @see http://elasticsearch.org/guide/reference/api/admin-indices-segments/
+        # @see https://www.elastic.co/guide/reference/api/admin-indices-segments/
         #
         def segments(arguments={})
           method = HTTP_GET

--- a/elasticsearch-api/lib/elasticsearch/api/actions/info.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/info.rb
@@ -21,7 +21,7 @@ module Elasticsearch
 
       # Return simple information about the cluster (name, version).
       #
-      # @see http://elasticsearch.org/guide/
+      # @see https://www.elastic.co/guide/
       #
       def info(arguments={})
         method = HTTP_GET

--- a/elasticsearch-api/lib/elasticsearch/api/actions/mget.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/mget.rb
@@ -54,7 +54,7 @@ module Elasticsearch
       # @option arguments [List] :_source_excludes A list of fields to exclude from the returned _source field
       # @option arguments [List] :_source_includes A list of fields to extract and return from the _source field
       #
-      # @see http://elasticsearch.org/guide/reference/api/multi-get/
+      # @see https://www.elastic.co/guide/reference/api/multi-get/
       #
       def mget(arguments={})
         raise ArgumentError, "Required argument 'body' missing" unless arguments[:body]

--- a/elasticsearch-api/lib/elasticsearch/api/actions/nodes/info.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/nodes/info.rb
@@ -55,7 +55,7 @@ module Elasticsearch
         # @option arguments [Boolean] :flat_settings Return settings in flat format (default: false)
         # @option arguments [Time] :timeout Explicit operation timeout
         #
-        # @see http://elasticsearch.org/guide/reference/api/admin-cluster-nodes-info/
+        # @see https://www.elastic.co/guide/reference/api/admin-cluster-nodes-info/
         #
         def info(arguments={})
           arguments = arguments.clone

--- a/elasticsearch-api/lib/elasticsearch/api/actions/nodes/reload_secure_settings.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/nodes/reload_secure_settings.rb
@@ -34,7 +34,7 @@ module Elasticsearch
         # @option arguments [ Array ] :node_id A comma-separated list of node IDs or names to perform the operation on
         # @option arguments [ String ] :timeout Explicit operation timeout
         #
-        # @see http://elasticsearch.org/guide/reference/api/cluster-nodes-reload-secure-settings
+        # @see https://www.elastic.co/guide/reference/api/cluster-nodes-reload-secure-settings
         #
         def reload_secure_settings(arguments={})
           valid_params = [

--- a/elasticsearch-api/lib/elasticsearch/api/actions/nodes/shutdown.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/nodes/shutdown.rb
@@ -32,7 +32,7 @@ module Elasticsearch
         # @option arguments [Time] :delay Set the delay for the operation (default: 1s)
         # @option arguments [Boolean] :exit Exit the JVM as well (default: true)
         #
-        # @see http://elasticsearch.org/guide/reference/api/admin-cluster-nodes-shutdown/
+        # @see https://www.elastic.co/guide/reference/api/admin-cluster-nodes-shutdown/
         #
         def shutdown(arguments={})
           method = HTTP_POST

--- a/elasticsearch-api/lib/elasticsearch/api/actions/ping.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/ping.rb
@@ -25,7 +25,7 @@ module Elasticsearch
       #
       #     client.ping
       #
-      # @see http://elasticsearch.org/guide/
+      # @see https://www.elastic.co/guide/
       #
       def ping(arguments={})
         method = HTTP_HEAD

--- a/elasticsearch-api/lib/elasticsearch/api/actions/update.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/update.rb
@@ -81,7 +81,7 @@ module Elasticsearch
       #
       # @since 0.20
       #
-      # @see http://elasticsearch.org/guide/reference/api/update/
+      # @see https://www.elastic.co/guide/reference/api/update/
       #
       def update(arguments={})
         raise ArgumentError, "Required argument 'index' missing" unless arguments[:index]

--- a/elasticsearch-api/utils/thor/generate_api.rb
+++ b/elasticsearch-api/utils/thor/generate_api.rb
@@ -115,7 +115,7 @@ module Elasticsearch
     # * Extract the URL parts (eg. `{index}`) from the URLs
     # * Extract the URL parameters (eg. `{timeout}`) from the `request.param("ABC")` statements
     # * Detect whether HTTP body is allowed for the API from `request.hasContent()` statements
-    # * Search the <http://elasticsearch.org> website to get proper documentation URLs
+    # * Search the <https://www.elastic.co> website to get proper documentation URLs
     # * Assemble the JSON format for the API spec
     #
     class JsonGenerator < Thor
@@ -158,7 +158,7 @@ module Elasticsearch
               if hit = hits.first
                 if hit['_score'] > 0.2
                   doc_title = hit['fields']['title']
-                  doc_url   = "http://elasticsearch.org" + hit['fields']['url']
+                  doc_url   = "https://www.elastic.co" + hit['fields']['url']
                 end
               end
             rescue Exception => e

--- a/elasticsearch-dsl/Rakefile
+++ b/elasticsearch-dsl/Rakefile
@@ -122,7 +122,7 @@ namespace :generate do
       hits     = JSON.load(response)['hits']['hits']
 
       if hit = hits.first
-        doc_url = ("http://elasticsearch.org" + hit['fields']['url']).gsub(/#.+$/, '') if hit['_score'] > 0.2
+        doc_url = ("https://www.elastic.co" + hit['fields']['url']).gsub(/#.+$/, '') if hit['_score'] > 0.2
       end
     rescue Exception => e
       puts "[!] ERROR: #{e.inspect}"

--- a/elasticsearch-dsl/lib/elasticsearch/dsl/search/aggregations/avg.rb
+++ b/elasticsearch-dsl/lib/elasticsearch/dsl/search/aggregations/avg.rb
@@ -30,7 +30,7 @@ module Elasticsearch
         #       end
         #     end
         #
-        # @see http://elasticsearch.org/guide/en/elasticsearch/reference/current/search-aggregations-metrics-avg-aggregation.html
+        # @see https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-metrics-avg-aggregation.html
         #
         class Avg
           include BaseComponent

--- a/elasticsearch-dsl/lib/elasticsearch/dsl/search/aggregations/cardinality.rb
+++ b/elasticsearch-dsl/lib/elasticsearch/dsl/search/aggregations/cardinality.rb
@@ -31,7 +31,7 @@ module Elasticsearch
         #       end
         #     end
         #
-        # @see http://elasticsearch.org/guide/en/elasticsearch/reference/current/search-aggregations-metrics-cardinality-aggregation.html
+        # @see https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-metrics-cardinality-aggregation.html
         #
         class Cardinality
           include BaseComponent

--- a/elasticsearch-dsl/lib/elasticsearch/dsl/search/aggregations/children.rb
+++ b/elasticsearch-dsl/lib/elasticsearch/dsl/search/aggregations/children.rb
@@ -42,7 +42,7 @@ module Elasticsearch
         #
         # See the integration test for a full example.
         #
-        # @see http://elasticsearch.org/guide/en/elasticsearch/reference/current/search-aggregations-bucket-children-aggregation.html
+        # @see https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-bucket-children-aggregation.html
         #
         class Children
           include BaseAggregationComponent

--- a/elasticsearch-dsl/lib/elasticsearch/dsl/search/aggregations/date_histogram.rb
+++ b/elasticsearch-dsl/lib/elasticsearch/dsl/search/aggregations/date_histogram.rb
@@ -32,7 +32,7 @@ module Elasticsearch
         #       end
         #     end
         #
-        # @see http://elasticsearch.org/guide/en/elasticsearch/reference/current/search-aggregations-bucket-datehistogram-aggregation.html
+        # @see https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-bucket-datehistogram-aggregation.html
         #
         class DateHistogram
           include BaseAggregationComponent

--- a/elasticsearch-dsl/lib/elasticsearch/dsl/search/aggregations/date_range.rb
+++ b/elasticsearch-dsl/lib/elasticsearch/dsl/search/aggregations/date_range.rb
@@ -36,7 +36,7 @@ module Elasticsearch
         #       end
         #     end
         #
-        # @see http://elasticsearch.org/guide/en/elasticsearch/reference/current/search-aggregations-bucket-daterange-aggregation.html
+        # @see https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-bucket-daterange-aggregation.html
         #
         class DateRange
           include BaseAggregationComponent

--- a/elasticsearch-dsl/lib/elasticsearch/dsl/search/aggregations/filter.rb
+++ b/elasticsearch-dsl/lib/elasticsearch/dsl/search/aggregations/filter.rb
@@ -35,7 +35,7 @@ module Elasticsearch
         #      end
         #    end
         #
-        # @see http://elasticsearch.org/guide/en/elasticsearch/reference/current/search-aggregations-bucket-filters-aggregation.html
+        # @see https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-bucket-filters-aggregation.html
         #
         class Filter
           include BaseAggregationComponent

--- a/elasticsearch-dsl/lib/elasticsearch/dsl/search/aggregations/filters.rb
+++ b/elasticsearch-dsl/lib/elasticsearch/dsl/search/aggregations/filters.rb
@@ -38,7 +38,7 @@ module Elasticsearch
         #      end
         #    end
         #
-        # @see http://elasticsearch.org/guide/en/elasticsearch/reference/current/search-aggregations-bucket-filters-aggregation.html
+        # @see https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-bucket-filters-aggregation.html
         #
         class Filters
           include BaseAggregationComponent

--- a/elasticsearch-dsl/lib/elasticsearch/dsl/search/aggregations/geo_bounds.rb
+++ b/elasticsearch-dsl/lib/elasticsearch/dsl/search/aggregations/geo_bounds.rb
@@ -46,7 +46,7 @@ module Elasticsearch
         #       end
         #     end
         #
-        # @see http://elasticsearch.org/guide/en/elasticsearch/guide/current/geo-bounds-agg.html
+        # @see https://www.elastic.co/guide/en/elasticsearch/guide/current/geo-bounds-agg.html
         #
         class GeoBounds
           include BaseComponent

--- a/elasticsearch-dsl/lib/elasticsearch/dsl/search/aggregations/geo_distance.rb
+++ b/elasticsearch-dsl/lib/elasticsearch/dsl/search/aggregations/geo_distance.rb
@@ -38,7 +38,7 @@ module Elasticsearch
         #
         # See the integration test for a full example.
         #
-        # @see http://elasticsearch.org/guide/en/elasticsearch/guide/current/geo-distance-agg.html
+        # @see https://www.elastic.co/guide/en/elasticsearch/guide/current/geo-distance-agg.html
         #
         class GeoDistance
           include BaseAggregationComponent

--- a/elasticsearch-dsl/lib/elasticsearch/dsl/search/aggregations/geohash_grid.rb
+++ b/elasticsearch-dsl/lib/elasticsearch/dsl/search/aggregations/geohash_grid.rb
@@ -35,7 +35,7 @@ module Elasticsearch
         #
         # See the integration test for a full example.
         #
-        # @see http://elasticsearch.org/guide/en/elasticsearch/guide/current/geohash-grid-agg.html
+        # @see https://www.elastic.co/guide/en/elasticsearch/guide/current/geohash-grid-agg.html
         #
         class GeohashGrid
           include BaseAggregationComponent

--- a/elasticsearch-dsl/lib/elasticsearch/dsl/search/aggregations/histogram.rb
+++ b/elasticsearch-dsl/lib/elasticsearch/dsl/search/aggregations/histogram.rb
@@ -33,7 +33,7 @@ module Elasticsearch
         #      end
         #    end
         #
-        # @see http://elasticsearch.org/guide/en/elasticsearch/reference/current/search-aggregations-bucket-histogram-aggregation.html
+        # @see https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-bucket-histogram-aggregation.html
         #
         class Histogram
           include BaseAggregationComponent

--- a/elasticsearch-dsl/lib/elasticsearch/dsl/search/aggregations/ip_range.rb
+++ b/elasticsearch-dsl/lib/elasticsearch/dsl/search/aggregations/ip_range.rb
@@ -33,7 +33,7 @@ module Elasticsearch
         #       end
         #     end
         #
-        # @see http://elasticsearch.org/guide/en/elasticsearch/reference/current/search-aggregations-bucket-iprange-aggregation.html
+        # @see https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-bucket-iprange-aggregation.html
         #
         class IpRange
           include BaseAggregationComponent

--- a/elasticsearch-dsl/lib/elasticsearch/dsl/search/aggregations/max.rb
+++ b/elasticsearch-dsl/lib/elasticsearch/dsl/search/aggregations/max.rb
@@ -30,7 +30,7 @@ module Elasticsearch
         #       end
         #     end
         #
-        # @see http://elasticsearch.org/guide/en/elasticsearch/reference/current/search-aggregations-metrics-max-aggregation.html
+        # @see https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-metrics-max-aggregation.html
         #
         class Max
           include BaseComponent

--- a/elasticsearch-dsl/lib/elasticsearch/dsl/search/aggregations/min.rb
+++ b/elasticsearch-dsl/lib/elasticsearch/dsl/search/aggregations/min.rb
@@ -30,7 +30,7 @@ module Elasticsearch
         #       end
         #     end
         #
-        # @see http://elasticsearch.org/guide/en/elasticsearch/reference/current/search-aggregations-metrics-min-aggregation.html
+        # @see https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-metrics-min-aggregation.html
         #
         class Min
           include BaseComponent

--- a/elasticsearch-dsl/lib/elasticsearch/dsl/search/aggregations/percentile_ranks.rb
+++ b/elasticsearch-dsl/lib/elasticsearch/dsl/search/aggregations/percentile_ranks.rb
@@ -33,7 +33,7 @@ module Elasticsearch
         #       end
         #     end
         #
-        # @see http://elasticsearch.org/guide/en/elasticsearch/reference/current/search-aggregations-metrics-percentile-rank-aggregation.html
+        # @see https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-metrics-percentile-rank-aggregation.html
         #
         class PercentileRanks
           include BaseComponent

--- a/elasticsearch-dsl/lib/elasticsearch/dsl/search/aggregations/percentiles.rb
+++ b/elasticsearch-dsl/lib/elasticsearch/dsl/search/aggregations/percentiles.rb
@@ -32,7 +32,7 @@ module Elasticsearch
         #       end
         #     end
         #
-        # @see http://elasticsearch.org/guide/en/elasticsearch/reference/current/search-aggregations-metrics-percentile-aggregation.html
+        # @see https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-metrics-percentile-aggregation.html
         #
         class Percentiles
           include BaseComponent

--- a/elasticsearch-dsl/lib/elasticsearch/dsl/search/aggregations/reverse_nested.rb
+++ b/elasticsearch-dsl/lib/elasticsearch/dsl/search/aggregations/reverse_nested.rb
@@ -42,7 +42,7 @@ module Elasticsearch
         #
         # See the integration test for a full example.
         #
-        # @see http://elasticsearch.org/guide/en/elasticsearch/guide/current/nested-aggregation.html
+        # @see https://www.elastic.co/guide/en/elasticsearch/guide/current/nested-aggregation.html
         #
         class ReverseNested
           include BaseAggregationComponent

--- a/elasticsearch-dsl/lib/elasticsearch/dsl/search/aggregations/scripted_metric.rb
+++ b/elasticsearch-dsl/lib/elasticsearch/dsl/search/aggregations/scripted_metric.rb
@@ -35,7 +35,7 @@ module Elasticsearch
         #       end
         #     end
         #
-        # @see http://elasticsearch.org/guide/en/elasticsearch/reference/current/search-aggregations-metrics-scripted-metric-aggregation.html
+        # @see https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-metrics-scripted-metric-aggregation.html
         #
         # See the integration test for a full example.
         #

--- a/elasticsearch-dsl/lib/elasticsearch/dsl/search/aggregations/significant_terms.rb
+++ b/elasticsearch-dsl/lib/elasticsearch/dsl/search/aggregations/significant_terms.rb
@@ -38,7 +38,7 @@ module Elasticsearch
         #       end
         #     end
         #
-        # @see http://elasticsearch.org/guide/en/elasticsearch/reference/current/search-aggregations-bucket-significantterms-aggregation.html
+        # @see https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-bucket-significantterms-aggregation.html
         #
         class SignificantTerms
           include BaseAggregationComponent

--- a/elasticsearch-dsl/lib/elasticsearch/dsl/search/aggregations/sum.rb
+++ b/elasticsearch-dsl/lib/elasticsearch/dsl/search/aggregations/sum.rb
@@ -30,7 +30,7 @@ module Elasticsearch
         #       end
         #     end
         #
-        # @see http://elasticsearch.org/guide/en/elasticsearch/reference/current/search-aggregations-metrics-sum-aggregation.html
+        # @see https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-metrics-sum-aggregation.html
         #
         class Sum
           include BaseComponent

--- a/elasticsearch-dsl/lib/elasticsearch/dsl/search/aggregations/top_hits.rb
+++ b/elasticsearch-dsl/lib/elasticsearch/dsl/search/aggregations/top_hits.rb
@@ -36,7 +36,7 @@ module Elasticsearch
         #       end
         #     end
         #
-        # @see http://elasticsearch.org/guide/en/elasticsearch/reference/current/search-aggregations-metrics-top-hits-aggregation.html
+        # @see https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-metrics-top-hits-aggregation.html
         #
         class TopHits
           include BaseComponent

--- a/elasticsearch-dsl/lib/elasticsearch/dsl/search/aggregations/value_count.rb
+++ b/elasticsearch-dsl/lib/elasticsearch/dsl/search/aggregations/value_count.rb
@@ -30,7 +30,7 @@ module Elasticsearch
         #       end
         #     end
         #
-        # @see http://elasticsearch.org/guide/en/elasticsearch/reference/current/search-aggregations-metrics-valuecount-aggregation.html
+        # @see https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-metrics-valuecount-aggregation.html
         #
         class ValueCount
           include BaseComponent

--- a/elasticsearch-dsl/lib/elasticsearch/dsl/search/filters/and.rb
+++ b/elasticsearch-dsl/lib/elasticsearch/dsl/search/filters/and.rb
@@ -50,7 +50,7 @@ module Elasticsearch
         #       end
         #     end
         #
-        # @see http://elasticsearch.org/guide/en/elasticsearch/reference/current/query-dsl-and-filter.html
+        # @see https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-and-filter.html
         #
         class And
           include BaseComponent

--- a/elasticsearch-dsl/lib/elasticsearch/dsl/search/filters/exists.rb
+++ b/elasticsearch-dsl/lib/elasticsearch/dsl/search/filters/exists.rb
@@ -35,7 +35,7 @@ module Elasticsearch
         #       end
         #     end
         #
-        # @see http://elasticsearch.org/guide/en/elasticsearch/reference/current/query-dsl-exists-filter.html
+        # @see https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-exists-filter.html
         #
         class Exists
           include BaseComponent

--- a/elasticsearch-dsl/lib/elasticsearch/dsl/search/filters/geo_bounding_box.rb
+++ b/elasticsearch-dsl/lib/elasticsearch/dsl/search/filters/geo_bounding_box.rb
@@ -41,7 +41,7 @@ module Elasticsearch
         #
         # Use eg. <http://boundingbox.klokantech.com> to visually define the bounding box.
         #
-        # @see http://elasticsearch.org/guide/en/elasticsearch/guide/current/geo-bounding-box.html
+        # @see https://www.elastic.co/guide/en/elasticsearch/guide/current/geo-bounding-box.html
         #
         class GeoBoundingBox
           include BaseComponent

--- a/elasticsearch-dsl/lib/elasticsearch/dsl/search/filters/geo_distance.rb
+++ b/elasticsearch-dsl/lib/elasticsearch/dsl/search/filters/geo_distance.rb
@@ -52,7 +52,7 @@ module Elasticsearch
         #
         # See the integration test for a working example.
         #
-        # @see http://elasticsearch.org/guide/en/elasticsearch/guide/current/geo-distance.html
+        # @see https://www.elastic.co/guide/en/elasticsearch/guide/current/geo-distance.html
         #
         class GeoDistance
           include BaseComponent

--- a/elasticsearch-dsl/lib/elasticsearch/dsl/search/filters/geo_distance_range.rb
+++ b/elasticsearch-dsl/lib/elasticsearch/dsl/search/filters/geo_distance_range.rb
@@ -34,7 +34,7 @@ module Elasticsearch
         #       end
         #     end
         #
-        # @see http://elasticsearch.org/guide/en/elasticsearch/guide/current/geo-distance.html
+        # @see https://www.elastic.co/guide/en/elasticsearch/guide/current/geo-distance.html
         #
         class GeoDistanceRange
           include BaseComponent

--- a/elasticsearch-dsl/lib/elasticsearch/dsl/search/filters/geo_polygon.rb
+++ b/elasticsearch-dsl/lib/elasticsearch/dsl/search/filters/geo_polygon.rb
@@ -44,7 +44,7 @@ module Elasticsearch
         #
         # See the integration test for a working example.
         #
-        # @see http://elasticsearch.org/guide/en/elasticsearch/reference/current/query-dsl-geo-polygon-filter.html
+        # @see https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-geo-polygon-filter.html
         #
         class GeoPolygon
           include BaseComponent

--- a/elasticsearch-dsl/lib/elasticsearch/dsl/search/filters/geo_shape.rb
+++ b/elasticsearch-dsl/lib/elasticsearch/dsl/search/filters/geo_shape.rb
@@ -37,7 +37,7 @@ module Elasticsearch
         #       end
         #     end
         #
-        # @see http://elasticsearch.org/guide/en/elasticsearch/reference/current/query-dsl-geo-shape-filter.html
+        # @see https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-geo-shape-filter.html
         #
         class GeoShape
           include BaseComponent

--- a/elasticsearch-dsl/lib/elasticsearch/dsl/search/filters/geohash_cell.rb
+++ b/elasticsearch-dsl/lib/elasticsearch/dsl/search/filters/geohash_cell.rb
@@ -42,7 +42,7 @@ module Elasticsearch
         #
         # See the integration test for a working example.
         #
-        # @see http://elasticsearch.org/guide/en/elasticsearch/guide/current/geohash-cell-filter.html
+        # @see https://www.elastic.co/guide/en/elasticsearch/guide/current/geohash-cell-filter.html
         #
         class GeohashCell
           include BaseComponent

--- a/elasticsearch-dsl/lib/elasticsearch/dsl/search/filters/has_child.rb
+++ b/elasticsearch-dsl/lib/elasticsearch/dsl/search/filters/has_child.rb
@@ -39,7 +39,7 @@ module Elasticsearch
         #       end
         #     end
         #
-        # @see http://elasticsearch.org/guide/en/elasticsearch/reference/current/query-dsl-has-child-filter.html
+        # @see https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-has-child-filter.html
         #
         class HasChild
           include BaseComponent

--- a/elasticsearch-dsl/lib/elasticsearch/dsl/search/filters/has_parent.rb
+++ b/elasticsearch-dsl/lib/elasticsearch/dsl/search/filters/has_parent.rb
@@ -39,7 +39,7 @@ module Elasticsearch
         #       end
         #     end
         #
-        # @see http://elasticsearch.org/guide/en/elasticsearch/reference/current/query-dsl-has-parent-filter.html
+        # @see https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-has-parent-filter.html
         #
         class HasParent
           include BaseComponent

--- a/elasticsearch-dsl/lib/elasticsearch/dsl/search/filters/ids.rb
+++ b/elasticsearch-dsl/lib/elasticsearch/dsl/search/filters/ids.rb
@@ -34,7 +34,7 @@ module Elasticsearch
         #       end
         #     end
         #
-        # @see http://elasticsearch.org/guide/en/elasticsearch/reference/current/query-dsl-ids-filter.html
+        # @see https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-ids-filter.html
         #
         class Ids
           include BaseComponent

--- a/elasticsearch-dsl/lib/elasticsearch/dsl/search/filters/indices.rb
+++ b/elasticsearch-dsl/lib/elasticsearch/dsl/search/filters/indices.rb
@@ -45,7 +45,7 @@ module Elasticsearch
         #       end
         #     end
         #
-        # @see http://elasticsearch.org/guide/en/elasticsearch/reference/current/query-dsl-indices-filter.html
+        # @see https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-indices-filter.html
         #
         class Indices
           include BaseComponent

--- a/elasticsearch-dsl/lib/elasticsearch/dsl/search/filters/limit.rb
+++ b/elasticsearch-dsl/lib/elasticsearch/dsl/search/filters/limit.rb
@@ -34,7 +34,7 @@ module Elasticsearch
         #       end
         #     end
         #
-        # @see http://elasticsearch.org/guide/en/elasticsearch/reference/current/query-dsl-limit-filter.html
+        # @see https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-limit-filter.html
         #
         class Limit
           include BaseComponent

--- a/elasticsearch-dsl/lib/elasticsearch/dsl/search/filters/missing.rb
+++ b/elasticsearch-dsl/lib/elasticsearch/dsl/search/filters/missing.rb
@@ -35,7 +35,7 @@ module Elasticsearch
         #       end
         #     end
         #
-        # @see http://elasticsearch.org/guide/en/elasticsearch/reference/current/query-dsl-missing-filter.html
+        # @see https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-missing-filter.html
         #
         class Missing
           include BaseComponent

--- a/elasticsearch-dsl/lib/elasticsearch/dsl/search/filters/nested.rb
+++ b/elasticsearch-dsl/lib/elasticsearch/dsl/search/filters/nested.rb
@@ -39,7 +39,7 @@ module Elasticsearch
         #       end
         #     end
         #
-        # @see http://elasticsearch.org/guide/en/elasticsearch/reference/current/query-dsl-nested-filter.html
+        # @see https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-nested-filter.html
         #
         class Nested
           include BaseComponent

--- a/elasticsearch-dsl/lib/elasticsearch/dsl/search/filters/not.rb
+++ b/elasticsearch-dsl/lib/elasticsearch/dsl/search/filters/not.rb
@@ -49,7 +49,7 @@ module Elasticsearch
         #       end
         #     end
         #
-        # @see http://elasticsearch.org/guide/en/elasticsearch/reference/current/query-dsl-not-filter.html
+        # @see https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-not-filter.html
         #
         class Not
           include BaseComponent

--- a/elasticsearch-dsl/lib/elasticsearch/dsl/search/filters/or.rb
+++ b/elasticsearch-dsl/lib/elasticsearch/dsl/search/filters/or.rb
@@ -50,7 +50,7 @@ module Elasticsearch
         #       end
         #     end
         #
-        # @see http://elasticsearch.org/guide/en/elasticsearch/reference/current/query-dsl-or-filter.html
+        # @see https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-or-filter.html
         #
         class Or
           include BaseComponent

--- a/elasticsearch-dsl/lib/elasticsearch/dsl/search/filters/prefix.rb
+++ b/elasticsearch-dsl/lib/elasticsearch/dsl/search/filters/prefix.rb
@@ -34,7 +34,7 @@ module Elasticsearch
         #       end
         #     end
         #
-        # @see http://elasticsearch.org/guide/en/elasticsearch/reference/current/query-dsl-prefix-filter.html
+        # @see https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-prefix-filter.html
         #
         class Prefix
           include BaseComponent

--- a/elasticsearch-dsl/lib/elasticsearch/dsl/search/filters/query.rb
+++ b/elasticsearch-dsl/lib/elasticsearch/dsl/search/filters/query.rb
@@ -38,7 +38,7 @@ module Elasticsearch
         #       end
         #     end
         #
-        # @see http://elasticsearch.org/guide/en/elasticsearch/reference/current/query-dsl-query-filter.html
+        # @see https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-query-filter.html
         #
         class Query
           include BaseComponent

--- a/elasticsearch-dsl/lib/elasticsearch/dsl/search/filters/regexp.rb
+++ b/elasticsearch-dsl/lib/elasticsearch/dsl/search/filters/regexp.rb
@@ -36,7 +36,7 @@ module Elasticsearch
         #       end
         #     end
         #
-        # @see http://elasticsearch.org/guide/en/elasticsearch/reference/current/query-dsl-regexp-filter.html
+        # @see https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-regexp-filter.html
         #
         class Regexp
           include BaseComponent

--- a/elasticsearch-dsl/lib/elasticsearch/dsl/search/filters/script.rb
+++ b/elasticsearch-dsl/lib/elasticsearch/dsl/search/filters/script.rb
@@ -34,7 +34,7 @@ module Elasticsearch
         #       end
         #     end
         #
-        # @see http://elasticsearch.org/guide/en/elasticsearch/reference/current/query-dsl-script-filter.html
+        # @see https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-script-filter.html
         #
         class Script
           include BaseComponent

--- a/elasticsearch-dsl/lib/elasticsearch/dsl/search/filters/terms.rb
+++ b/elasticsearch-dsl/lib/elasticsearch/dsl/search/filters/terms.rb
@@ -37,7 +37,7 @@ module Elasticsearch
         # @note The specified terms are *not analyzed* (lowercased, stemmed, etc),
         #       so they must match the indexed terms.
         #
-        # @see http://elasticsearch.org/guide/en/elasticsearch/reference/current/query-dsl-terms-filter.html
+        # @see https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-terms-filter.html
         #
         class Terms
           include BaseComponent

--- a/elasticsearch-dsl/lib/elasticsearch/dsl/search/filters/type.rb
+++ b/elasticsearch-dsl/lib/elasticsearch/dsl/search/filters/type.rb
@@ -37,7 +37,7 @@ module Elasticsearch
         #     end
         #
         #
-        # @see http://elasticsearch.org/guide/en/elasticsearch/reference/current/query-dsl-type-filter.html
+        # @see https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-type-filter.html
         #
         class Type
           include BaseComponent

--- a/elasticsearch-dsl/lib/elasticsearch/dsl/search/queries/bool.rb
+++ b/elasticsearch-dsl/lib/elasticsearch/dsl/search/queries/bool.rb
@@ -48,7 +48,7 @@ module Elasticsearch
         #
         # See the integration test for a working example.
         #
-        # @see http://elasticsearch.org/guide/en/elasticsearch/reference/current/query-dsl-bool-query.html
+        # @see https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-bool-query.html
         #
         class Bool
           include BaseComponent

--- a/elasticsearch-dsl/lib/elasticsearch/dsl/search/queries/boosting.rb
+++ b/elasticsearch-dsl/lib/elasticsearch/dsl/search/queries/boosting.rb
@@ -34,7 +34,7 @@ module Elasticsearch
         #       end
         #     end
         #
-        # @see http://elasticsearch.org/guide/en/elasticsearch/reference/current/query-dsl-boosting-query.html
+        # @see https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-boosting-query.html
         #
         class Boosting
           include BaseComponent

--- a/elasticsearch-dsl/lib/elasticsearch/dsl/search/queries/common.rb
+++ b/elasticsearch-dsl/lib/elasticsearch/dsl/search/queries/common.rb
@@ -35,7 +35,7 @@ module Elasticsearch
         #
         # This query is frequently used when a stopwords-based approach loses too much recall and/or precision.
         #
-        # @see http://elasticsearch.org/guide/en/elasticsearch/reference/current/query-dsl-common-terms-query.html
+        # @see https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-common-terms-query.html
         #
         class Common
           include BaseComponent

--- a/elasticsearch-dsl/lib/elasticsearch/dsl/search/queries/constant_score.rb
+++ b/elasticsearch-dsl/lib/elasticsearch/dsl/search/queries/constant_score.rb
@@ -34,7 +34,7 @@ module Elasticsearch
         #       end
         #     end
         #
-        # @see http://elasticsearch.org/guide/en/elasticsearch/guide/current/ignoring-tfidf.html
+        # @see https://www.elastic.co/guide/en/elasticsearch/guide/current/ignoring-tfidf.html
         #
         class ConstantScore
           include BaseComponent

--- a/elasticsearch-dsl/lib/elasticsearch/dsl/search/queries/dis_max.rb
+++ b/elasticsearch-dsl/lib/elasticsearch/dsl/search/queries/dis_max.rb
@@ -36,7 +36,7 @@ module Elasticsearch
         #       end
         #     end
         #
-        # @see http://elasticsearch.org/guide/en/elasticsearch/guide/current/_best_fields.html
+        # @see https://www.elastic.co/guide/en/elasticsearch/guide/current/_best_fields.html
         #
         class DisMax
           include BaseComponent

--- a/elasticsearch-dsl/lib/elasticsearch/dsl/search/queries/filtered.rb
+++ b/elasticsearch-dsl/lib/elasticsearch/dsl/search/queries/filtered.rb
@@ -45,7 +45,7 @@ module Elasticsearch
         #       end
         #     end
         #
-        # @see http://elasticsearch.org/guide/en/elasticsearch/reference/current/query-dsl-filtered-query.html
+        # @see https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-filtered-query.html
         #
         class Filtered
           include BaseComponent

--- a/elasticsearch-dsl/lib/elasticsearch/dsl/search/queries/function_score.rb
+++ b/elasticsearch-dsl/lib/elasticsearch/dsl/search/queries/function_score.rb
@@ -38,7 +38,7 @@ module Elasticsearch
         #       end
         #     end
         #
-        # @see http://elasticsearch.org/guide/en/elasticsearch/guide/current/function-score-query.html
+        # @see https://www.elastic.co/guide/en/elasticsearch/guide/current/function-score-query.html
         #
         class FunctionScore
           include BaseComponent

--- a/elasticsearch-dsl/lib/elasticsearch/dsl/search/queries/fuzzy.rb
+++ b/elasticsearch-dsl/lib/elasticsearch/dsl/search/queries/fuzzy.rb
@@ -44,7 +44,7 @@ module Elasticsearch
         #       end
         #     end
         #
-        # @see http://elasticsearch.org/guide/en/elasticsearch/reference/current/query-dsl-fuzzy-query.html
+        # @see https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-fuzzy-query.html
         #
         class Fuzzy
           include BaseComponent

--- a/elasticsearch-dsl/lib/elasticsearch/dsl/search/queries/fuzzy_like_this.rb
+++ b/elasticsearch-dsl/lib/elasticsearch/dsl/search/queries/fuzzy_like_this.rb
@@ -33,7 +33,7 @@ module Elasticsearch
         #       end
         #     end
         #
-        # @see http://elasticsearch.org/guide/en/elasticsearch/reference/current/query-dsl-flt-query.html
+        # @see https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-flt-query.html
         #
         class FuzzyLikeThis
           include BaseComponent

--- a/elasticsearch-dsl/lib/elasticsearch/dsl/search/queries/fuzzy_like_this_field.rb
+++ b/elasticsearch-dsl/lib/elasticsearch/dsl/search/queries/fuzzy_like_this_field.rb
@@ -33,7 +33,7 @@ module Elasticsearch
         #       end
         #     end
         #
-        # @see http://elasticsearch.org/guide/en/elasticsearch/reference/current/query-dsl-flt-field-query.html
+        # @see https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-flt-field-query.html
         #
         class FuzzyLikeThisField
           include BaseComponent

--- a/elasticsearch-dsl/lib/elasticsearch/dsl/search/queries/has_child.rb
+++ b/elasticsearch-dsl/lib/elasticsearch/dsl/search/queries/has_child.rb
@@ -35,7 +35,7 @@ module Elasticsearch
         #       end
         #     end
         #
-        # @see http://elasticsearch.org/guide/en/elasticsearch/reference/current/query-dsl-has-child-query.html
+        # @see https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-has-child-query.html
         #
         class HasChild
           include BaseComponent

--- a/elasticsearch-dsl/lib/elasticsearch/dsl/search/queries/has_parent.rb
+++ b/elasticsearch-dsl/lib/elasticsearch/dsl/search/queries/has_parent.rb
@@ -37,7 +37,7 @@ module Elasticsearch
         #
         # @example
         #
-        # @see http://elasticsearch.org/guide/en/elasticsearch/reference/current/query-dsl-has-parent-query.html
+        # @see https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-has-parent-query.html
         #
         class HasParent
           include BaseComponent

--- a/elasticsearch-dsl/lib/elasticsearch/dsl/search/queries/ids.rb
+++ b/elasticsearch-dsl/lib/elasticsearch/dsl/search/queries/ids.rb
@@ -30,7 +30,7 @@ module Elasticsearch
         #       end
         #     end
         #
-        # @see http://elasticsearch.org/guide/en/elasticsearch/reference/current/query-dsl-ids-query.html
+        # @see https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-ids-query.html
         #
         class Ids
           include BaseComponent

--- a/elasticsearch-dsl/lib/elasticsearch/dsl/search/queries/indices.rb
+++ b/elasticsearch-dsl/lib/elasticsearch/dsl/search/queries/indices.rb
@@ -35,7 +35,7 @@ module Elasticsearch
         #       end
         #     end
         #
-        # @see http://elasticsearch.org/guide/en/elasticsearch/reference/current/query-dsl-indices-query.html
+        # @see https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-indices-query.html
         #
         class Indices
           include BaseComponent

--- a/elasticsearch-dsl/lib/elasticsearch/dsl/search/queries/more_like_this.rb
+++ b/elasticsearch-dsl/lib/elasticsearch/dsl/search/queries/more_like_this.rb
@@ -45,7 +45,7 @@ module Elasticsearch
         #       end
         #     end
         #
-        # @see http://elasticsearch.org/guide/en/elasticsearch/reference/current/query-dsl-mlt-query.html
+        # @see https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-mlt-query.html
         #
         class MoreLikeThis
           include BaseComponent

--- a/elasticsearch-dsl/lib/elasticsearch/dsl/search/queries/multi_match.rb
+++ b/elasticsearch-dsl/lib/elasticsearch/dsl/search/queries/multi_match.rb
@@ -34,7 +34,7 @@ module Elasticsearch
         #       end
         #     end
         #
-        # @see http://elasticsearch.org/guide/en/elasticsearch/reference/current/query-dsl-multi-match-query.html
+        # @see https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-multi-match-query.html
         #
         class MultiMatch
           include BaseComponent

--- a/elasticsearch-dsl/lib/elasticsearch/dsl/search/queries/nested.rb
+++ b/elasticsearch-dsl/lib/elasticsearch/dsl/search/queries/nested.rb
@@ -35,7 +35,7 @@ module Elasticsearch
         #       end
         #     end
         #
-        # @see http://elasticsearch.org/guide/en/elasticsearch/reference/current/query-dsl-nested-query.html
+        # @see https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-nested-query.html
         #
         class Nested
           include BaseComponent

--- a/elasticsearch-dsl/lib/elasticsearch/dsl/search/queries/prefix.rb
+++ b/elasticsearch-dsl/lib/elasticsearch/dsl/search/queries/prefix.rb
@@ -32,7 +32,7 @@ module Elasticsearch
         #   end
         # end
         #
-        # @see http://elasticsearch.org/guide/en/elasticsearch/reference/current/query-dsl-prefix-query.html
+        # @see https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-prefix-query.html
         #
         class Prefix
           include BaseComponent

--- a/elasticsearch-dsl/lib/elasticsearch/dsl/search/queries/regexp.rb
+++ b/elasticsearch-dsl/lib/elasticsearch/dsl/search/queries/regexp.rb
@@ -32,7 +32,7 @@ module Elasticsearch
         #       end
         #     end
         #
-        # @see http://elasticsearch.org/guide/en/elasticsearch/reference/current/query-dsl-regexp-query.html
+        # @see https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-regexp-query.html
         #
         class Regexp
           include BaseComponent

--- a/elasticsearch-dsl/lib/elasticsearch/dsl/search/queries/simple_query_string.rb
+++ b/elasticsearch-dsl/lib/elasticsearch/dsl/search/queries/simple_query_string.rb
@@ -34,7 +34,7 @@ module Elasticsearch
         #       end
         #     end
         #
-        # @see http://elasticsearch.org/guide/en/elasticsearch/reference/current/query-dsl-simple-query-string-query.html
+        # @see https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-simple-query-string-query.html
         #
         class SimpleQueryString
           include BaseComponent

--- a/elasticsearch-dsl/lib/elasticsearch/dsl/search/queries/span_first.rb
+++ b/elasticsearch-dsl/lib/elasticsearch/dsl/search/queries/span_first.rb
@@ -30,7 +30,7 @@ module Elasticsearch
         #       end
         #     end
         #
-        # @see http://elasticsearch.org/guide/en/elasticsearch/reference/current/query-dsl-span-first-query.html
+        # @see https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-span-first-query.html
         # @see https://lucene.apache.org/core/5_0_0/core/org/apache/lucene/search/spans/package-summary.html
         #
         class SpanFirst

--- a/elasticsearch-dsl/lib/elasticsearch/dsl/search/queries/span_multi.rb
+++ b/elasticsearch-dsl/lib/elasticsearch/dsl/search/queries/span_multi.rb
@@ -30,7 +30,7 @@ module Elasticsearch
         #       end
         #     end
         #
-        # @see http://elasticsearch.org/guide/en/elasticsearch/reference/current/query-dsl-span-multi-term-query.html
+        # @see https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-span-multi-term-query.html
         # @see https://lucene.apache.org/core/5_0_0/core/org/apache/lucene/search/spans/package-summary.html
         #
         class SpanMulti

--- a/elasticsearch-dsl/lib/elasticsearch/dsl/search/queries/span_near.rb
+++ b/elasticsearch-dsl/lib/elasticsearch/dsl/search/queries/span_near.rb
@@ -31,7 +31,7 @@ module Elasticsearch
         #       end
         #     end
         #
-        # @see http://elasticsearch.org/guide/en/elasticsearch/reference/current/query-dsl-span-near-query.html
+        # @see https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-span-near-query.html
         # @see https://lucene.apache.org/core/5_0_0/core/org/apache/lucene/search/spans/package-summary.html
         #
         class SpanNear

--- a/elasticsearch-dsl/lib/elasticsearch/dsl/search/queries/span_not.rb
+++ b/elasticsearch-dsl/lib/elasticsearch/dsl/search/queries/span_not.rb
@@ -31,7 +31,7 @@ module Elasticsearch
         #       end
         #     end
         #
-        # @see http://elasticsearch.org/guide/en/elasticsearch/reference/current/query-dsl-span-not-query.html
+        # @see https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-span-not-query.html
         # @see https://lucene.apache.org/core/5_0_0/core/org/apache/lucene/search/spans/package-summary.html
         #
         class SpanNot

--- a/elasticsearch-dsl/lib/elasticsearch/dsl/search/queries/span_or.rb
+++ b/elasticsearch-dsl/lib/elasticsearch/dsl/search/queries/span_or.rb
@@ -30,7 +30,7 @@ module Elasticsearch
         #       end
         #     end
         #
-        # @see http://elasticsearch.org/guide/en/elasticsearch/reference/current/query-dsl-span-or-query.html
+        # @see https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-span-or-query.html
         # @see https://lucene.apache.org/core/5_0_0/core/org/apache/lucene/search/spans/package-summary.html
         #
         class SpanOr

--- a/elasticsearch-dsl/lib/elasticsearch/dsl/search/queries/span_term.rb
+++ b/elasticsearch-dsl/lib/elasticsearch/dsl/search/queries/span_term.rb
@@ -30,7 +30,7 @@ module Elasticsearch
         #       end
         #     end
         #
-        # @see http://elasticsearch.org/guide/en/elasticsearch/reference/current/query-dsl-span-term-query.html
+        # @see https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-span-term-query.html
         # @see https://lucene.apache.org/core/5_0_0/core/org/apache/lucene/search/spans/package-summary.html
         #
         class SpanTerm

--- a/elasticsearch-dsl/lib/elasticsearch/dsl/search/queries/template.rb
+++ b/elasticsearch-dsl/lib/elasticsearch/dsl/search/queries/template.rb
@@ -33,7 +33,7 @@ module Elasticsearch
         #       end
         #     end
         #
-        # @see http://elasticsearch.org/guide/en/elasticsearch/reference/current/query-dsl-template-query.html
+        # @see https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-template-query.html
         #
         class Template
           include BaseComponent

--- a/elasticsearch-dsl/lib/elasticsearch/dsl/search/queries/terms.rb
+++ b/elasticsearch-dsl/lib/elasticsearch/dsl/search/queries/terms.rb
@@ -32,7 +32,7 @@ module Elasticsearch
         #       end
         #     end
         #
-        # @see http://elasticsearch.org/guide/en/elasticsearch/reference/current/query-dsl-common-terms-query.html
+        # @see https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-common-terms-query.html
         #
         class Terms
           include BaseComponent

--- a/elasticsearch-dsl/lib/elasticsearch/dsl/search/queries/top_children.rb
+++ b/elasticsearch-dsl/lib/elasticsearch/dsl/search/queries/top_children.rb
@@ -35,7 +35,7 @@ module Elasticsearch
         #     end
         #
         #
-        # @see http://elasticsearch.org/guide/en/elasticsearch/reference/current/query-dsl-top-children-query.html
+        # @see https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-top-children-query.html
         #
         class TopChildren
           include BaseComponent

--- a/elasticsearch-dsl/lib/elasticsearch/dsl/search/queries/wildcard.rb
+++ b/elasticsearch-dsl/lib/elasticsearch/dsl/search/queries/wildcard.rb
@@ -32,7 +32,7 @@ module Elasticsearch
         #       end
         #     end
         #
-        # @see http://elasticsearch.org/guide/en/elasticsearch/reference/current/query-dsl-wildcard-query.html
+        # @see https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-wildcard-query.html
         #
         class Wildcard
           include BaseComponent


### PR DESCRIPTION
Search and replace swapping http://elasticsearch.org/ to https://www.elastic.co/

Similar to 448c2afb1e78d7b41178081b1823b528a318ee4c but picking up links without 'www'