### PR TITLE
[XPACK] Support Index Lifecycle Management(ILM) API

### DIFF
--- a/elasticsearch-xpack/lib/elasticsearch/xpack.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack.rb
@@ -27,7 +27,7 @@ module Elasticsearch
   end
 end
 
-Elasticsearch::API::COMMON_PARAMS.push :job_id, :datafeed_id, :filter_id, :snapshot_id, :category_id
+Elasticsearch::API::COMMON_PARAMS.push :job_id, :datafeed_id, :filter_id, :snapshot_id, :category_id, :policy_id
 
 module Elasticsearch
   module Transport
@@ -70,6 +70,10 @@ module Elasticsearch
 
       def data_frame
         @data_frame ||= xpack.data_frame
+      end
+
+      def ilm
+        @ilm ||= xpack.ilm
       end
     end
   end

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/index_lifecycle_management/delete_policy.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/index_lifecycle_management/delete_policy.rb
@@ -1,0 +1,39 @@
+# Licensed to Elasticsearch B.V under one or more agreements.
+# Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+# See the LICENSE file in the project root for more information
+
+module Elasticsearch
+  module XPack
+    module API
+      module IndexLifecycleManagement
+        module Actions
+
+          # Deletes a lifecycle policy
+          #
+          # @option arguments [String] :policy_id Identifier for the policy
+          # @option arguments [Time] :master_timeout Specifies the period of time to wait for a connection to the master node
+          # @option arguments [Time] :timeout Specifies the period of time to wait for a response.
+          #
+          # @see https://www.elastic.co/guide/en/elasticsearch/reference/current/ilm-delete-lifecycle.html
+          #
+          def delete_policy(arguments={})
+            raise ArgumentError, "Required argument 'policy_id' missing" unless arguments[:policy_id]
+            method = Elasticsearch::API::HTTP_DELETE
+            path   = Elasticsearch::API::Utils.__pathify "_ilm/policy",
+                                                         Elasticsearch::API::Utils.__escape(arguments[:policy_id])
+            params = Elasticsearch::API::Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
+            body   = nil
+
+            perform_request(method, path, params, body).body
+          end
+
+          # Register this action with its valid params when the module is loaded.
+          #
+          ParamsRegistry.register(:delete_policy, [ :master_timeout,
+                                                    :timeout ].freeze)
+
+        end
+      end
+    end
+  end
+end

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/index_lifecycle_management/explain.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/index_lifecycle_management/explain.rb
@@ -1,0 +1,40 @@
+# Licensed to Elasticsearch B.V under one or more agreements.
+# Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+# See the LICENSE file in the project root for more information
+
+module Elasticsearch
+  module XPack
+    module API
+      module IndexLifecycleManagement
+        module Actions
+
+          # Shows an index’s current lifecycle status
+          #
+          # @option arguments [String] :index The target index (*Required*)
+          # @option arguments [Time] :master_timeout Specifies the period of time to wait for a connection to the master node
+          # @option arguments [Time] :timeout Specifies the period of time to wait for a response.
+          #
+          # @see https://www.elastic.co/guide/en/elasticsearch/reference/current/ilm-explain-lifecycle.html
+          #
+          def explain(arguments={})
+            raise ArgumentError, "Required argument 'index' missing" unless arguments[:index]
+            index = Elasticsearch::API::Utils.__escape(arguments.delete(:index))
+
+            method = Elasticsearch::API::HTTP_GET
+            path   = Elasticsearch::API::Utils.__pathify index, "_ilm/explain"
+            params = Elasticsearch::API::Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
+            body   = nil
+
+            perform_request(method, path, params, body).body
+          end
+
+          # Register this action with its valid params when the module is loaded.
+          #
+          ParamsRegistry.register(:explain, [ :master_timeout,
+                                              :timeout ].freeze)
+
+        end
+      end
+    end
+  end
+end

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/index_lifecycle_management/get_policy.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/index_lifecycle_management/get_policy.rb
@@ -1,0 +1,38 @@
+# Licensed to Elasticsearch B.V under one or more agreements.
+# Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+# See the LICENSE file in the project root for more information
+
+module Elasticsearch
+  module XPack
+    module API
+      module IndexLifecycleManagement
+        module Actions
+
+          # Retrieves a lifecycle policy
+          #
+          # @option arguments [String] :policy_id Identifier for the policy
+          # @option arguments [Time] :master_timeout Specifies the period of time to wait for a connection to the master node
+          # @option arguments [Time] :timeout Specifies the period of time to wait for a response.
+          #
+          # @see https://www.elastic.co/guide/en/elasticsearch/reference/current/ilm-get-lifecycle.html
+          #
+          def get_policy(arguments={})
+            method = Elasticsearch::API::HTTP_GET
+            path   = Elasticsearch::API::Utils.__pathify "_ilm/policy",
+                                                         Elasticsearch::API::Utils.__escape(arguments[:policy_id])
+            params = Elasticsearch::API::Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
+            body   = nil
+
+            perform_request(method, path, params, body).body
+          end
+
+          # Register this action with its valid params when the module is loaded.
+          #
+          ParamsRegistry.register(:get_policy, [ :master_timeout,
+                                                 :timeout ].freeze)
+
+        end
+      end
+    end
+  end
+end

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/index_lifecycle_management/get_status.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/index_lifecycle_management/get_status.rb
@@ -1,0 +1,36 @@
+# Licensed to Elasticsearch B.V under one or more agreements.
+# Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+# See the LICENSE file in the project root for more information
+
+module Elasticsearch
+  module XPack
+    module API
+      module IndexLifecycleManagement
+        module Actions
+
+          # Retrieves the current index lifecycle management (ILM) status
+          #
+          # @option arguments [Time] :master_timeout Specifies the period of time to wait for a connection to the master node
+          # @option arguments [Time] :timeout Specifies the period of time to wait for a response.
+          #
+          # @see https://www.elastic.co/guide/en/elasticsearch/reference/current/ilm-get-status.html
+          #
+          def get_status(arguments={})
+            method = Elasticsearch::API::HTTP_GET
+            path   = "_ilm/status"
+            params = Elasticsearch::API::Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
+            body   = nil
+
+            perform_request(method, path, params, body).body
+          end
+
+          # Register this action with its valid params when the module is loaded.
+          #
+          ParamsRegistry.register(:get_status, [ :master_timeout,
+                                                 :timeout ].freeze)
+
+        end
+      end
+    end
+  end
+end

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/index_lifecycle_management/move_to_step.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/index_lifecycle_management/move_to_step.rb
@@ -1,0 +1,41 @@
+# Licensed to Elasticsearch B.V under one or more agreements.
+# Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+# See the LICENSE file in the project root for more information
+
+module Elasticsearch
+  module XPack
+    module API
+      module IndexLifecycleManagement
+        module Actions
+
+          # Triggers execution of a specific step in the lifecycle policy
+          #
+          # @option arguments [String] :index The target index (*Required*)
+          # @option arguments [Hash] :body The request template content (*Required*)
+          # @option arguments [Time] :master_timeout Specifies the period of time to wait for a connection to the master node
+          # @option arguments [Time] :timeout Specifies the period of time to wait for a response.
+          #
+          # @see https://www.elastic.co/guide/en/elasticsearch/reference/current/ilm-move-to-step.html
+          #
+          def move_to_step(arguments={})
+            raise ArgumentError, "Required argument 'index' missing" unless arguments[:index]
+            raise ArgumentError, "Required argument 'body' missing" unless arguments[:body]
+            method = Elasticsearch::API::HTTP_POST
+            index = Elasticsearch::API::Utils.__escape(arguments.delete(:index))
+            path   = Elasticsearch::API::Utils.__pathify "_ilm/move",
+                                                         index
+            params = Elasticsearch::API::Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
+            body   = arguments[:body]
+
+            perform_request(method, path, params, body).body
+          end
+
+          # Register this action with its valid params when the module is loaded.
+          #
+          ParamsRegistry.register(:move_to_step, [ :master_timeout,
+                                                   :timeout ].freeze)
+        end
+      end
+    end
+  end
+end

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/index_lifecycle_management/params_registry.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/index_lifecycle_management/params_registry.rb
@@ -1,0 +1,50 @@
+# Licensed to Elasticsearch B.V under one or more agreements.
+# Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+# See the LICENSE file in the project root for more information
+
+module Elasticsearch
+  module XPack
+    module API
+      module IndexLifecycleManagement
+        module Actions
+          module ParamsRegistry
+
+            extend self
+
+            # A Mapping of all the actions to their list of valid params.
+            #
+            # @since 7.4.0
+            PARAMS = {}
+
+            # Register an action with its list of valid params.
+            #
+            # @example Register the action.
+            #   ParamsRegistry.register(:benchmark, [ :verbose ])
+            #
+            # @param [ Symbol ] action The action to register.
+            # @param [ Array[Symbol] ] valid_params The list of valid params.
+            #
+            # @since 7.4.0
+            def register(action, valid_params)
+              PARAMS[action.to_sym] = valid_params
+            end
+
+            # Get the list of valid params for a given action.
+            #
+            # @example Get the list of valid params.
+            #   ParamsRegistry.get(:benchmark)
+            #
+            # @param [ Symbol ] action The action.
+            #
+            # @return [ Array<Symbol> ] The list of valid params for the action.
+            #
+            # @since 7.4.0
+            def get(action)
+              PARAMS.fetch(action, [])
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/index_lifecycle_management/put_policy.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/index_lifecycle_management/put_policy.rb
@@ -1,0 +1,40 @@
+# Licensed to Elasticsearch B.V under one or more agreements.
+# Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+# See the LICENSE file in the project root for more information
+
+module Elasticsearch
+  module XPack
+    module API
+      module IndexLifecycleManagement
+        module Actions
+
+          # Register a new watch in or update an existing one
+          #
+          # @option arguments [String] :policy_id Identifier for the policy (*Required*)
+          # @option arguments [Hash] :body The policy (*Required*)
+          # @option arguments [Time] :master_timeout Specifies the period of time to wait for a connection to the master node
+          # @option arguments [Time] :timeout Specifies the period of time to wait for a response.
+          #
+          # @see https://www.elastic.co/guide/en/elasticsearch/reference/current/ilm-put-lifecycle.html
+          #
+          def put_policy(arguments={})
+            raise ArgumentError, "Required argument 'policy_id' missing" unless arguments[:policy_id]
+            raise ArgumentError, "Required argument 'body' missing" unless arguments[:body]
+            method = Elasticsearch::API::HTTP_PUT
+            path   = Elasticsearch::API::Utils.__pathify "_ilm/policy",
+                                                         Elasticsearch::API::Utils.__escape(arguments[:policy_id])
+            params = Elasticsearch::API::Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
+            body   = arguments[:body]
+
+            perform_request(method, path, params, body).body
+          end
+
+          # Register this action with its valid params when the module is loaded.
+          #
+          ParamsRegistry.register(:put_policy, [ :master_timeout,
+                                                 :timeout ].freeze)
+        end
+      end
+    end
+  end
+end

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/index_lifecycle_management/remove_policy.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/index_lifecycle_management/remove_policy.rb
@@ -1,0 +1,38 @@
+# Licensed to Elasticsearch B.V under one or more agreements.
+# Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+# See the LICENSE file in the project root for more information
+
+module Elasticsearch
+  module XPack
+    module API
+      module IndexLifecycleManagement
+        module Actions
+
+          # Removes the assigned lifecycle policy from an index
+          #
+          # @option arguments [String] :index The target index (*Required*)
+          # @option arguments [Time] :master_timeout Specifies the period of time to wait for a connection to the master node
+          # @option arguments [Time] :timeout Specifies the period of time to wait for a response.
+          #
+          # @see https://www.elastic.co/guide/en/elasticsearch/reference/current/ilm-remove-policy.html
+          #
+          def remove_policy(arguments={})
+            raise ArgumentError, "Required argument 'index' missing" unless arguments[:index]
+            method = Elasticsearch::API::HTTP_POST
+            index = Elasticsearch::API::Utils.__escape(arguments.delete(:index))
+            path   = Elasticsearch::API::Utils.__pathify index, "_ilm/remove"
+            params = Elasticsearch::API::Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
+            body   = nil
+
+            perform_request(method, path, params, body).body
+          end
+
+          # Register this action with its valid params when the module is loaded.
+          #
+          ParamsRegistry.register(:remove_policy, [ :master_timeout,
+                                                    :timeout ].freeze)
+        end
+      end
+    end
+  end
+end

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/index_lifecycle_management/retry_policy.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/index_lifecycle_management/retry_policy.rb
@@ -1,0 +1,38 @@
+# Licensed to Elasticsearch B.V under one or more agreements.
+# Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+# See the LICENSE file in the project root for more information
+
+module Elasticsearch
+  module XPack
+    module API
+      module IndexLifecycleManagement
+        module Actions
+
+          # Retry executing the policy for an index that is in the ERROR step
+          #
+          # @option arguments [String] :index The target index (*Required*)
+          # @option arguments [Time] :master_timeout Specifies the period of time to wait for a connection to the master node
+          # @option arguments [Time] :timeout Specifies the period of time to wait for a response.
+          #
+          # @see https://www.elastic.co/guide/en/elasticsearch/reference/current/ilm-move-to-step.html
+          #
+          def retry_policy(arguments={})
+            raise ArgumentError, "Required argument 'index' missing" unless arguments[:index]
+            method = Elasticsearch::API::HTTP_POST
+            index = Elasticsearch::API::Utils.__escape(arguments.delete(:index))
+            path   = Elasticsearch::API::Utils.__pathify index, "_ilm/retry"
+            params = Elasticsearch::API::Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
+            body   = nil
+
+            perform_request(method, path, params, body).body
+          end
+
+          # Register this action with its valid params when the module is loaded.
+          #
+          ParamsRegistry.register(:retry_policy, [ :master_timeout,
+                                                   :timeout ].freeze)
+        end
+      end
+    end
+  end
+end

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/index_lifecycle_management/start.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/index_lifecycle_management/start.rb
@@ -1,0 +1,36 @@
+# Licensed to Elasticsearch B.V under one or more agreements.
+# Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+# See the LICENSE file in the project root for more information
+
+module Elasticsearch
+  module XPack
+    module API
+      module IndexLifecycleManagement
+        module Actions
+
+          # Start the index lifecycle management (ILM) plugin
+          #
+          # @option arguments [Time] :master_timeout Specifies the period of time to wait for a connection to the master node
+          # @option arguments [Time] :timeout Specifies the period of time to wait for a response.
+          #
+          # @see https://www.elastic.co/guide/en/elasticsearch/reference/current/ilm-start.html
+          #
+          def start(arguments={})
+            method = Elasticsearch::API::HTTP_POST
+            path   = "_ilm/start"
+            params = Elasticsearch::API::Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
+            body   = nil
+
+            perform_request(method, path, params, body).body
+          end
+
+          # Register this action with its valid params when the module is loaded.
+          #
+          ParamsRegistry.register(:start, [ :master_timeout,
+                                            :timeout ].freeze)
+
+        end
+      end
+    end
+  end
+end

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/index_lifecycle_management/stop.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/index_lifecycle_management/stop.rb
@@ -1,0 +1,36 @@
+# Licensed to Elasticsearch B.V under one or more agreements.
+# Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+# See the LICENSE file in the project root for more information
+
+module Elasticsearch
+  module XPack
+    module API
+      module IndexLifecycleManagement
+        module Actions
+
+          # Stop the index lifecycle management (ILM) plugin
+          #
+          # @option arguments [Time] :master_timeout Specifies the period of time to wait for a connection to the master node
+          # @option arguments [Time] :timeout Specifies the period of time to wait for a response.
+          #
+          # @see https://www.elastic.co/guide/en/elasticsearch/reference/current/ilm-stop.html
+          #
+          def stop(arguments={})
+            method = Elasticsearch::API::HTTP_POST
+            path   = "_ilm/stop"
+            params = Elasticsearch::API::Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
+            body   = nil
+
+            perform_request(method, path, params, body).body
+          end
+
+          # Register this action with its valid params when the module is loaded.
+          #
+          ParamsRegistry.register(:stop, [ :master_timeout,
+                                           :timeout ].freeze)
+
+        end
+      end
+    end
+  end
+end

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/namespace/index_lifecycle_management.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/namespace/index_lifecycle_management.rb
@@ -1,0 +1,22 @@
+# Licensed to Elasticsearch B.V under one or more agreements.
+# Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+# See the LICENSE file in the project root for more information
+
+module Elasticsearch
+  module XPack
+    module API
+      module IndexLifecycleManagement
+        module Actions; end
+
+        class IndexLifecycleManagementClient
+          include Elasticsearch::API::Common::Client, Elasticsearch::API::Common::Client::Base, IndexLifecycleManagement::Actions
+        end
+
+        def ilm
+          @ilm ||= IndexLifecycleManagementClient.new(self)
+        end
+
+      end
+    end
+  end
+end

--- a/elasticsearch-xpack/test/unit/index_lifecycle_management/delete_policy_test.rb
+++ b/elasticsearch-xpack/test/unit/index_lifecycle_management/delete_policy_test.rb
@@ -1,0 +1,30 @@
+# Licensed to Elasticsearch B.V under one or more agreements.
+# Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+# See the LICENSE file in the project root for more information
+
+require 'test_helper'
+
+module Elasticsearch
+  module Test
+    class XPackIndexLifecycleManagementDeletePolicyTest < Minitest::Test
+
+      context "XPack Index Lifecycle Management: Delete policy" do
+        subject { FakeClient.new }
+
+        should "perform correct request" do
+          subject.expects(:perform_request).with do |method, url, params, body|
+            assert_equal 'DELETE', method
+            assert_equal '_ilm/policy/foo', url
+            assert_equal Hash.new, params
+            assert_nil   body
+            true
+          end.returns(FakeResponse.new)
+
+          subject.xpack.ilm.delete_policy :policy_id => 'foo'
+        end
+
+      end
+
+    end
+  end
+end

--- a/elasticsearch-xpack/test/unit/index_lifecycle_management/explain_test.rb
+++ b/elasticsearch-xpack/test/unit/index_lifecycle_management/explain_test.rb
@@ -1,0 +1,30 @@
+# Licensed to Elasticsearch B.V under one or more agreements.
+# Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+# See the LICENSE file in the project root for more information
+
+require 'test_helper'
+
+module Elasticsearch
+  module Test
+    class XPackIndexLifecycleManagementExplainTest < Minitest::Test
+
+      context "XPack Index Lifecycle Management: explain" do
+        subject { FakeClient.new }
+
+        should "perform correct request" do
+          subject.expects(:perform_request).with do |method, url, params, body|
+            assert_equal 'GET', method
+            assert_equal 'foo/_ilm/explain', url
+            assert_equal Hash.new, params
+            assert_nil   body
+            true
+          end.returns(FakeResponse.new)
+
+          subject.xpack.ilm.explain :index => 'foo'
+        end
+
+      end
+
+    end
+  end
+end

--- a/elasticsearch-xpack/test/unit/index_lifecycle_management/get_policy_test.rb
+++ b/elasticsearch-xpack/test/unit/index_lifecycle_management/get_policy_test.rb
@@ -1,0 +1,30 @@
+# Licensed to Elasticsearch B.V under one or more agreements.
+# Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+# See the LICENSE file in the project root for more information
+
+require 'test_helper'
+
+module Elasticsearch
+  module Test
+    class XPackIndexLifecycleManagementGetPolicyTest < Minitest::Test
+
+      context "XPack Index Lifecycle Management: Get policy" do
+        subject { FakeClient.new }
+
+        should "perform correct request" do
+          subject.expects(:perform_request).with do |method, url, params, body|
+            assert_equal 'GET', method
+            assert_equal '_ilm/policy/foo', url
+            assert_equal Hash.new, params
+            assert_nil   body
+            true
+          end.returns(FakeResponse.new)
+
+          subject.xpack.ilm.get_policy :policy_id => 'foo'
+        end
+
+      end
+
+    end
+  end
+end

--- a/elasticsearch-xpack/test/unit/index_lifecycle_management/get_status_test.rb
+++ b/elasticsearch-xpack/test/unit/index_lifecycle_management/get_status_test.rb
@@ -1,0 +1,30 @@
+# Licensed to Elasticsearch B.V under one or more agreements.
+# Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+# See the LICENSE file in the project root for more information
+
+require 'test_helper'
+
+module Elasticsearch
+  module Test
+    class XPackIndexLifecycleManagementGetStatusTest < Minitest::Test
+
+      context "XPack Index Lifecycle Management: Get status" do
+        subject { FakeClient.new }
+
+        should "perform correct request" do
+          subject.expects(:perform_request).with do |method, url, params, body|
+            assert_equal 'GET', method
+            assert_equal '_ilm/status', url
+            assert_equal Hash.new, params
+            assert_nil body
+            true
+          end.returns(FakeResponse.new)
+
+          subject.xpack.ilm.get_status
+        end
+
+      end
+
+    end
+  end
+end

--- a/elasticsearch-xpack/test/unit/index_lifecycle_management/move_to_step.rb
+++ b/elasticsearch-xpack/test/unit/index_lifecycle_management/move_to_step.rb
@@ -1,0 +1,30 @@
+# Licensed to Elasticsearch B.V under one or more agreements.
+# Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+# See the LICENSE file in the project root for more information
+
+require 'test_helper'
+
+module Elasticsearch
+  module Test
+    class XPackIndexLifecycleManagementMoveStepTest < Minitest::Test
+
+      context "XPack Index Lifecycle Management: Move to step" do
+        subject { FakeClient.new }
+
+        should "perform correct request" do
+          subject.expects(:perform_request).with do |method, url, params, body|
+            assert_equal 'POST', method
+            assert_equal '_ilm/move/foo', url
+            assert_equal Hash.new, params
+            assert_equal Hash.new, body
+            true
+          end.returns(FakeResponse.new)
+
+          subject.xpack.ilm.move_to_step :index => 'foo', :body => {}
+        end
+
+      end
+
+    end
+  end
+end

--- a/elasticsearch-xpack/test/unit/index_lifecycle_management/put_policy_test.rb
+++ b/elasticsearch-xpack/test/unit/index_lifecycle_management/put_policy_test.rb
@@ -1,0 +1,30 @@
+# Licensed to Elasticsearch B.V under one or more agreements.
+# Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+# See the LICENSE file in the project root for more information
+
+require 'test_helper'
+
+module Elasticsearch
+  module Test
+    class XPackIndexLifecycleManagementPutPolicyTest < Minitest::Test
+
+      context "XPack Index Lifecycle Management: Put policy" do
+        subject { FakeClient.new }
+
+        should "perform correct request" do
+          subject.expects(:perform_request).with do |method, url, params, body|
+            assert_equal 'PUT', method
+            assert_equal '_ilm/policy/foo', url
+            assert_equal Hash.new, params
+            assert_equal Hash.new, body
+            true
+          end.returns(FakeResponse.new)
+
+          subject.xpack.ilm.put_policy :policy_id => 'foo', :body => {}
+        end
+
+      end
+
+    end
+  end
+end

--- a/elasticsearch-xpack/test/unit/index_lifecycle_management/remove_policy_test.rb
+++ b/elasticsearch-xpack/test/unit/index_lifecycle_management/remove_policy_test.rb
@@ -1,0 +1,30 @@
+# Licensed to Elasticsearch B.V under one or more agreements.
+# Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+# See the LICENSE file in the project root for more information
+
+require 'test_helper'
+
+module Elasticsearch
+  module Test
+    class XPackIndexLifecycleManagementRemovePolicyTest < Minitest::Test
+
+      context "XPack Index Lifecycle Management: Remove policy" do
+        subject { FakeClient.new }
+
+        should "perform correct request" do
+          subject.expects(:perform_request).with do |method, url, params, body|
+            assert_equal 'POST', method
+            assert_equal 'foo/_ilm/remove', url
+            assert_equal Hash.new, params
+            assert_nil   body
+            true
+          end.returns(FakeResponse.new)
+
+          subject.xpack.ilm.remove_policy :index => 'foo'
+        end
+
+      end
+
+    end
+  end
+end

--- a/elasticsearch-xpack/test/unit/index_lifecycle_management/retry_policy_test.rb
+++ b/elasticsearch-xpack/test/unit/index_lifecycle_management/retry_policy_test.rb
@@ -1,0 +1,30 @@
+# Licensed to Elasticsearch B.V under one or more agreements.
+# Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+# See the LICENSE file in the project root for more information
+
+require 'test_helper'
+
+module Elasticsearch
+  module Test
+    class XPackIndexLifecycleManagementRetryTest < Minitest::Test
+
+      context "XPack Index Lifecycle Management: retry" do
+        subject { FakeClient.new }
+
+        should "perform correct request" do
+          subject.expects(:perform_request).with do |method, url, params, body|
+            assert_equal 'POST', method
+            assert_equal 'foo/_ilm/retry', url
+            assert_equal Hash.new, params
+            assert_equal nil, body
+            true
+          end.returns(FakeResponse.new)
+
+          subject.xpack.ilm.retry_policy :index => 'foo'
+        end
+
+      end
+
+    end
+  end
+end

--- a/elasticsearch-xpack/test/unit/index_lifecycle_management/start_test.rb
+++ b/elasticsearch-xpack/test/unit/index_lifecycle_management/start_test.rb
@@ -1,0 +1,30 @@
+# Licensed to Elasticsearch B.V under one or more agreements.
+# Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+# See the LICENSE file in the project root for more information
+
+require 'test_helper'
+
+module Elasticsearch
+  module Test
+    class XPackIndexLifecycleManagementStartTest < Minitest::Test
+
+      context "XPack Index Lifecycle Management: start" do
+        subject { FakeClient.new }
+
+        should "perform correct request" do
+          subject.expects(:perform_request).with do |method, url, params, body|
+            assert_equal 'POST', method
+            assert_equal '_ilm/start', url
+            assert_equal Hash.new, params
+            assert_nil   body
+            true
+          end.returns(FakeResponse.new)
+
+          subject.xpack.ilm.start
+        end
+
+      end
+
+    end
+  end
+end

--- a/elasticsearch-xpack/test/unit/index_lifecycle_management/stop_test.rb
+++ b/elasticsearch-xpack/test/unit/index_lifecycle_management/stop_test.rb
@@ -1,0 +1,30 @@
+# Licensed to Elasticsearch B.V under one or more agreements.
+# Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+# See the LICENSE file in the project root for more information
+
+require 'test_helper'
+
+module Elasticsearch
+  module Test
+    class XPackIndexLifecycleManagementStopTest < Minitest::Test
+
+      context "XPack Index Lifecycle Management: stop" do
+        subject { FakeClient.new }
+
+        should "perform correct request" do
+          subject.expects(:perform_request).with do |method, url, params, body|
+            assert_equal 'POST', method
+            assert_equal '_ilm/stop', url
+            assert_equal Hash.new, params
+            assert_nil   body
+            true
+          end.returns(FakeResponse.new)
+
+          subject.xpack.ilm.stop
+        end
+
+      end
+
+    end
+  end
+end


### PR DESCRIPTION
Fixes #728.

Without this patch, elasticsearch-ruby client users cannot use ILM API via elasticsearch-xpack.