### PR TITLE
Adds _cat/health doc example

### DIFF
--- a/docs/doc_examples/f8cc4b331a19ff4df8e4a490f906ee69.asciidoc
+++ b/docs/doc_examples/f8cc4b331a19ff4df8e4a490f906ee69.asciidoc
@@ -1,0 +1,4 @@
+[source, ruby]
+----
+client.cat.health(v: true)
+----


### PR DESCRIPTION
Adds `_cat/health` doc for Client examples in Elasticsearch documentation.