### PR TITLE
Pass HTTP request headers to perform_request in bulk

### DIFF
--- a/elasticsearch-api/lib/elasticsearch/api/actions/bulk.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/bulk.rb
@@ -54,6 +54,7 @@ module Elasticsearch
       # @option arguments [String] :index Default index for items which don't provide one
       # @option arguments [String] :type Default document type for items which don't provide one
       # @option arguments [Hash] :body The operation definition and data (action-data pairs), separated by newlines (*Required*)
+      # @option arguments [Hash] :headers Additional HTTP headers to include in the request
       # @option arguments [String] :wait_for_active_shards Sets the number of shard copies that must be active before proceeding with the bulk operation. Defaults to 1, meaning the primary shard only. Set to `all` for all shard copies, otherwise set to any non-negative value less than or equal to the total number of copies for the shard (number of replicas + 1)
       # @option arguments [String] :refresh If `true` then refresh the effected shards to make this operation visible to search, if `wait_for` then wait for a refresh to make this operation visible to search, if `false` (the default) then do nothing with refreshes. (options: true, false, wait_for)
       # @option arguments [String] :routing Specific routing value
@@ -71,6 +72,7 @@ module Elasticsearch
         arguments = arguments.clone
 
         type      = arguments.delete(:type)
+        headers   = arguments.delete(:headers)
 
         method = HTTP_POST
         path   = Utils.__pathify Utils.__escape(arguments[:index]), Utils.__escape(type), '_bulk'
@@ -84,7 +86,9 @@ module Elasticsearch
           payload = body
         end
 
-        perform_request(method, path, params, payload, {"Content-Type" => "application/x-ndjson"}).body
+        request_headers = {"Content-Type" => "application/x-ndjson"}.merge(headers || {})
+
+        perform_request(method, path, params, payload, request_headers).body
       end
 
       # Register this action with its valid params when the module is loaded.

--- a/elasticsearch-api/spec/elasticsearch/api/actions/bulk_spec.rb
+++ b/elasticsearch-api/spec/elasticsearch/api/actions/bulk_spec.rb
@@ -123,4 +123,15 @@ describe 'client#bulk' do
       expect(client_double.bulk(index: 'myindex', type: 'mytype', body: [])).to eq({})
     end
   end
+
+  context 'when additional HTTP header is provided' do
+
+    let(:headers) do
+      {'Content-Type'=>'application/x-ndjson', 'foo'=>'bar'}
+    end
+
+    it 'performs the request' do
+      expect(client_double.bulk(headers: { 'foo'=>'bar' }, body: [])).to eq({})
+    end
+  end
 end


### PR DESCRIPTION
Support passing additional HTTP request headers in bulk requests.

This allows setting `Content-Encoding: gzip` on requests where `body` has already been compressed

(e.g. https://github.com/uken/fluent-plugin-elasticsearch with `compression_level` set to a value other than the default `no_compression`)

I'm not sure if this is the preferred approach, I'm happy to adjust as necessary (e.g. Setting request header `Content-Encoding: gzip` could be done dynamically in `perform_request` by examining the request body, similar as is done for the response body in [Transport::base](https://github.com/elastic/elasticsearch-ruby/blob/5a808dfd2255955531c05c3f04622b1a16571929/elasticsearch-transport/lib/elasticsearch/transport/transport/base.rb#L385) )