### PR TITLE
[API] Generator: Refactor to generate both X-Pack and OSS code by def…

### DIFF
--- a/elasticsearch-api/utils/thor/generator/files_helper.rb
+++ b/elasticsearch-api/utils/thor/generator/files_helper.rb
@@ -10,8 +10,8 @@ module Elasticsearch
       XPACK_OUTPUT_DIR = '../../elasticsearch-xpack/lib/elasticsearch/xpack/api/actions'.freeze
 
       # Path to directory with JSON API specs
-      def self.input_dir(xpack = false)
-        input_dir = if xpack
+      def self.input_dir(api)
+        input_dir = if api == :xpack
                       File.expand_path(XPACK_SRC_PATH, __FILE__)
                     else
                       File.expand_path(OSS_SRC_PATH, __FILE__)
@@ -20,13 +20,13 @@ module Elasticsearch
       end
 
       # Path to directory to copy generated files
-      def self.output_dir(xpack = false)
-        xpack ? Pathname(XPACK_OUTPUT_DIR) : Pathname(OSS_OUTPUT_DIR)
+      def self.output_dir(api)
+        api == :xpack ? Pathname(XPACK_OUTPUT_DIR) : Pathname(OSS_OUTPUT_DIR)
       end
 
       # Only get JSON files and remove hidden files
-      def self.files(xpack = false)
-        Dir.entries(input_dir(xpack).to_s).reject do |f|
+      def self.files(api)
+        Dir.entries(input_dir(api).to_s).reject do |f|
           f.start_with?('.') ||
             f.start_with?('_') ||
             File.extname(f) != '.json'


### PR DESCRIPTION
Refactor The Generator to generate both X-Pack and OSS code by default

**Usage:**
```
thor api:code:generate
```
Will generate code for both Open Source and X-Pack.

```
thor api:code:generate --api='xpack'
```
Will generate only X-Pack code.

```
thor api:code:generate --api='oss'
```
Will generate only the Open Source code.