### PR TITLE
add auto_generate_synonyms_phrase_query

### DIFF
--- a/elasticsearch-dsl/lib/elasticsearch/dsl/search/queries/query_string.rb
+++ b/elasticsearch-dsl/lib/elasticsearch/dsl/search/queries/query_string.rb
@@ -42,6 +42,7 @@ module Elasticsearch
           option_method :boost
           option_method :analyze_wildcard
           option_method :auto_generate_phrase_queries
+          option_method :auto_generate_synonyms_phrase_query
           option_method :minimum_should_match
           option_method :lenient
           option_method :locale

--- a/elasticsearch-dsl/spec/elasticsearch/dsl/search/queries/query_string_spec.rb
+++ b/elasticsearch-dsl/spec/elasticsearch/dsl/search/queries/query_string_spec.rb
@@ -38,6 +38,7 @@ describe Elasticsearch::DSL::Search::Queries::QueryString do
       'boost',
       'analyze_wildcard',
       'auto_generate_phrase_queries',
+      'auto_generate_synonyms_phrase_query',
       'minimum_should_match',
       'lenient',
       'locale',


### PR DESCRIPTION
I haven't run this in production yet but i assume it works.

Btw i couldn't find `auto_generate_phrase_queries` in the documentation - is it maybe outdated syntax?
