### PR TITLE
`dup` string before calling `force_encoding`

### DIFF
--- a/elasticsearch-transport/lib/elasticsearch/transport/transport/response.rb
+++ b/elasticsearch-transport/lib/elasticsearch/transport/transport/response.rb
@@ -16,7 +16,7 @@ module Elasticsearch
         # @param headers [Hash]    Response headers
         def initialize(status, body, headers={})
           @status, @body, @headers = status, body, headers
-          @body = body.force_encoding('UTF-8') if body.respond_to?(:force_encoding)
+          @body = body.dup.force_encoding('UTF-8') if body.respond_to?(:force_encoding)
         end
       end
 


### PR DESCRIPTION
Without this fix, a recent change in faraday causes responses to occasionally be frozen empty string literals, which throw a `FrozenError` when you call `force_encoding` on them.

You can see a similar fix at https://github.com/fastlane/fastlane/pull/15403/files#diff-a9086da2d7e8a66b647fdabdb0a7cca7R811.