### PR TITLE
Support for X-Opaque-Id

### DIFF
--- a/elasticsearch-api/lib/elasticsearch/api.rb
+++ b/elasticsearch-api/lib/elasticsearch/api.rb
@@ -32,7 +32,8 @@ module Elasticsearch
       :format,                        # Search, Cat, ...
       :pretty,                        # Pretty-print the response
       :human,                         # Return numeric values in human readable format
-      :filter_path                    # Filter the JSON response
+      :filter_path,                   # Filter the JSON response
+      :opaque_id                      # Use X-Opaque-Id
     ]
 
     HTTP_GET          = 'GET'.freeze

--- a/elasticsearch-transport/README.md
+++ b/elasticsearch-transport/README.md
@@ -211,25 +211,21 @@ You can pass the client any conforming logger implementation:
     client = Elasticsearch::Client.new logger: log
 ### Identifying running tasks with X-Opaque-Id
 
-The X-Opaque-Id header allows to track certain calls, or associate certain tasks with the client that started them ([more on the Elasticsearch docs](https://www.elastic.co/guide/en/elasticsearch/reference/master/tasks.html#_identifying_running_tasks)). To use this feature, you need to set an id for `opaque_id` on the client before each request. Example:
+The X-Opaque-Id header allows to track certain calls, or associate certain tasks with the client that started them ([more on the Elasticsearch docs](https://www.elastic.co/guide/en/elasticsearch/reference/master/tasks.html#_identifying_running_tasks)). To use this feature, you need to set an id for `opaque_id` on the client on each request. Example:
 
 ```ruby
 client = Elasticsearch::Client.new
-client.opaque_id = '123456'
-client.search(index: 'myindex', q: 'title:test')
+client.search(index: 'myindex', q: 'title:test', opaque_id: '123456')
 ```
 The search request will include the following HTTP Header:
 ```
 X-Opaque-Id: 123456
 ```
 
-Please note that `opaque_id` will be set to nil after every request, so you need to set it on the client for every individual request.
-
 You can also set a prefix for X-Opaque-Id when initializing the client. This will be prepended to the id you set before each request if you're using X-Opaque-Id. Example:
 ```ruby
 client = Elasticsearch::Client.new(opaque_id_prefix: 'eu-west1')
-client.opaque_id = '123456'
-client.search(index: 'myindex', q: 'title:test')
+client.search(index: 'myindex', q: 'title:test', opaque_id: '123456')
 ```
 The request will include the following HTTP Header:
 ```

--- a/elasticsearch-transport/README.md
+++ b/elasticsearch-transport/README.md
@@ -74,6 +74,7 @@ Full documentation is available at <http://rubydoc.info/gems/elasticsearch-trans
 * [Connect using an Elastic Cloud ID](#connect-using-an-elastic-cloud-id)
 * [Authentication](#authentication)
 * [Logging](#logging)
+* [Identifying running tasks with X-Opaque-Id](#identifying-running-tasks-with-x-opaque-id)
 * [Setting Timeouts](#setting-timeouts)
 * [Randomizing Hosts](#randomizing-hosts)
 * [Retrying on Failures](#retrying-on-failures)
@@ -208,6 +209,32 @@ You can pass the client any conforming logger implementation:
     log.level = :info
 
     client = Elasticsearch::Client.new logger: log
+### Identifying running tasks with X-Opaque-Id
+
+The X-Opaque-Id header allows to track certain calls, or associate certain tasks with the client that started them ([more on the Elasticsearch docs](https://www.elastic.co/guide/en/elasticsearch/reference/master/tasks.html#_identifying_running_tasks)). To use this feature, you need to set an id for `opaque_id` on the client before each request. Example:
+
+```ruby
+client = Elasticsearch::Client.new
+client.opaque_id = '123456'
+client.search(index: 'myindex', q: 'title:test')
+```
+The search request will include the following HTTP Header:
+```
+X-Opaque-Id: 123456
+```
+
+Please note that `opaque_id` will be set to nil after every request, so you need to set it on the client for every individual request.
+
+You can also set a prefix for X-Opaque-Id when initializing the client. This will be prepended to the id you set before each request if you're using X-Opaque-Id. Example:
+```ruby
+client = Elasticsearch::Client.new(opaque_id_prefix: 'eu-west1')
+client.opaque_id = '123456'
+client.search(index: 'myindex', q: 'title:test')
+```
+The request will include the following HTTP Header:
+```
+X-Opaque-Id: eu-west1_123456
+```
 
 ### Setting Timeouts
 

--- a/elasticsearch-transport/lib/elasticsearch/transport/client.rb
+++ b/elasticsearch-transport/lib/elasticsearch/transport/client.rb
@@ -157,16 +157,13 @@ module Elasticsearch
       #
       def perform_request(method, path, params = {}, body = nil, headers = nil)
         method = @send_get_body_as if 'GET' == method && body
-        if @opaque_id
+        if (opaque_id = params.delete(:opaque_id))
           headers = {} if headers.nil?
-          opaque_id = @opaque_id_prefix ? "#{@opaque_id_prefix}#{@opaque_id}" : @opaque_id
+          opaque_id = @opaque_id_prefix ? "#{@opaque_id_prefix}#{opaque_id}" : opaque_id
           headers.merge!('X-Opaque-Id' => opaque_id)
-          @opaque_id = nil # Remove Opaque id after each request
         end
         transport.perform_request(method, path, params, body, headers)
       end
-
-      attr_accessor :opaque_id
 
       private
 

--- a/elasticsearch-transport/lib/elasticsearch/transport/client.rb
+++ b/elasticsearch-transport/lib/elasticsearch/transport/client.rb
@@ -154,8 +154,15 @@ module Elasticsearch
       #
       def perform_request(method, path, params = {}, body = nil, headers = nil)
         method = @send_get_body_as if 'GET' == method && body
+        if @opaque_id
+          headers = {} if headers.nil?
+          headers.merge!('X-Opaque-Id' => @opaque_id)
+          @opaque_id = nil # Remove Opaque id after each request
+        end
         transport.perform_request(method, path, params, body, headers)
       end
+
+      attr_accessor :opaque_id
 
       private
 

--- a/elasticsearch-transport/lib/elasticsearch/transport/client.rb
+++ b/elasticsearch-transport/lib/elasticsearch/transport/client.rb
@@ -101,6 +101,8 @@ module Elasticsearch
       #
       # @option api_key [String, Hash] :api_key Use API Key Authentication, either the base64 encoding of `id` and `api_key`
       #                                         joined by a colon as a String, or a hash with the `id` and `api_key` values.
+      # @option opaque_id_prefix [String] :opaque_id_prefix set a prefix for X-Opaque-Id when initializing the client. This
+      # will be prepended to the id you set before each request if you're using X-Opaque-Id
       #
       # @yield [faraday] Access and configure the `Faraday::Connection` instance directly with a block
       #
@@ -128,6 +130,7 @@ module Elasticsearch
                                      DEFAULT_HOST)
 
         @send_get_body_as = @arguments[:send_get_body_as] || 'GET'
+        @opaque_id_prefix = @arguments[:opaque_id_prefix] || nil
 
         if @arguments[:request_timeout]
           @arguments[:transport_options][:request] = { timeout: @arguments[:request_timeout] }
@@ -156,7 +159,8 @@ module Elasticsearch
         method = @send_get_body_as if 'GET' == method && body
         if @opaque_id
           headers = {} if headers.nil?
-          headers.merge!('X-Opaque-Id' => @opaque_id)
+          opaque_id = @opaque_id_prefix ? "#{@opaque_id_prefix}#{@opaque_id}" : @opaque_id
+          headers.merge!('X-Opaque-Id' => opaque_id)
           @opaque_id = nil # Remove Opaque id after each request
         end
         transport.perform_request(method, path, params, body, headers)

--- a/elasticsearch-transport/spec/elasticsearch/transport/client_spec.rb
+++ b/elasticsearch-transport/spec/elasticsearch/transport/client_spec.rb
@@ -1096,18 +1096,11 @@ describe Elasticsearch::Transport::Client do
       end
     end
 
-    context 'when x-opaque-id is set before calling a method' do
+    context 'when x-opaque-id is set' do
       let(:client) { described_class.new(host: hosts) }
 
       it 'uses x-opaque-id on a request' do
-        client.opaque_id = '12345'
-        expect(client.perform_request('GET', '/').headers['x-opaque-id']).to eq('12345')
-      end
-
-      it 'deletes x-opaque-id on a second request' do
-        client.opaque_id = 'asdfg'
-        expect(client.perform_request('GET', '/').headers['x-opaque-id']).to eq('asdfg')
-        expect(client.perform_request('GET', '/').headers).not_to include('x-opaque-id')
+        expect(client.perform_request('GET', '/', { opaque_id: '12345' }).headers['x-opaque-id']).to eq('12345')
       end
     end
 
@@ -1118,20 +1111,27 @@ describe Elasticsearch::Transport::Client do
       end
 
       it 'uses x-opaque-id on a request' do
-        client.opaque_id = '12345'
-        expect(client.perform_request('GET', '/').headers['x-opaque-id']).to eq("#{prefix}12345")
+        expect(client.perform_request('GET', '/', { opaque_id: '12345' }).headers['x-opaque-id']).to eq("#{prefix}12345")
       end
 
-      it 'deletes x-opaque-id on a second request' do
-        client.opaque_id = 'asdfg'
-        expect(client.perform_request('GET', '/').headers['x-opaque-id']).to eq("#{prefix}_asdfg")
-        expect(client.perform_request('GET', '/').headers).not_to include('x-opaque-id')
+      context 'when using an API call' do
+        let(:client) { described_class.new(host: hosts) }
+
+        it 'doesnae raise an ArgumentError' do
+          expect { client.search(opaque_id: 'no_error') }.not_to raise_error
+        end
+
+        it 'uses X-Opaque-Id in the header' do
+          allow(client).to receive(:perform_request) { OpenStruct.new(body: '') }
+          expect { client.search(opaque_id: 'opaque_id') }.not_to raise_error
+          expect(client).to have_received(:perform_request)
+            .with('GET', '_search', { opaque_id: 'opaque_id' }, nil)
+        end
       end
     end
   end
 
   context 'when the client connects to Elasticsearch' do
-
     let(:logger) do
       Logger.new(STDERR).tap do |logger|
         logger.formatter = proc do |severity, datetime, progname, msg|

--- a/elasticsearch-transport/spec/elasticsearch/transport/client_spec.rb
+++ b/elasticsearch-transport/spec/elasticsearch/transport/client_spec.rb
@@ -1110,6 +1110,24 @@ describe Elasticsearch::Transport::Client do
         expect(client.perform_request('GET', '/').headers).not_to include('x-opaque-id')
       end
     end
+
+    context 'when an x-opaque-id prefix is set on initialization' do
+      let(:prefix) { 'elastic_cloud' }
+      let(:client) do
+        described_class.new(host: hosts, opaque_id_prefix: prefix)
+      end
+
+      it 'uses x-opaque-id on a request' do
+        client.opaque_id = '12345'
+        expect(client.perform_request('GET', '/').headers['x-opaque-id']).to eq("#{prefix}12345")
+      end
+
+      it 'deletes x-opaque-id on a second request' do
+        client.opaque_id = 'asdfg'
+        expect(client.perform_request('GET', '/').headers['x-opaque-id']).to eq("#{prefix}_asdfg")
+        expect(client.perform_request('GET', '/').headers).not_to include('x-opaque-id')
+      end
+    end
   end
 
   context 'when the client connects to Elasticsearch' do

--- a/elasticsearch-transport/spec/elasticsearch/transport/client_spec.rb
+++ b/elasticsearch-transport/spec/elasticsearch/transport/client_spec.rb
@@ -1095,6 +1095,21 @@ describe Elasticsearch::Transport::Client do
         expect(request).to be(true)
       end
     end
+
+    context 'when x-opaque-id is set before calling a method' do
+      let(:client) { described_class.new(host: hosts) }
+
+      it 'uses x-opaque-id on a request' do
+        client.opaque_id = '12345'
+        expect(client.perform_request('GET', '/').headers['x-opaque-id']).to eq('12345')
+      end
+
+      it 'deletes x-opaque-id on a second request' do
+        client.opaque_id = 'asdfg'
+        expect(client.perform_request('GET', '/').headers['x-opaque-id']).to eq('asdfg')
+        expect(client.perform_request('GET', '/').headers).not_to include('x-opaque-id')
+      end
+    end
   end
 
   context 'when the client connects to Elasticsearch' do


### PR DESCRIPTION
This Pull Request adds support for [X-Opaque-Id](https://www.elastic.co/guide/en/elasticsearch/reference/master/tasks.html#_identifying_running_tasks).

Example usage:

```ruby
client = Elasticsearch::Client.new
client.search(index: 'myindex', q: 'title:test', opaque_id: 'searching')
```

I've also implemented the prefix for the initializer. You can pass it in when creating the client and it'll be prepended to whatever opaque id you set in your request:
```ruby
client = Elasticsearch::Client.new(opaque_id_prefix: 'eu-west1_')
client.search(index: 'myindex', q: 'title:test', opaque_id: 'searching')
```
The request will include the following HTTP Header:
```
X-Opaque-Id: eu-west1_searching
```