### PR TITLE
[CI] Update Ruby versions

### DIFF
--- a/.ci/test-matrix.yml
+++ b/.ci/test-matrix.yml
@@ -3,9 +3,9 @@ ELASTICSEARCH_VERSION:
 - 8.0.0-SNAPSHOT
 
 RUBY_TEST_VERSION:
+- 2.7.0
 - 2.6.5
 - 2.5.7
-- 2.4.9
 
 TEST_SUITE:
 - rest_api

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,15 +30,15 @@ matrix:
       jdk: oraclejdk8
       env: TEST_SUITE=unit
 
+    - rvm: 2.7.0
+      jdk: oraclejdk8
+      env: TEST_SUITE=unit
+
     - rvm: 2.6.5
       jdk: oraclejdk8
       env: TEST_SUITE=unit
 
     - rvm: 2.5.7
-      jdk: oraclejdk8
-      env: TEST_SUITE=unit
-
-    - rvm: 2.4.9
       jdk: oraclejdk8
       env: TEST_SUITE=unit
 


### PR DESCRIPTION
Drops Ruby 2.4 in `master`, it will only be maintained until March 2020.
Adds 2.7 to CI build.