### PR TITLE
[DSL] Allow calling methods in the scope of the surrounding search definition

### DIFF
--- a/elasticsearch-dsl/lib/elasticsearch/dsl/search.rb
+++ b/elasticsearch-dsl/lib/elasticsearch/dsl/search.rb
@@ -58,7 +58,8 @@ module Elasticsearch
 
         def initialize(*args, &block)
           @options = Options.new *args
-          block.arity < 1 ? self.instance_eval(&block) : block.call(self) if block
+          @block = block
+          @block.arity < 1 ? self.instance_eval(&@block) : @block.call(self) if @block
         end
 
         # DSL method for building or accessing the `query` part of a search definition
@@ -263,6 +264,8 @@ module Elasticsearch
           if @options.respond_to? name
             @options.__send__ name, *args, &block
             self
+          elsif @block
+            @block.binding.eval('self').send(name, *args, &block)
           else
             super
           end

--- a/elasticsearch-dsl/lib/elasticsearch/dsl/search/aggregation.rb
+++ b/elasticsearch-dsl/lib/elasticsearch/dsl/search/aggregation.rb
@@ -46,8 +46,10 @@ module Elasticsearch
           klass = Utils.__camelize(name)
           if Aggregations.const_defined? klass
             @value = Aggregations.const_get(klass).new *args, &block
+          elsif @block && _self = @block.binding.eval('self') && _self.respond_to?(name)
+            _self.send(name, *args, &block)
           else
-            raise NoMethodError, "undefined method '#{name}' for #{self}"
+            super
           end
         end
 

--- a/elasticsearch-dsl/lib/elasticsearch/dsl/search/aggregation.rb
+++ b/elasticsearch-dsl/lib/elasticsearch/dsl/search/aggregation.rb
@@ -46,8 +46,8 @@ module Elasticsearch
           klass = Utils.__camelize(name)
           if Aggregations.const_defined? klass
             @value = Aggregations.const_get(klass).new *args, &block
-          elsif @block && _self = @block.binding.eval('self') && _self.respond_to?(name)
-            _self.send(name, *args, &block)
+          elsif @block
+            @block.binding.eval('self').send(name, *args, &block)
           else
             super
           end

--- a/elasticsearch-dsl/lib/elasticsearch/dsl/search/base_aggregation_component.rb
+++ b/elasticsearch-dsl/lib/elasticsearch/dsl/search/base_aggregation_component.rb
@@ -40,8 +40,10 @@ module Elasticsearch
             klass = Utils.__camelize(name)
             if Aggregations.const_defined? klass
               @value = Aggregations.const_get(klass).new *args, &block
+            elsif @block
+              @block.binding.eval('self').send(name, *args, &block)
             else
-              raise NoMethodError, "undefined method '#{name}' for #{self}"
+              super
             end
           end
 

--- a/elasticsearch-dsl/lib/elasticsearch/dsl/search/base_component.rb
+++ b/elasticsearch-dsl/lib/elasticsearch/dsl/search/base_component.rb
@@ -179,6 +179,16 @@ module Elasticsearch
                 @hash
             end
           end
+
+          private
+
+          def method_missing(name, *args, &block)
+            if @block && _self = @block.binding.eval('self') && _self.respond_to?(name)
+              _self.send(name, *args, &block)
+            else
+              super
+            end
+          end
         end
       end
     end

--- a/elasticsearch-dsl/lib/elasticsearch/dsl/search/base_component.rb
+++ b/elasticsearch-dsl/lib/elasticsearch/dsl/search/base_component.rb
@@ -183,8 +183,8 @@ module Elasticsearch
           private
 
           def method_missing(name, *args, &block)
-            if @block && _self = @block.binding.eval('self') && _self.respond_to?(name)
-              _self.send(name, *args, &block)
+            if @block
+              @block.binding.eval('self').send(name, *args, &block)
             else
               super
             end

--- a/elasticsearch-dsl/lib/elasticsearch/dsl/search/base_compound_filter_component.rb
+++ b/elasticsearch-dsl/lib/elasticsearch/dsl/search/base_compound_filter_component.rb
@@ -103,8 +103,10 @@ module Elasticsearch
             klass = Utils.__camelize(name)
             if Filters.const_defined? klass
               @value << Filters.const_get(klass).new(*args, &block)
+            elsif @block
+              @block.binding.eval('self').send(name, *args, &block)
             else
-              raise NoMethodError, "undefined method '#{name}' for #{self}"
+              super
             end
           end
         end

--- a/elasticsearch-dsl/lib/elasticsearch/dsl/search/filter.rb
+++ b/elasticsearch-dsl/lib/elasticsearch/dsl/search/filter.rb
@@ -40,8 +40,8 @@ module Elasticsearch
           klass = Utils.__camelize(name)
           if Filters.const_defined? klass
             @value = Filters.const_get(klass).new *args, &block
-          elsif @block && _self = @block.binding.eval('self') && _self.respond_to?(name)
-            _self.send(name, *args, &block)
+          elsif @block
+            @block.binding.eval('self').send(name, *args, &block)
           else
             super
           end

--- a/elasticsearch-dsl/lib/elasticsearch/dsl/search/filter.rb
+++ b/elasticsearch-dsl/lib/elasticsearch/dsl/search/filter.rb
@@ -40,8 +40,10 @@ module Elasticsearch
           klass = Utils.__camelize(name)
           if Filters.const_defined? klass
             @value = Filters.const_get(klass).new *args, &block
+          elsif @block && _self = @block.binding.eval('self') && _self.respond_to?(name)
+            _self.send(name, *args, &block)
           else
-            raise NoMethodError, "undefined method '#{name}' for #{self}"
+            super
           end
         end
 

--- a/elasticsearch-dsl/lib/elasticsearch/dsl/search/filters/not.rb
+++ b/elasticsearch-dsl/lib/elasticsearch/dsl/search/filters/not.rb
@@ -62,8 +62,10 @@ module Elasticsearch
             klass = Utils.__camelize(name)
             if Filters.const_defined? klass
               @value = Filters.const_get(klass).new(*args, &block)
+            elsif @block && _self = @block.binding.eval('self') && _self.respond_to?(name)
+              _self.send(name, *args, &block)
             else
-              raise NoMethodError, "undefined method '#{name}' for #{self}"
+              super
             end
           end
 

--- a/elasticsearch-dsl/lib/elasticsearch/dsl/search/filters/not.rb
+++ b/elasticsearch-dsl/lib/elasticsearch/dsl/search/filters/not.rb
@@ -62,8 +62,8 @@ module Elasticsearch
             klass = Utils.__camelize(name)
             if Filters.const_defined? klass
               @value = Filters.const_get(klass).new(*args, &block)
-            elsif @block && _self = @block.binding.eval('self') && _self.respond_to?(name)
-              _self.send(name, *args, &block)
+            elsif @block
+              @block.binding.eval('self').send(name, *args, &block)
             else
               super
             end

--- a/elasticsearch-dsl/lib/elasticsearch/dsl/search/query.rb
+++ b/elasticsearch-dsl/lib/elasticsearch/dsl/search/query.rb
@@ -40,8 +40,10 @@ module Elasticsearch
           klass = Utils.__camelize(name)
           if Queries.const_defined? klass
             @value = Queries.const_get(klass).new *args, &block
+          elsif @block
+            @value = @block.binding.eval('self').send(name, *args, &block)
           else
-            raise NoMethodError, "undefined method '#{name}' for #{self}"
+            super
           end
         end
 

--- a/elasticsearch-dsl/lib/elasticsearch/dsl/search/query.rb
+++ b/elasticsearch-dsl/lib/elasticsearch/dsl/search/query.rb
@@ -41,7 +41,7 @@ module Elasticsearch
           if Queries.const_defined? klass
             @value = Queries.const_get(klass).new *args, &block
           elsif @block
-            @value = @block.binding.eval('self').send(name, *args, &block)
+           @block.binding.eval('self').send(name, *args, &block)
           else
             super
           end

--- a/elasticsearch-dsl/spec/elasticsearch/dsl/search_spec.rb
+++ b/elasticsearch-dsl/spec/elasticsearch/dsl/search_spec.rb
@@ -158,14 +158,10 @@ describe Elasticsearch::DSL::Search do
 
         let(:s) do
 
-          def term_field
-            :color
-          end
-
           def not_clause(obj)
             obj.instance_eval do
               _not do
-                term term_field => 'red'
+                term color: 'red'
               end
             end
           end
@@ -272,7 +268,7 @@ describe Elasticsearch::DSL::Search do
       end
     end
 
-    it 'finds the correct bindings' do
+    it 'allows the subquery to be defined on the calling scope' do
       expect(my_search.to_hash).to eq(query: { bool: { filter: [{ term: { foo: 'bar' } }],
                                                      must: [{ match: { foo: 'bar' } }] } })
     end

--- a/elasticsearch-dsl/spec/elasticsearch/dsl/search_spec.rb
+++ b/elasticsearch-dsl/spec/elasticsearch/dsl/search_spec.rb
@@ -40,6 +40,115 @@ describe Elasticsearch::DSL::Search do
     end
   end
 
+  context 'when a block is provided' do
+
+    context 'when the containing scope is accessed in the block' do
+
+      let(:s) do
+        def query_value
+          { title: 'test' }
+        end
+
+        search do
+          query do
+            match query_value
+          end
+        end
+      end
+
+      let(:expected_hash) do
+        { query: { match: { title: 'test' } } }
+      end
+
+      it 'allows access to the containing scope' do
+        expect(s.to_hash).to eq(expected_hash)
+      end
+    end
+
+    context 'when other methods are used to construct the query' do
+
+      def bool_query(obj)
+        obj.instance_eval do
+          bool do
+            must do
+              match foo: 'bar'
+            end
+            filter do
+              term foo: 'bar'
+            end
+          end
+        end
+      end
+
+      let(:my_search) do
+        search do
+          query do
+            bool_query(self)
+          end
+        end
+      end
+
+      it 'finds the correct bindings' do
+        expect(my_search.to_hash).to eq(query: { bool: { filter: [{ term: { foo: 'bar' } }],
+                                                         must: [{ match: { foo: 'bar' } }] } })
+      end
+    end
+  end
+
+  describe '#collapse' do
+
+    let(:s) do
+      search do
+        query do
+          match title: 'test'
+        end
+        collapse :user do
+          max_concurrent_group_searches 4
+          inner_hits 'last_tweet' do
+            size 10
+            from 5
+            sort do
+              by :date, order: 'desc'
+              by :likes, order: 'asc'
+            end
+          end
+        end
+      end
+    end
+
+    let(:inner_hits_hash) do
+      { name: 'last_tweet',
+        size: 10,
+        from: 5,
+        sort: [ { date: { order: 'desc' } },
+                { likes: { order: 'asc' } }]
+      }
+    end
+
+    let(:expected_hash) do
+      { query: { match: { title: 'test' } },
+        collapse: { field: :user,
+                    max_concurrent_group_searches: 4,
+                    inner_hits: inner_hits_hash }  }
+    end
+
+    it 'sets the field name' do
+      expect(s.to_hash[:collapse][:field]).to eq(:user)
+    end
+
+    it 'sets the max_concurrent_group_searches option' do
+      expect(s.to_hash[:collapse][:max_concurrent_group_searches]).to eq(4)
+    end
+
+    it 'sets the inner_hits' do
+      expect(s.to_hash[:collapse][:inner_hits]).to eq(inner_hits_hash)
+    end
+
+    it 'constructs the correct hash' do
+      expect(s.to_hash).to eq(expected_hash)
+    end
+  end
+
   describe '#collapse' do
 
     let(:s) do


### PR DESCRIPTION
This pull request is a first attempt to adjust the DSL library to look for method definitions in the scope of the top-level search definition.

It also allows a sub-definition to be defined if the current object is passed to the method.

It's not a complete solution, but rather a starting point that might help some users interested in splitting out their search definition into different methods.
