### PR TITLE
Docs: Make asciidoc happy

### DIFF
--- a/docs/client.asciidoc
+++ b/docs/client.asciidoc
@@ -15,15 +15,17 @@ The Elasticsearch client is compatible with Ruby 1.9 and higher.
 The client's API is compatible with Elasticsearch's API versions from 0.90 till current,
 just use a release matching major version of Elasticsearch.
 
-| Gem Version   |   | Elasticsearch |
-|:-------------:|:-:| :-----------: |
-| 0.90          | → | 0.90          |
-| 1.x           | → | 1.x           |
-| 2.x           | → | 2.x           |
-| 5.x           | → | 5.x           |
-| 6.x           | → | 6.x           |
-| 7.x           | → | 7.x           |
-| master        | → | master        |
+|===
+| Gem Version   |   | Elasticsearch Version
+
+| 0.90          | → | 0.90
+| 1.x           | → | 1.x
+| 2.x           | → | 2.x
+| 5.x           | → | 5.x
+| 6.x           | → | 6.x
+| 7.x           | → | 7.x
+| master        | → | master
+|===
 
 === Installation
 

--- a/docs/persistence.asciidoc
+++ b/docs/persistence.asciidoc
@@ -69,7 +69,7 @@ n = repository.find(1)
 # GET http://localhost:9200/repository/_doc/1 [status:200, request:0.003s, query:n/a]
 # < {"_index":"repository","_type":"note","_id":"1","_version":2,"found":true, "_source" : {"id":1,"text":"Test"}}
 => <Note:0x007fcbfc0c4980 @attributes={"id"=>1, "text"=>"Test"}>
-------------------------------------`
+------------------------------------
 
 ...search for it...
 


### PR DESCRIPTION
The docs weren't building with asciidoc without the change to
`persistence.asciidoc` and the table on the client page was mangled
without the change to `client.asciidoc`.