### PR TITLE
Update to Faraday 1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,9 +77,7 @@ Both of these libraries are extensively documented.
 and the [`elasticsearch-api`](http://rubydoc.info/gems/elasticsearch-api) documentation carefully.**
 
 _Keep in mind, that for optimal performance, you should use a HTTP library which supports persistent
-("keep-alive") connections, e.g. [Patron](https://github.com/toland/patron) or
-[Typhoeus](https://github.com/typhoeus/typhoeus)._ These libraries are not dependencies of the elasticsearch gems, so
-be sure to define a dependency in your own application.
+("keep-alive") connections, e.g. [Patron](https://github.com/toland/patron)._ These libraries are not dependencies of the elasticsearch gems, so be sure to define a dependency in your own application.
 
 This repository contains these additional Ruby libraries:
 

--- a/elasticsearch-api/Rakefile
+++ b/elasticsearch-api/Rakefile
@@ -69,7 +69,7 @@ namespace :test do
       es_version_info = client.info['version']
       build_hash      = es_version_info['build_hash']
       cluster_running = true
-    rescue Faraday::Error::ConnectionFailed
+    rescue Faraday::ConnectionFailed
       STDERR.puts "[!] Test cluster not running?"
       cluster_running = false
     end

--- a/elasticsearch-transport/README.md
+++ b/elasticsearch-transport/README.md
@@ -28,12 +28,16 @@ Features overview:
 * Node reloading (based on cluster state) on errors or on demand
 
 For optimal performance, use a HTTP library which supports persistent ("keep-alive") connections,
-such as [Typhoeus](https://github.com/typhoeus/typhoeus).
-Just require the library (`require 'typhoeus'; require 'typhoeus/adapters/faraday'`) in your code,
-and it will be automatically used; currently these libraries will be automatically detected and used:
-[Patron](https://github.com/toland/patron),
-[HTTPClient](https://rubygems.org/gems/httpclient) and
-[Net::HTTP::Persistent](https://rubygems.org/gems/net-http-persistent).
+such as [patron](https://github.com/toland/patron).
+Just require the library (`require 'patron'`) in your code,
+and it will be automatically used.
+
+Currently these libraries will be automatically detected and used:
+- [Patron](https://github.com/toland/patron)
+- [HTTPClient](https://rubygems.org/gems/httpclient)
+- [Net::HTTP::Persistent](https://rubygems.org/gems/net-http-persistent)
+
+**Note on [Typhoeus](https://github.com/typhoeus/typhoeus)**: Typhoeus is compatible and will be automatically detected too. However, the latest release (v1.3.1 at the moment of writing this) is not compatible with Faraday 1.0. [It still uses the deprecated `Faraday::Error` namespace](https://github.com/typhoeus/typhoeus/blob/v1.3.1/lib/typhoeus/adapters/faraday.rb#L100). If you want to use it with this gem, we suggest getting `master` from GitHub, since this has been fixed for v1.4.0. We'll update this if/when v1.4.0 is released.a
 
 For detailed information, see example configurations [below](#transport-implementations).
 
@@ -366,12 +370,11 @@ constructor, use the `transport_options` key:
 
 To configure the _Faraday_ instance directly, use a block:
 
-    require 'typhoeus'
-    require 'typhoeus/adapters/faraday'
+    require 'patron'
 
     client = Elasticsearch::Client.new(host: 'localhost', port: '9200') do |f|
       f.response :logger
-      f.adapter  :typhoeus
+      f.adapter  :patron
     end
 
 You can use any standard Faraday middleware and plugins in the configuration block, for example sign the requests for the [AWS Elasticsearch service](https://aws.amazon.com/elasticsearch-service/). See [the AWS documentation](https://docs.aws.amazon.com/elasticsearch-service/latest/developerguide/es-request-signing.html#es-request-signing-ruby) for an example.
@@ -379,21 +382,23 @@ You can use any standard Faraday middleware and plugins in the configuration blo
 You can also initialize the transport class yourself, and pass it to the client constructor
 as the `transport` argument:
 
-    require 'typhoeus'
-    require 'typhoeus/adapters/faraday'
+```ruby
+require 'patron'
 
-    transport_configuration = lambda do |f|
-      f.response :logger
-      f.adapter  :typhoeus
-    end
+transport_configuration = lambda do |f|
+  f.response :logger
+  f.adapter  :patron
+end
 
-    transport = Elasticsearch::Transport::Transport::HTTP::Faraday.new \
-      hosts: [ { host: 'localhost', port: '9200' } ],
-      &transport_configuration
+transport = Elasticsearch::Transport::Transport::HTTP::Faraday.new \
+  hosts: [ { host: 'localhost', port: '9200' } ],
+  &transport_configuration
 
-    # Pass the transport to the client
-    #
-    client = Elasticsearch::Client.new transport: transport
+# Pass the transport to the client
+#
+client = Elasticsearch::Client.new transport: transport
+```
+
 
 Instead of passing the transport to the constructor, you can inject it at run time:
 

--- a/elasticsearch-transport/README.md
+++ b/elasticsearch-transport/README.md
@@ -374,17 +374,7 @@ To configure the _Faraday_ instance directly, use a block:
       f.adapter  :typhoeus
     end
 
-You can use any standard Faraday middleware and plugins in the configuration block,
-for example sign the requests for the [AWS Elasticsearch service](https://aws.amazon.com/elasticsearch-service/):
-
-    require 'faraday_middleware/aws_signers_v4'
-
-    client = Elasticsearch::Client.new url: 'https://search-my-cluster-abc123....es.amazonaws.com' do |f|
-      f.request :aws_signers_v4,
-                credentials: Aws::Credentials.new(ENV['AWS_ACCESS_KEY'], ENV['AWS_SECRET_ACCESS_KEY']),
-                service_name: 'es',
-                region: 'us-east-1'
-    end
+You can use any standard Faraday middleware and plugins in the configuration block, for example sign the requests for the [AWS Elasticsearch service](https://aws.amazon.com/elasticsearch-service/). See [the AWS documentation](https://docs.aws.amazon.com/elasticsearch-service/latest/developerguide/es-request-signing.html#es-request-signing-ruby) for an example.
 
 You can also initialize the transport class yourself, and pass it to the client constructor
 as the `transport` argument:

--- a/elasticsearch-transport/elasticsearch-transport.gemspec
+++ b/elasticsearch-transport/elasticsearch-transport.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |s|
   s.required_ruby_version = '>= 2.4'
 
   s.add_dependency 'multi_json'
-  s.add_dependency 'faraday', '>= 0.14', '< 1'
+  s.add_dependency 'faraday', '~> 1'
 
   s.add_development_dependency 'cane'
   s.add_development_dependency 'curb'   unless defined? JRUBY_VERSION

--- a/elasticsearch-transport/lib/elasticsearch/transport/client.rb
+++ b/elasticsearch-transport/lib/elasticsearch/transport/client.rb
@@ -142,10 +142,8 @@ module Elasticsearch
           transport_class  = @arguments[:transport_class] || DEFAULT_TRANSPORT_CLASS
           if transport_class == Transport::HTTP::Faraday
             @transport = transport_class.new(hosts: @seeds, options: @arguments) do |faraday|
-              block.call faraday if block
-              unless (h = faraday.builder.handlers.last) && h.name.start_with?("Faraday::Adapter")
-                faraday.adapter(@arguments[:adapter] || __auto_detect_adapter)
-              end
+              faraday.adapter(@arguments[:adapter] || __auto_detect_adapter)
+              block&.call faraday
             end
           else
             @transport = transport_class.new(hosts: @seeds, options: @arguments)

--- a/elasticsearch-transport/lib/elasticsearch/transport/transport/http/faraday.rb
+++ b/elasticsearch-transport/lib/elasticsearch/transport/transport/http/faraday.rb
@@ -48,7 +48,7 @@ module Elasticsearch
           # @return [Array]
           #
           def host_unreachable_exceptions
-            [::Faraday::Error::ConnectionFailed, ::Faraday::Error::TimeoutError]
+            [::Faraday::ConnectionFailed, ::Faraday::TimeoutError]
           end
 
           private

--- a/elasticsearch-transport/spec/elasticsearch/transport/client_spec.rb
+++ b/elasticsearch-transport/spec/elasticsearch/transport/client_spec.rb
@@ -1275,7 +1275,7 @@ describe Elasticsearch::Transport::Client do
           expect(client.perform_request('GET', '_nodes/_local'))
           expect {
             client.perform_request('GET', '_nodes/_local')
-          }.to raise_exception(Faraday::Error::ConnectionFailed)
+          }.to raise_exception(Faraday::ConnectionFailed)
         end
       end
 

--- a/elasticsearch-transport/spec/elasticsearch/transport/client_spec.rb
+++ b/elasticsearch-transport/spec/elasticsearch/transport/client_spec.rb
@@ -220,41 +220,41 @@ describe Elasticsearch::Transport::Client do
   describe 'adapter' do
     context 'when no adapter is specified' do
       let(:adapter) do
-        client.transport.connections.all.first.connection.builder.handlers
+        client.transport.connections.all.first.connection.builder.adapter
       end
 
       it 'uses Faraday NetHttp' do
-        expect(adapter).to include(Faraday::Adapter::NetHttp)
+        expect(adapter).to eq Faraday::Adapter::NetHttp
       end
     end
 
     context 'when the adapter is specified' do
 
       let(:adapter) do
-        client.transport.connections.all.first.connection.builder.handlers
+        client.transport.connections.all.first.connection.builder.adapter
       end
 
       let(:client) do
-        described_class.new(adapter: :typhoeus)
+        described_class.new(adapter: :patron)
       end
 
       it 'uses Faraday with the adapter' do
-        expect(adapter).to include(Faraday::Adapter::Typhoeus)
+        expect(adapter).to eq Faraday::Adapter::Patron
       end
     end
 
     context 'when the adapter is specified as a string key' do
 
       let(:adapter) do
-        client.transport.connections.all.first.connection.builder.handlers
+        client.transport.connections.all.first.connection.builder.adapter
       end
 
       let(:client) do
-        described_class.new('adapter' => :typhoeus)
+        described_class.new('adapter' => :patron)
       end
 
       it 'uses Faraday with the adapter' do
-        expect(adapter).to include(Faraday::Adapter::Typhoeus)
+        expect(adapter).to eq Faraday::Adapter::Patron
       end
     end
 
@@ -266,11 +266,11 @@ describe Elasticsearch::Transport::Client do
       end
 
       let(:adapter) do
-        client.transport.connections.all.first.connection.builder.handlers
+        client.transport.connections.all.first.connection.builder.adapter
       end
 
       it 'uses the detected adapter' do
-        expect(adapter).to include(Faraday::Adapter::Patron)
+        expect(adapter).to eq Faraday::Adapter::Patron
       end
     end
 
@@ -278,9 +278,13 @@ describe Elasticsearch::Transport::Client do
 
       let(:client) do
         described_class.new do |faraday|
-          faraday.adapter :typhoeus
+          faraday.adapter :patron
           faraday.response :logger
         end
+      end
+
+      let(:adapter) do
+        client.transport.connections.all.first.connection.builder.adapter
       end
 
       let(:handlers) do
@@ -288,7 +292,7 @@ describe Elasticsearch::Transport::Client do
       end
 
       it 'sets the adapter' do
-        expect(handlers).to include(Faraday::Adapter::Typhoeus)
+        expect(adapter).to eq Faraday::Adapter::Patron
       end
 
       it 'sets the logger' do
@@ -1209,15 +1213,14 @@ describe Elasticsearch::Transport::Client do
         end
 
         context 'when the Faraday adapter is set in the block' do
-
           let(:client) do
             Elasticsearch::Client.new(host: ELASTICSEARCH_HOSTS.first, logger: logger) do |client|
               client.adapter(:net_http_persistent)
             end
           end
 
-          let(:connection_handler) do
-            client.transport.connections.first.connection.builder.handlers.first
+          let(:handler_name) do
+            client.transport.connections.first.connection.builder.adapter.name
           end
 
           let(:response) do
@@ -1225,7 +1228,7 @@ describe Elasticsearch::Transport::Client do
           end
 
           it 'sets the adapter' do
-            expect(connection_handler.name).to eq('Faraday::Adapter::NetHttpPersistent')
+            expect(handler_name).to eq('Faraday::Adapter::NetHttpPersistent')
           end
 
           it 'uses the adapter to connect' do
@@ -1559,12 +1562,12 @@ describe Elasticsearch::Transport::Client do
           { adapter: :patron }
         end
 
-        let(:connection_handler) do
-          client.transport.connections.first.connection.builder.handlers.first
+        let(:adapter) do
+          client.transport.connections.first.connection.builder.adapter
         end
 
         it 'uses the patron connection handler' do
-          expect(connection_handler).to eq('Faraday::Adapter::Patron')
+          expect(adapter).to eq('Faraday::Adapter::Patron')
         end
 
         it 'keeps connections open' do


### PR DESCRIPTION
Migration to Faraday 1.0.

- We were already using `adapter` method to set the adapter, so that's :+1: 
- We were checking `handlers` for loaded adapters in the specs, I changed them to use Faraday's `adapters`.
- The client initializer was modified but this should not disrupt final users at all, check 0fdc6533f4621a549a4cb99e778bbd827461a2d0 for more information.
- Migrated error checking to remove the deprecated `Faraday::Error` namespace.
- **This change is not compatible with [Typhoeus](https://github.com/typhoeus/typhoeus)**. The latest release is 1.3.1, but it's [still using the deprecated `Faraday::Error` namespace](https://github.com/typhoeus/typhoeus/blob/v1.3.1/lib/typhoeus/adapters/faraday.rb#L100). This has been fixed on master, but the last release was November 6, 2018. Version 1.4.0 should be ok once it's released.
- Note: Faraday 1.0 drops official support for JRuby. It installs fine on the tests we run with JRuby in this repo, but it's something we should pay attention to.

Reference: [Upgrading - Faraday 1.0](https://github.com/lostisland/faraday/blob/master/UPGRADING.md)