### PR TITLE
Adds doc examples

### DIFF
--- a/examples/docs/asciidoc/231aa0bb39c35fe199d28fe0e4a62b2e.asciidoc
+++ b/examples/docs/asciidoc/231aa0bb39c35fe199d28fe0e4a62b2e.asciidoc
@@ -1,0 +1,11 @@
+[source, ruby]
+----
+client.search(
+  index: 'bank',
+  body: {
+    query: {
+      match_phrase: { address: "mill lane" }
+    }
+  }
+)
+----

--- a/examples/docs/asciidoc/251ea12c1248385ab409906ac64d9ee9.asciidoc
+++ b/examples/docs/asciidoc/251ea12c1248385ab409906ac64d9ee9.asciidoc
@@ -1,0 +1,21 @@
+[source, ruby]
+----
+client.search(
+  index: 'bank',
+  body: {
+    query: {
+      bool: {
+        must: { match_all: {} },
+        filter: {
+          range: {
+            balance: {
+              gte: 20000,
+              lte: 30000
+            }
+          }
+        }
+      }
+    }
+  }
+)
+----

--- a/examples/docs/asciidoc/311c4b632a29b9ead63b02d01f10096b.asciidoc
+++ b/examples/docs/asciidoc/311c4b632a29b9ead63b02d01f10096b.asciidoc
@@ -1,0 +1,4 @@
+[source, ruby]
+----
+client.index(index: 'customer', id: '1', body: {name: 'John Doe'})
+----

--- a/examples/docs/asciidoc/3f3b3e207f79303ce6f86e03e928e062.asciidoc
+++ b/examples/docs/asciidoc/3f3b3e207f79303ce6f86e03e928e062.asciidoc
@@ -1,0 +1,4 @@
+[source, ruby]
+----
+client.get(index: 'customer', id: '1')
+----

--- a/examples/docs/asciidoc/47bb632c6091ad0cd94bc660bdd309a5.asciidoc
+++ b/examples/docs/asciidoc/47bb632c6091ad0cd94bc660bdd309a5.asciidoc
@@ -1,0 +1,18 @@
+[source, ruby]
+----
+client.search(
+  index: 'bank',
+  body: {
+    query: {
+      bool: {
+        must: [
+          { match: { age: "40" } }
+        ],
+        must_not: [
+          { match: { state: "ID" } }
+        ]
+      }
+    }
+  }
+)
+----

--- a/examples/docs/asciidoc/4b90feb9d5d3dbfce424dac0341320b7.asciidoc
+++ b/examples/docs/asciidoc/4b90feb9d5d3dbfce424dac0341320b7.asciidoc
@@ -1,0 +1,12 @@
+[source, ruby]
+----
+client.search(
+  index: 'bank',
+  body: {
+    query: { match_all: {} },
+    sort: { account_number: 'asc' },
+    from: 10,
+    size: 10
+  }
+)
+----

--- a/examples/docs/asciidoc/506844befdc5691d835771bcbb1c1a60.asciidoc
+++ b/examples/docs/asciidoc/506844befdc5691d835771bcbb1c1a60.asciidoc
@@ -1,0 +1,10 @@
+[source, ruby]
+----
+client.search(
+  index: 'bank',
+  body: {
+    query: { match_all: {} },
+    sort: { account_number: 'asc' }
+  }
+)
+----

--- a/examples/docs/asciidoc/645796e8047967ca4a7635a22a876f4c.asciidoc
+++ b/examples/docs/asciidoc/645796e8047967ca4a7635a22a876f4c.asciidoc
@@ -1,0 +1,24 @@
+[source, ruby]
+----
+client.search(
+  index: 'bank',
+  size: 0,
+  body: {
+    aggregations: {
+      group_by_state: {
+        terms: {
+          field: "state.keyword",
+          order: {
+            average_balance: "desc"
+          }
+        },
+        aggregations: {
+          average_balance: {
+            avg: { field: "balance" }
+          }
+        }
+      }
+    }
+  }
+)
+----

--- a/examples/docs/asciidoc/cd247f267968aa0927bfdad56852f8f5.asciidoc
+++ b/examples/docs/asciidoc/cd247f267968aa0927bfdad56852f8f5.asciidoc
@@ -1,0 +1,11 @@
+[source, ruby]
+----
+client.search(
+  index: 'bank',
+  body: {
+    query: {
+      match: { address: "mill lane" }
+    }
+  }
+)
+----

--- a/examples/docs/asciidoc/cfbaea6f0df045c5d940bbb6a9c69cd8.asciidoc
+++ b/examples/docs/asciidoc/cfbaea6f0df045c5d940bbb6a9c69cd8.asciidoc
@@ -1,0 +1,19 @@
+[source, ruby]
+----
+client.search(
+  index: 'bank',
+  size: 0,
+  body: {
+    aggregations: {
+      group_by_state: {
+        terms: { field: "state.keyword" },
+        aggregations: {
+          average_balance: {
+            avg: { field: "balance" }
+          }
+        }
+      }
+    }
+  }
+)
+----

--- a/examples/docs/asciidoc/feefeb68144002fd1fff57b77b95b85e.asciidoc
+++ b/examples/docs/asciidoc/feefeb68144002fd1fff57b77b95b85e.asciidoc
@@ -1,0 +1,14 @@
+[source, ruby]
+----
+client.search(
+  index: 'bank',
+  size: 0,
+  body: {
+    aggregations: {
+      group_by_state: {
+        terms: { field: "state.keyword" }
+      }
+    }
+  }
+)
+----


### PR DESCRIPTION
This Pull Request adds Ruby code examples for:
- [Index some documents](https://www.elastic.co/guide/en/elasticsearch/reference/master/getting-started-index.html)
- [Start searching](https://www.elastic.co/guide/en/elasticsearch/reference/master/getting-started-search.html)
- [Analyze results with aggregations](https://www.elastic.co/guide/en/elasticsearch/reference/master/getting-started-aggregations.html)

I've split it into different commits to make it easier to review.