### PR TITLE
[transport] support for faraday 1.0 error types

### DIFF
--- a/elasticsearch-transport/elasticsearch-transport.gemspec
+++ b/elasticsearch-transport/elasticsearch-transport.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |s|
   s.required_ruby_version = '>= 1.9'
 
   s.add_dependency "multi_json"
-  s.add_dependency "faraday"
+  s.add_dependency "faraday", '>= 0.14', "< 2"
 
   if defined?(RUBY_VERSION) && RUBY_VERSION < '1.9'
     s.add_dependency "system_timer"

--- a/elasticsearch-transport/lib/elasticsearch/transport/transport/http/faraday.rb
+++ b/elasticsearch-transport/lib/elasticsearch/transport/transport/http/faraday.rb
@@ -48,7 +48,12 @@ module Elasticsearch
           # @return [Array]
           #
           def host_unreachable_exceptions
-            [::Faraday::Error::ConnectionFailed, ::Faraday::Error::TimeoutError]
+            [
+                ::Faraday::ConnectionFailed,
+                ::Faraday::TimeoutError,
+                ::Faraday.const_defined?(:ServerError) ? ::Faraday::ServerError : nil,
+                ::Faraday::SSLError
+            ].compact
           end
 
           private


### PR DESCRIPTION
1.0 isn't released yet but users can use the RC
... maintain backwards compatibility with 0.1X

closes #694 (and #637)