### PR TITLE
Implement significant_text aggregation

### DIFF
--- a/elasticsearch-dsl/lib/elasticsearch/dsl/search/aggregations/significant_text.rb
+++ b/elasticsearch-dsl/lib/elasticsearch/dsl/search/aggregations/significant_text.rb
@@ -1,0 +1,49 @@
+# Licensed to Elasticsearch B.V under one or more agreements.
+# Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+# See the LICENSE file in the project root for more information
+
+module Elasticsearch
+  module DSL
+    module Search
+      module Aggregations
+
+        # An aggregation that returns interesting or unusual occurrences of free-text terms in a set. 
+        #
+        # @example
+        #
+        #     search do
+        #       query do
+        #         match :title do
+        #           query 'fink'
+        #         end
+        #       end
+        #
+        #       aggregation :interesting_terms do
+        #         significant_text do
+        #           field :body
+        #         end
+        #       end
+        #     end
+        #
+        # @see https://www.elastic.co/guide/en/elasticsearch/reference/6.8/search-aggregations-bucket-significanttext-aggregation.html
+        #
+        class SignificantText
+          include BaseAggregationComponent
+
+          option_method :field
+          option_method :size
+          option_method :shard_size
+          option_method :min_doc_count
+          option_method :shard_min_doc_count
+          option_method :include
+          option_method :exclude
+          option_method :background_filter
+          option_method :mutual_information
+          option_method :chi_square
+          option_method :gnd
+        end
+
+      end
+    end
+  end
+end

--- a/elasticsearch-dsl/spec/elasticsearch/dsl/search/aggregations/significant_text_spec.rb
+++ b/elasticsearch-dsl/spec/elasticsearch/dsl/search/aggregations/significant_text_spec.rb
@@ -1,0 +1,163 @@
+# Licensed to Elasticsearch B.V under one or more agreements.
+# Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+# See the LICENSE file in the project root for more information
+
+require 'spec_helper'
+
+describe Elasticsearch::DSL::Search::Aggregations::SignificantText do
+
+  let(:search) do
+    described_class.new
+  end
+
+  describe '#to_hash' do
+
+    it 'can be converted to a hash' do
+      expect(search.to_hash).to eq(significant_text: {})
+    end
+  end
+
+  context 'when options methods are called' do
+
+    let(:search) do
+      described_class.new(:foo)
+    end
+
+    describe '#field' do
+
+      before do
+        search.field('bar')
+      end
+
+      it 'applies the option' do
+        expect(search.to_hash[:significant_text][:foo][:field]).to eq('bar')
+      end
+    end
+
+    describe '#size' do
+
+      before do
+        search.size('bar')
+      end
+
+      it 'applies the option' do
+        expect(search.to_hash[:significant_text][:foo][:size]).to eq('bar')
+      end
+    end
+
+    describe '#shard_size' do
+
+      before do
+        search.shard_size('bar')
+      end
+
+      it 'applies the option' do
+        expect(search.to_hash[:significant_text][:foo][:shard_size]).to eq('bar')
+      end
+    end
+
+    describe '#min_doc_count' do
+
+      before do
+        search.min_doc_count('bar')
+      end
+
+      it 'applies the option' do
+        expect(search.to_hash[:significant_text][:foo][:min_doc_count]).to eq('bar')
+      end
+    end
+
+    describe '#shard_min_doc_count' do
+
+      before do
+        search.shard_min_doc_count('bar')
+      end
+
+      it 'applies the option' do
+        expect(search.to_hash[:significant_text][:foo][:shard_min_doc_count]).to eq('bar')
+      end
+    end
+
+    describe '#include' do
+
+      before do
+        search.include('bar')
+      end
+
+      it 'applies the option' do
+        expect(search.to_hash[:significant_text][:foo][:include]).to eq('bar')
+      end
+    end
+
+    describe '#exclude' do
+
+      before do
+        search.exclude('bar')
+      end
+
+      it 'applies the option' do
+        expect(search.to_hash[:significant_text][:foo][:exclude]).to eq('bar')
+      end
+    end
+
+    describe '#background_filter' do
+
+      before do
+        search.background_filter('bar')
+      end
+
+      it 'applies the option' do
+        expect(search.to_hash[:significant_text][:foo][:background_filter]).to eq('bar')
+      end
+    end
+
+    describe '#mutual_information' do
+
+      before do
+        search.mutual_information('bar')
+      end
+
+      it 'applies the option' do
+        expect(search.to_hash[:significant_text][:foo][:mutual_information]).to eq('bar')
+      end
+    end
+
+    describe '#chi_square' do
+
+      before do
+        search.chi_square('bar')
+      end
+
+      it 'applies the option' do
+        expect(search.to_hash[:significant_text][:foo][:chi_square]).to eq('bar')
+      end
+    end
+
+    describe '#gnd' do
+
+      before do
+        search.gnd('bar')
+      end
+
+      it 'applies the option' do
+        expect(search.to_hash[:significant_text][:foo][:gnd]).to eq('bar')
+      end
+    end
+  end
+
+  describe '#initialize' do
+
+    context 'when a block is provided' do
+
+      let(:search) do
+        described_class.new do
+          field 'bar'
+        end
+      end
+
+      it 'executes the block' do
+        expect(search.to_hash).to eq(significant_text: { field: 'bar' })
+      end
+    end
+  end
+end


### PR DESCRIPTION
`significant_text` aggregation got introduced in v6.0. Basically c&p from `significant_terms`.

See https://www.elastic.co/guide/en/elasticsearch/reference/6.8/search-aggregations-bucket-significanttext-aggregation.html
