### PR TITLE
add track_total_hits option to DSL Options

### DIFF
--- a/elasticsearch-dsl/lib/elasticsearch/dsl/search/options.rb
+++ b/elasticsearch-dsl/lib/elasticsearch/dsl/search/options.rb
@@ -21,7 +21,8 @@ module Elasticsearch
           :version,
           :indices_boost,
           :track_scores,
-          :min_score
+          :min_score,
+          :track_total_hits
         ]
 
         def initialize(*args, &block)

--- a/elasticsearch-dsl/test/unit/search_options_test.rb
+++ b/elasticsearch-dsl/test/unit/search_options_test.rb
@@ -64,6 +64,14 @@ module Elasticsearch
           assert_equal( { version: true }, subject.to_hash )
         end
 
+        should "encode track_total_hits" do
+          subject.track_total_hits 123
+          assert_equal( { track_total_hits: 123 }, subject.to_hash )
+
+          subject.track_total_hits true
+          assert_equal( { track_total_hits: true }, subject.to_hash )
+        end
+
         should "encode indices_boost" do
           subject.indices_boost foo: 'bar'
           assert_equal( { indices_boost: { foo: 'bar' } }, subject.to_hash )


### PR DESCRIPTION
adds track_total_hits as option for the DSL

hopefully fixes #715 
