### PR TITLE
Set upper limit of elasticsearch-transport faraday dependency to "< 1"

### DIFF
--- a/elasticsearch-transport/elasticsearch-transport.gemspec
+++ b/elasticsearch-transport/elasticsearch-transport.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |s|
   s.required_ruby_version = '>= 1.9'
 
   s.add_dependency "multi_json"
-  s.add_dependency "faraday", '>= 0.14', "< 2"
+  s.add_dependency "faraday", '>= 0.14', "< 1"
 
   if defined?(RUBY_VERSION) && RUBY_VERSION < '1.9'
     s.add_dependency "system_timer"


### PR DESCRIPTION
Faraday recently released 1.0, and elasticsearch-transport was on 0.xx. Breaking changes in 1.0 plus the gemspec allowing the update to 1.x can cause unclear problems.

Related issue: #751