### PR TITLE
Fix update_by_query_rethrottle to accept the task_id required argument

### DIFF
--- a/elasticsearch-api/lib/elasticsearch/api/actions/update_by_query_rethrottle.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/update_by_query_rethrottle.rb
@@ -14,9 +14,10 @@ module Elasticsearch
       # @see https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-update-by-query.html
       #
       def update_by_query_rethrottle(arguments={})
-        raise ArgumentError, "Required argument 'task_id' missing" unless arguments[:task_id]
+        task_id = arguments.delete(:task_id)
+        raise ArgumentError, "Required argument 'task_id' missing" unless task_id
         method = Elasticsearch::API::HTTP_POST
-        path   = "_update_by_query/#{arguments[:task_id]}/_rethrottle"
+        path   = "_update_by_query/#{task_id}/_rethrottle"
         params = Elasticsearch::API::Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
         body   = nil
 
@@ -27,6 +28,7 @@ module Elasticsearch
       #
       # @since 6.2.0
       ParamsRegistry.register(:update_by_query_rethrottle, [
+          :task_id,
           :requests_per_second ].freeze)
     end
   end

--- a/elasticsearch-api/spec/elasticsearch/api/actions/update_by_query_rethrottle_spec.rb
+++ b/elasticsearch-api/spec/elasticsearch/api/actions/update_by_query_rethrottle_spec.rb
@@ -1,0 +1,28 @@
+# Licensed to Elasticsearch B.V under one or more agreements.
+# Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+# See the LICENSE file in the project root for more information
+
+require 'spec_helper'
+
+describe 'client#update_by_query_rethrottle' do
+
+  let(:task_id) { "abcd:1234" }
+
+  let(:requests_per_second) { 1000 }
+
+  let(:expected_args) do
+    [
+        'POST',
+        "_update_by_query/#{task_id}/_rethrottle",
+        { requests_per_second: requests_per_second },
+        nil
+    ]
+  end
+
+  it 'performs the request' do
+    expect(client_double.update_by_query_rethrottle(
+      task_id: task_id,
+      requests_per_second: requests_per_second
+    )).to eq({})
+  end
+end


### PR DESCRIPTION
Calling `update_by_query_rethrottle` throws the following. The reason is that while `task_id` is a required argument it is not whitelisted with the `ParamsRegistry.register`.
This PR fixes this by whitelisting `task_id` and making sure it is not propagated further on as a param to `perform_request`

```
/home/inokentii.mykhailov/.gem/ruby/2.4/gems/elasticsearch-api-7.4.0/lib/elasticsearch/api/utils.rb:158:in `block in __validate_params': URL parameter 'task_id' is not supported (ArgumentError)
	from /home/inokentii.mykhailov/.gem/ruby/2.4/gems/elasticsearch-api-7.4.0/lib/elasticsearch/api/utils.rb:157:in `each'
	from /home/inokentii.mykhailov/.gem/ruby/2.4/gems/elasticsearch-api-7.4.0/lib/elasticsearch/api/utils.rb:157:in `__validate_params'
	from /home/inokentii.mykhailov/.gem/ruby/2.4/gems/elasticsearch-api-7.4.0/lib/elasticsearch/api/utils.rb:151:in `__validate_and_extract_params'
	from /home/inokentii.mykhailov/.gem/ruby/2.4/gems/elasticsearch-api-7.4.0/lib/elasticsearch/api/actions/update_by_query_rethrottle.rb:20:in `update_by_query_rethrottle'
	from cli.rb:73:in `rethrottle'
	from cli.rb:166:in `<main>'
```