### PR TITLE
Support ApiKey

### DIFF
--- a/elasticsearch-transport/README.md
+++ b/elasticsearch-transport/README.md
@@ -144,6 +144,26 @@ use the `transport_options` option:
     Elasticsearch::Client.new url: 'https://username:password@example.com:9200',
                               transport_options: { ssl: { ca_file: '/path/to/cacert.pem' } }
 
+You can also use [**API Key authentication**](https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-create-api-key.html):
+
+``` ruby
+Elasticsearch::Client.new(
+  host: host,
+  transport_options: transport_options,
+  api_key: credentials
+)
+```
+
+Where credentials is either the base64 encoding of `id` and `api_key` joined by a colon or a hash with the `id` and `api_key`:
+
+``` ruby
+Elasticsearch::Client.new(
+  host: host,
+  transport_options: transport_options,
+  api_key: {id: 'my_id', api_key: 'my_api_key'}
+)
+```
+
 ### Logging
 
 To log requests and responses to standard output with the default logger (an instance of Ruby's {::Logger} class),

--- a/elasticsearch-transport/lib/elasticsearch/transport/client.rb
+++ b/elasticsearch-transport/lib/elasticsearch/transport/client.rb
@@ -99,6 +99,9 @@ module Elasticsearch
       #   The default is false. Responses will automatically be inflated if they are compressed.
       #   If a custom transport object is used, it must handle the request compression and response inflation.
       #
+      # @option api_key [String, Hash] :api_key Use API Key Authentication, either the base64 encoding of `id` and `api_key`
+      #                                         joined by a colon as a String, or a hash with the `id` and `api_key` values.
+      #
       # @yield [faraday] Access and configure the `Faraday::Connection` instance directly with a block
       #
       def initialize(arguments={}, &block)

--- a/elasticsearch-transport/lib/elasticsearch/transport/client.rb
+++ b/elasticsearch-transport/lib/elasticsearch/transport/client.rb
@@ -124,6 +124,13 @@ module Elasticsearch
 
         @send_get_body_as = @arguments[:send_get_body_as] || 'GET'
 
+        if (api_key = @arguments[:api_key])
+          api_key = __encode(api_key) if api_key.is_a? Hash
+          @arguments[:transport_options].merge!(
+            headers: { 'Authorization' => "ApiKey #{api_key}" }
+          )
+        end
+
         if @arguments[:request_timeout]
           @arguments[:transport_options][:request] = { :timeout => @arguments[:request_timeout] }
         end
@@ -254,6 +261,13 @@ module Elasticsearch
         else
           ::Faraday.default_adapter
         end
+      end
+
+      # Encode credentials for the Authorization Header
+      # Credentials is the base64 encoding of id and api_key joined by a colon
+      # @see https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-create-api-key.html
+      def __encode(api_key)
+        Base64.encode64([api_key[:id], api_key[:api_key]].join(':'))
       end
     end
   end

--- a/elasticsearch-transport/lib/elasticsearch/transport/client.rb
+++ b/elasticsearch-transport/lib/elasticsearch/transport/client.rb
@@ -114,6 +114,15 @@ module Elasticsearch
         @arguments[:http]               ||= {}
         @options[:http]                 ||= {}
 
+        if (@api_key = @arguments[:api_key])
+          @api_key = __encode(@api_key) if @api_key.is_a? Hash
+          @arguments[:transport_options].merge!(
+            headers: { 'Authorization' => "ApiKey #{@api_key}" }
+          )
+          @arguments.delete(:user)
+          @arguments.delete(:password)
+        end
+
         @seeds = extract_cloud_creds(@arguments)
         @seeds ||= __extract_hosts(@arguments[:hosts] ||
                                      @arguments[:host] ||
@@ -123,13 +132,6 @@ module Elasticsearch
                                      DEFAULT_HOST)
 
         @send_get_body_as = @arguments[:send_get_body_as] || 'GET'
-
-        if (api_key = @arguments[:api_key])
-          api_key = __encode(api_key) if api_key.is_a? Hash
-          @arguments[:transport_options].merge!(
-            headers: { 'Authorization' => "ApiKey #{api_key}" }
-          )
-        end
 
         if @arguments[:request_timeout]
           @arguments[:transport_options][:request] = { :timeout => @arguments[:request_timeout] }
@@ -232,8 +234,14 @@ module Elasticsearch
           raise ArgumentError, "Please pass host as a String, URI or Hash -- #{host.class} given."
         end
 
-        @options[:http][:user] ||= host_parts[:user]
-        @options[:http][:password] ||= host_parts[:password]
+        if @api_key
+          # Remove Basic Auth if using API KEY
+          host_parts.delete(:user)
+          host_parts.delete(:password)
+        else
+          @options[:http][:user] ||= host_parts[:user]
+          @options[:http][:password] ||= host_parts[:password]
+        end
 
         host_parts[:port] = host_parts[:port].to_i if host_parts[:port]
         host_parts[:path].chomp!('/') if host_parts[:path]

--- a/elasticsearch-transport/lib/elasticsearch/transport/client.rb
+++ b/elasticsearch-transport/lib/elasticsearch/transport/client.rb
@@ -267,7 +267,7 @@ module Elasticsearch
       # Credentials is the base64 encoding of id and api_key joined by a colon
       # @see https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-create-api-key.html
       def __encode(api_key)
-        Base64.encode64([api_key[:id], api_key[:api_key]].join(':'))
+        Base64.strict_encode64([api_key[:id], api_key[:api_key]].join(':'))
       end
     end
   end

--- a/elasticsearch-transport/spec/elasticsearch/transport/client_spec.rb
+++ b/elasticsearch-transport/spec/elasticsearch/transport/client_spec.rb
@@ -62,21 +62,42 @@ describe Elasticsearch::Transport::Client do
     let(:client) do
       described_class.new(api_key: 'an_api_key')
     end
+    let(:authorization_header) do
+      client.transport.connections.first.connection.headers['Authorization']
+    end
 
     it 'Adds the ApiKey header to the connection' do
-      expect(client.transport.connections.first.connection.headers['Authorization']).to eq('ApiKey an_api_key')
+      expect(authorization_header).to eq('ApiKey an_api_key')
     end
   end
 
   context 'when an un-encoded api_key is provided' do
     let(:client) do
-      described_class.new(api_key: {id: 'my_id', api_key: 'my_api_key'})
+      described_class.new(api_key: { id: 'my_id', api_key: 'my_api_key' })
+    end
+    let(:authorization_header) do
+      client.transport.connections.first.connection.headers['Authorization']
     end
 
     it 'Adds the ApiKey header to the connection' do
-      expect(
-        client.transport.connections.first.connection.headers['Authorization']
-      ).to eq("ApiKey #{Base64.strict_encode64('my_id:my_api_key')}")
+      expect(authorization_header).to eq("ApiKey #{Base64.strict_encode64('my_id:my_api_key')}")
+    end
+  end
+
+  context 'when basic auth and api_key are provided' do
+    let(:client) do
+      described_class.new(
+        api_key: { id: 'my_id', api_key: 'my_api_key' },
+        host: 'http://elastic:password@localhost:9200'
+      )
+    end
+    let(:authorization_header) do
+      client.transport.connections.first.connection.headers['Authorization']
+    end
+
+    it 'removes basic auth credentials' do
+      expect(authorization_header).not_to match(/^Basic/)
+      expect(authorization_header).to match(/^ApiKey/)
     end
   end
 
@@ -197,9 +218,7 @@ describe Elasticsearch::Transport::Client do
   end
 
   describe 'adapter' do
-
     context 'when no adapter is specified' do
-
       let(:adapter) do
         client.transport.connections.all.first.connection.builder.handlers
       end

--- a/elasticsearch-transport/spec/elasticsearch/transport/client_spec.rb
+++ b/elasticsearch-transport/spec/elasticsearch/transport/client_spec.rb
@@ -76,7 +76,7 @@ describe Elasticsearch::Transport::Client do
     it 'Adds the ApiKey header to the connection' do
       expect(
         client.transport.connections.first.connection.headers['Authorization']
-      ).to eq("ApiKey #{Base64.encode64('my_id:my_api_key')}")
+      ).to eq("ApiKey #{Base64.strict_encode64('my_id:my_api_key')}")
     end
   end
 

--- a/elasticsearch-transport/spec/elasticsearch/transport/client_spec.rb
+++ b/elasticsearch-transport/spec/elasticsearch/transport/client_spec.rb
@@ -49,13 +49,34 @@ describe Elasticsearch::Transport::Client do
   end
 
   context 'when a User-Agent header is specified as client option' do
-
     let(:client) do
       described_class.new(transport_options: { headers: { 'User-Agent' => 'testing' } })
     end
 
     it 'sets the specified User-Agent header' do
       expect(client.transport.connections.first.connection.headers['User-Agent']).to eq('testing')
+    end
+  end
+
+  context 'when an encoded api_key is provided' do
+    let(:client) do
+      described_class.new(api_key: 'an_api_key')
+    end
+
+    it 'Adds the ApiKey header to the connection' do
+      expect(client.transport.connections.first.connection.headers['Authorization']).to eq('ApiKey an_api_key')
+    end
+  end
+
+  context 'when an un-encoded api_key is provided' do
+    let(:client) do
+      described_class.new(api_key: {id: 'my_id', api_key: 'my_api_key'})
+    end
+
+    it 'Adds the ApiKey header to the connection' do
+      expect(
+        client.transport.connections.first.connection.headers['Authorization']
+      ).to eq("ApiKey #{Base64.encode64('my_id:my_api_key')}")
     end
   end
 


### PR DESCRIPTION
Support API Key authentication.

**TO-DO/Notes**:
- I implemented the js client's hybrid solution (accepts `apiKey: 'base64ApiKey'` or `apiKey: {id: 'foo', api_key: 'bar'}`
- [x] Check precedence over Basic Auth. ~~Initially I think we delegate this to the underlying http libraries, but to avoid conflict might need to be explicit~~
- [x] Test with the other http implementations
- [x] Add instructions to README
- [x] Backport to `master` (#789) and `6.x` (#785)