### PR TITLE
Custom HTTP headers

### DIFF
--- a/elasticsearch-api/lib/elasticsearch/api/actions/bulk.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/bulk.rb
@@ -20,13 +20,15 @@ module Elasticsearch
       # @option arguments [List] :_source_excludes Default list of fields to exclude from the returned _source field, can be overridden on each sub-request
       # @option arguments [List] :_source_includes Default list of fields to extract and return from the _source field, can be overridden on each sub-request
       # @option arguments [String] :pipeline The pipeline id to preprocess incoming documents with
-
+      # @option arguments [Hash] :headers Custom HTTP headers
       # @option arguments [Hash] :body The operation definition and data (action-data pairs), separated by newlines (*Required*)
       #
-      # @see https://www.elastic.co/guide/en/elasticsearch/reference/7.5/docs-bulk.html
+      # @see https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-bulk.html
       #
       def bulk(arguments = {})
         raise ArgumentError, "Required argument 'body' missing" unless arguments[:body]
+
+        headers = arguments.delete(:headers) || {}
 
         arguments = arguments.clone
 
@@ -51,7 +53,8 @@ module Elasticsearch
           payload = body
       end
 
-        perform_request(method, path, params, payload, { "Content-Type" => "application/x-ndjson" }).body
+        headers.merge!("Content-Type" => "application/x-ndjson")
+        perform_request(method, path, params, payload, headers).body
       end
 
       # Register this action with its valid params when the module is loaded.

--- a/elasticsearch-api/lib/elasticsearch/api/actions/cat/aliases.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/cat/aliases.rb
@@ -18,10 +18,13 @@ module Elasticsearch
         # @option arguments [String] :expand_wildcards Whether to expand wildcard expression to concrete indices that are open, closed or both.
         #   (options: open,closed,hidden,none,all)
 
+        # @option arguments [Hash] :headers Custom HTTP headers
         #
-        # @see https://www.elastic.co/guide/en/elasticsearch/reference/7.5/cat-alias.html
+        # @see https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-alias.html
         #
         def aliases(arguments = {})
+          headers = arguments.delete(:headers) || {}
+
           arguments = arguments.clone
 
           _name = arguments.delete(:name)
@@ -31,12 +34,12 @@ module Elasticsearch
                      "_cat/aliases/#{Utils.__listify(_name)}"
                    else
                      "_cat/aliases"
-end
+      end
           params = Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
           params[:h] = Utils.__listify(params[:h]) if params[:h]
 
           body = nil
-          perform_request(method, path, params, body).body
+          perform_request(method, path, params, body, headers).body
         end
 
         # Register this action with its valid params when the module is loaded.

--- a/elasticsearch-api/lib/elasticsearch/api/actions/cat/allocation.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/cat/allocation.rb
@@ -19,11 +19,13 @@ module Elasticsearch
         # @option arguments [Boolean] :help Return help information
         # @option arguments [List] :s Comma-separated list of column names or column aliases to sort by
         # @option arguments [Boolean] :v Verbose mode. Display column headers
-
+        # @option arguments [Hash] :headers Custom HTTP headers
         #
-        # @see https://www.elastic.co/guide/en/elasticsearch/reference/7.5/cat-allocation.html
+        # @see https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-allocation.html
         #
         def allocation(arguments = {})
+          headers = arguments.delete(:headers) || {}
+
           arguments = arguments.clone
 
           _node_id = arguments.delete(:node_id)
@@ -33,12 +35,12 @@ module Elasticsearch
                      "_cat/allocation/#{Utils.__listify(_node_id)}"
                    else
                      "_cat/allocation"
-end
+      end
           params = Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
           params[:h] = Utils.__listify(params[:h]) if params[:h]
 
           body = nil
-          perform_request(method, path, params, body).body
+          perform_request(method, path, params, body, headers).body
         end
 
         # Register this action with its valid params when the module is loaded.

--- a/elasticsearch-api/lib/elasticsearch/api/actions/cat/count.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/cat/count.rb
@@ -14,11 +14,13 @@ module Elasticsearch
         # @option arguments [Boolean] :help Return help information
         # @option arguments [List] :s Comma-separated list of column names or column aliases to sort by
         # @option arguments [Boolean] :v Verbose mode. Display column headers
-
+        # @option arguments [Hash] :headers Custom HTTP headers
         #
-        # @see https://www.elastic.co/guide/en/elasticsearch/reference/7.5/cat-count.html
+        # @see https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-count.html
         #
         def count(arguments = {})
+          headers = arguments.delete(:headers) || {}
+
           arguments = arguments.clone
 
           _index = arguments.delete(:index)
@@ -28,12 +30,12 @@ module Elasticsearch
                      "_cat/count/#{Utils.__listify(_index)}"
                    else
                      "_cat/count"
-end
+      end
           params = Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
           params[:h] = Utils.__listify(params[:h]) if params[:h]
 
           body = nil
-          perform_request(method, path, params, body).body
+          perform_request(method, path, params, body, headers).body
         end
 
         # Register this action with its valid params when the module is loaded.

--- a/elasticsearch-api/lib/elasticsearch/api/actions/cat/fielddata.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/cat/fielddata.rb
@@ -18,11 +18,13 @@ module Elasticsearch
         # @option arguments [List] :s Comma-separated list of column names or column aliases to sort by
         # @option arguments [Boolean] :v Verbose mode. Display column headers
         # @option arguments [List] :fields A comma-separated list of fields to return in the output
-
+        # @option arguments [Hash] :headers Custom HTTP headers
         #
-        # @see https://www.elastic.co/guide/en/elasticsearch/reference/7.5/cat-fielddata.html
+        # @see https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-fielddata.html
         #
         def fielddata(arguments = {})
+          headers = arguments.delete(:headers) || {}
+
           arguments = arguments.clone
 
           _fields = arguments.delete(:fields)
@@ -32,11 +34,11 @@ module Elasticsearch
                      "_cat/fielddata/#{Utils.__listify(_fields)}"
                    else
                      "_cat/fielddata"
-end
+      end
           params = Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
 
           body = nil
-          perform_request(method, path, params, body).body
+          perform_request(method, path, params, body, headers).body
         end
 
         # Register this action with its valid params when the module is loaded.

--- a/elasticsearch-api/lib/elasticsearch/api/actions/cat/health.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/cat/health.rb
@@ -13,15 +13,17 @@ module Elasticsearch
         # @option arguments [Boolean] :help Return help information
         # @option arguments [List] :s Comma-separated list of column names or column aliases to sort by
         # @option arguments [String] :time The unit in which to display time values
-        #   (options: d (Days),h (Hours),m (Minutes),s (Seconds),ms (Milliseconds),micros (Microseconds),nanos (Nanoseconds))
+        #   (options: d,h,m,s,ms,micros,nanos)
 
         # @option arguments [Boolean] :ts Set to false to disable timestamping
         # @option arguments [Boolean] :v Verbose mode. Display column headers
-
+        # @option arguments [Hash] :headers Custom HTTP headers
         #
-        # @see https://www.elastic.co/guide/en/elasticsearch/reference/7.5/cat-health.html
+        # @see https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-health.html
         #
         def health(arguments = {})
+          headers = arguments.delete(:headers) || {}
+
           arguments = arguments.clone
 
           method = Elasticsearch::API::HTTP_GET
@@ -30,7 +32,7 @@ module Elasticsearch
           params[:h] = Utils.__listify(params[:h]) if params[:h]
 
           body = nil
-          perform_request(method, path, params, body).body
+          perform_request(method, path, params, body, headers).body
         end
 
         # Register this action with its valid params when the module is loaded.

--- a/elasticsearch-api/lib/elasticsearch/api/actions/cat/help.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/cat/help.rb
@@ -10,11 +10,13 @@ module Elasticsearch
         #
         # @option arguments [Boolean] :help Return help information
         # @option arguments [List] :s Comma-separated list of column names or column aliases to sort by
-
+        # @option arguments [Hash] :headers Custom HTTP headers
         #
-        # @see https://www.elastic.co/guide/en/elasticsearch/reference/7.5/cat.html
+        # @see https://www.elastic.co/guide/en/elasticsearch/reference/master/cat.html
         #
         def help(arguments = {})
+          headers = arguments.delete(:headers) || {}
+
           arguments = arguments.clone
 
           method = Elasticsearch::API::HTTP_GET
@@ -22,7 +24,7 @@ module Elasticsearch
           params = Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
 
           body = nil
-          perform_request(method, path, params, body).body
+          perform_request(method, path, params, body, headers).body
         end
 
         # Register this action with its valid params when the module is loaded.

--- a/elasticsearch-api/lib/elasticsearch/api/actions/cat/indices.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/cat/indices.rb
@@ -30,10 +30,13 @@ module Elasticsearch
         # @option arguments [String] :expand_wildcards Whether to expand wildcard expression to concrete indices that are open, closed or both.
         #   (options: open,closed,hidden,none,all)
 
+        # @option arguments [Hash] :headers Custom HTTP headers
         #
-        # @see https://www.elastic.co/guide/en/elasticsearch/reference/7.5/cat-indices.html
+        # @see https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-indices.html
         #
         def indices(arguments = {})
+          headers = arguments.delete(:headers) || {}
+
           arguments = arguments.clone
 
           _index = arguments.delete(:index)
@@ -43,12 +46,12 @@ module Elasticsearch
                      "_cat/indices/#{Utils.__listify(_index)}"
                    else
                      "_cat/indices"
-end
+      end
           params = Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
           params[:h] = Utils.__listify(params[:h]) if params[:h]
 
           body = nil
-          perform_request(method, path, params, body).body
+          perform_request(method, path, params, body, headers).body
         end
 
         # Register this action with its valid params when the module is loaded.

--- a/elasticsearch-api/lib/elasticsearch/api/actions/cat/master.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/cat/master.rb
@@ -15,11 +15,13 @@ module Elasticsearch
         # @option arguments [Boolean] :help Return help information
         # @option arguments [List] :s Comma-separated list of column names or column aliases to sort by
         # @option arguments [Boolean] :v Verbose mode. Display column headers
-
+        # @option arguments [Hash] :headers Custom HTTP headers
         #
-        # @see https://www.elastic.co/guide/en/elasticsearch/reference/7.5/cat-master.html
+        # @see https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-master.html
         #
         def master(arguments = {})
+          headers = arguments.delete(:headers) || {}
+
           arguments = arguments.clone
 
           method = Elasticsearch::API::HTTP_GET
@@ -27,7 +29,7 @@ module Elasticsearch
           params = Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
 
           body = nil
-          perform_request(method, path, params, body).body
+          perform_request(method, path, params, body, headers).body
         end
 
         # Register this action with its valid params when the module is loaded.

--- a/elasticsearch-api/lib/elasticsearch/api/actions/cat/nodeattrs.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/cat/nodeattrs.rb
@@ -15,11 +15,13 @@ module Elasticsearch
         # @option arguments [Boolean] :help Return help information
         # @option arguments [List] :s Comma-separated list of column names or column aliases to sort by
         # @option arguments [Boolean] :v Verbose mode. Display column headers
-
+        # @option arguments [Hash] :headers Custom HTTP headers
         #
-        # @see https://www.elastic.co/guide/en/elasticsearch/reference/7.5/cat-nodeattrs.html
+        # @see https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-nodeattrs.html
         #
         def nodeattrs(arguments = {})
+          headers = arguments.delete(:headers) || {}
+
           arguments = arguments.clone
 
           method = Elasticsearch::API::HTTP_GET
@@ -27,7 +29,7 @@ module Elasticsearch
           params = Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
 
           body = nil
-          perform_request(method, path, params, body).body
+          perform_request(method, path, params, body, headers).body
         end
 
         # Register this action with its valid params when the module is loaded.

--- a/elasticsearch-api/lib/elasticsearch/api/actions/cat/nodes.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/cat/nodes.rb
@@ -22,11 +22,13 @@ module Elasticsearch
         #   (options: d,h,m,s,ms,micros,nanos)
 
         # @option arguments [Boolean] :v Verbose mode. Display column headers
-
+        # @option arguments [Hash] :headers Custom HTTP headers
         #
-        # @see https://www.elastic.co/guide/en/elasticsearch/reference/7.5/cat-nodes.html
+        # @see https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-nodes.html
         #
         def nodes(arguments = {})
+          headers = arguments.delete(:headers) || {}
+
           arguments = arguments.clone
 
           method = Elasticsearch::API::HTTP_GET
@@ -35,7 +37,7 @@ module Elasticsearch
           params[:h] = Utils.__listify(params[:h], escape: false) if params[:h]
 
           body = nil
-          perform_request(method, path, params, body).body
+          perform_request(method, path, params, body, headers).body
         end
 
         # Register this action with its valid params when the module is loaded.

--- a/elasticsearch-api/lib/elasticsearch/api/actions/cat/pending_tasks.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/cat/pending_tasks.rb
@@ -18,11 +18,13 @@ module Elasticsearch
         #   (options: d,h,m,s,ms,micros,nanos)
 
         # @option arguments [Boolean] :v Verbose mode. Display column headers
-
+        # @option arguments [Hash] :headers Custom HTTP headers
         #
-        # @see https://www.elastic.co/guide/en/elasticsearch/reference/7.5/cat-pending-tasks.html
+        # @see https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-pending-tasks.html
         #
         def pending_tasks(arguments = {})
+          headers = arguments.delete(:headers) || {}
+
           arguments = arguments.clone
 
           method = Elasticsearch::API::HTTP_GET
@@ -31,7 +33,7 @@ module Elasticsearch
           params[:h] = Utils.__listify(params[:h]) if params[:h]
 
           body = nil
-          perform_request(method, path, params, body).body
+          perform_request(method, path, params, body, headers).body
         end
 
         # Register this action with its valid params when the module is loaded.

--- a/elasticsearch-api/lib/elasticsearch/api/actions/cat/plugins.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/cat/plugins.rb
@@ -15,11 +15,13 @@ module Elasticsearch
         # @option arguments [Boolean] :help Return help information
         # @option arguments [List] :s Comma-separated list of column names or column aliases to sort by
         # @option arguments [Boolean] :v Verbose mode. Display column headers
-
+        # @option arguments [Hash] :headers Custom HTTP headers
         #
-        # @see https://www.elastic.co/guide/en/elasticsearch/reference/7.5/cat-plugins.html
+        # @see https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-plugins.html
         #
         def plugins(arguments = {})
+          headers = arguments.delete(:headers) || {}
+
           arguments = arguments.clone
 
           method = Elasticsearch::API::HTTP_GET
@@ -27,7 +29,7 @@ module Elasticsearch
           params = Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
 
           body = nil
-          perform_request(method, path, params, body).body
+          perform_request(method, path, params, body, headers).body
         end
 
         # Register this action with its valid params when the module is loaded.

--- a/elasticsearch-api/lib/elasticsearch/api/actions/cat/recovery.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/cat/recovery.rb
@@ -23,11 +23,13 @@ module Elasticsearch
         #   (options: d,h,m,s,ms,micros,nanos)
 
         # @option arguments [Boolean] :v Verbose mode. Display column headers
-
+        # @option arguments [Hash] :headers Custom HTTP headers
         #
-        # @see https://www.elastic.co/guide/en/elasticsearch/reference/7.5/cat-recovery.html
+        # @see https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-recovery.html
         #
         def recovery(arguments = {})
+          headers = arguments.delete(:headers) || {}
+
           arguments = arguments.clone
 
           _index = arguments.delete(:index)
@@ -37,12 +39,12 @@ module Elasticsearch
                      "_cat/recovery/#{Utils.__listify(_index)}"
                    else
                      "_cat/recovery"
-end
+      end
           params = Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
           params[:h] = Utils.__listify(params[:h]) if params[:h]
 
           body = nil
-          perform_request(method, path, params, body).body
+          perform_request(method, path, params, body, headers).body
         end
 
         # Register this action with its valid params when the module is loaded.

--- a/elasticsearch-api/lib/elasticsearch/api/actions/cat/repositories.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/cat/repositories.rb
@@ -15,11 +15,13 @@ module Elasticsearch
         # @option arguments [Boolean] :help Return help information
         # @option arguments [List] :s Comma-separated list of column names or column aliases to sort by
         # @option arguments [Boolean] :v Verbose mode. Display column headers
-
+        # @option arguments [Hash] :headers Custom HTTP headers
         #
-        # @see https://www.elastic.co/guide/en/elasticsearch/reference/7.5/cat-repositories.html
+        # @see https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-repositories.html
         #
         def repositories(arguments = {})
+          headers = arguments.delete(:headers) || {}
+
           arguments = arguments.clone
 
           method = Elasticsearch::API::HTTP_GET
@@ -27,7 +29,7 @@ module Elasticsearch
           params = Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
 
           body = nil
-          perform_request(method, path, params, body).body
+          perform_request(method, path, params, body, headers).body
         end
 
         # Register this action with its valid params when the module is loaded.

--- a/elasticsearch-api/lib/elasticsearch/api/actions/cat/segments.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/cat/segments.rb
@@ -17,11 +17,13 @@ module Elasticsearch
         # @option arguments [Boolean] :help Return help information
         # @option arguments [List] :s Comma-separated list of column names or column aliases to sort by
         # @option arguments [Boolean] :v Verbose mode. Display column headers
-
+        # @option arguments [Hash] :headers Custom HTTP headers
         #
-        # @see https://www.elastic.co/guide/en/elasticsearch/reference/7.5/cat-segments.html
+        # @see https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-segments.html
         #
         def segments(arguments = {})
+          headers = arguments.delete(:headers) || {}
+
           arguments = arguments.clone
 
           _index = arguments.delete(:index)
@@ -31,11 +33,11 @@ module Elasticsearch
                      "_cat/segments/#{Utils.__listify(_index)}"
                    else
                      "_cat/segments"
-end
+      end
           params = Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
 
           body = nil
-          perform_request(method, path, params, body).body
+          perform_request(method, path, params, body, headers).body
         end
 
         # Register this action with its valid params when the module is loaded.

--- a/elasticsearch-api/lib/elasticsearch/api/actions/cat/shards.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/cat/shards.rb
@@ -22,11 +22,13 @@ module Elasticsearch
         #   (options: d,h,m,s,ms,micros,nanos)
 
         # @option arguments [Boolean] :v Verbose mode. Display column headers
-
+        # @option arguments [Hash] :headers Custom HTTP headers
         #
-        # @see https://www.elastic.co/guide/en/elasticsearch/reference/7.5/cat-shards.html
+        # @see https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-shards.html
         #
         def shards(arguments = {})
+          headers = arguments.delete(:headers) || {}
+
           arguments = arguments.clone
 
           _index = arguments.delete(:index)
@@ -36,12 +38,12 @@ module Elasticsearch
                      "_cat/shards/#{Utils.__listify(_index)}"
                    else
                      "_cat/shards"
-end
+      end
           params = Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
           params[:h] = Utils.__listify(params[:h]) if params[:h]
 
           body = nil
-          perform_request(method, path, params, body).body
+          perform_request(method, path, params, body, headers).body
         end
 
         # Register this action with its valid params when the module is loaded.

--- a/elasticsearch-api/lib/elasticsearch/api/actions/cat/snapshots.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/cat/snapshots.rb
@@ -19,11 +19,13 @@ module Elasticsearch
         #   (options: d,h,m,s,ms,micros,nanos)
 
         # @option arguments [Boolean] :v Verbose mode. Display column headers
-
+        # @option arguments [Hash] :headers Custom HTTP headers
         #
-        # @see https://www.elastic.co/guide/en/elasticsearch/reference/7.5/cat-snapshots.html
+        # @see https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-snapshots.html
         #
         def snapshots(arguments = {})
+          headers = arguments.delete(:headers) || {}
+
           arguments = arguments.clone
 
           _repository = arguments.delete(:repository)
@@ -33,11 +35,11 @@ module Elasticsearch
                      "_cat/snapshots/#{Utils.__listify(_repository)}"
                    else
                      "_cat/snapshots"
-end
+      end
           params = Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
 
           body = nil
-          perform_request(method, path, params, body).body
+          perform_request(method, path, params, body, headers).body
         end
 
         # Register this action with its valid params when the module is loaded.

--- a/elasticsearch-api/lib/elasticsearch/api/actions/cat/tasks.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/cat/tasks.rb
@@ -20,11 +20,13 @@ module Elasticsearch
         #   (options: d,h,m,s,ms,micros,nanos)
 
         # @option arguments [Boolean] :v Verbose mode. Display column headers
-
+        # @option arguments [Hash] :headers Custom HTTP headers
         #
-        # @see https://www.elastic.co/guide/en/elasticsearch/reference/7.5/tasks.html
+        # @see https://www.elastic.co/guide/en/elasticsearch/reference/master/tasks.html
         #
         def tasks(arguments = {})
+          headers = arguments.delete(:headers) || {}
+
           arguments = arguments.clone
 
           method = Elasticsearch::API::HTTP_GET
@@ -32,7 +34,7 @@ module Elasticsearch
           params = Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
 
           body = nil
-          perform_request(method, path, params, body).body
+          perform_request(method, path, params, body, headers).body
         end
 
         # Register this action with its valid params when the module is loaded.

--- a/elasticsearch-api/lib/elasticsearch/api/actions/cat/templates.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/cat/templates.rb
@@ -16,11 +16,13 @@ module Elasticsearch
         # @option arguments [Boolean] :help Return help information
         # @option arguments [List] :s Comma-separated list of column names or column aliases to sort by
         # @option arguments [Boolean] :v Verbose mode. Display column headers
-
+        # @option arguments [Hash] :headers Custom HTTP headers
         #
-        # @see https://www.elastic.co/guide/en/elasticsearch/reference/7.5/cat-templates.html
+        # @see https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-templates.html
         #
         def templates(arguments = {})
+          headers = arguments.delete(:headers) || {}
+
           arguments = arguments.clone
 
           _name = arguments.delete(:name)
@@ -30,11 +32,11 @@ module Elasticsearch
                      "_cat/templates/#{Utils.__listify(_name)}"
                    else
                      "_cat/templates"
-end
+      end
           params = Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
 
           body = nil
-          perform_request(method, path, params, body).body
+          perform_request(method, path, params, body, headers).body
         end
 
         # Register this action with its valid params when the module is loaded.

--- a/elasticsearch-api/lib/elasticsearch/api/actions/cat/thread_pool.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/cat/thread_pool.rb
@@ -20,11 +20,13 @@ module Elasticsearch
         # @option arguments [Boolean] :help Return help information
         # @option arguments [List] :s Comma-separated list of column names or column aliases to sort by
         # @option arguments [Boolean] :v Verbose mode. Display column headers
-
+        # @option arguments [Hash] :headers Custom HTTP headers
         #
-        # @see https://www.elastic.co/guide/en/elasticsearch/reference/7.5/cat-thread-pool.html
+        # @see https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-thread-pool.html
         #
         def thread_pool(arguments = {})
+          headers = arguments.delete(:headers) || {}
+
           arguments = arguments.clone
 
           _thread_pool_patterns = arguments.delete(:thread_pool_patterns)
@@ -34,12 +36,12 @@ module Elasticsearch
                      "_cat/thread_pool/#{Utils.__listify(_thread_pool_patterns)}"
                    else
                      "_cat/thread_pool"
-end
+      end
           params = Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
           params[:h] = Utils.__listify(params[:h]) if params[:h]
 
           body = nil
-          perform_request(method, path, params, body).body
+          perform_request(method, path, params, body, headers).body
         end
 
         # Register this action with its valid params when the module is loaded.

--- a/elasticsearch-api/lib/elasticsearch/api/actions/clear_scroll.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/clear_scroll.rb
@@ -8,7 +8,7 @@ module Elasticsearch
       # Explicitly clears the search context for a scroll.
       #
       # @option arguments [List] :scroll_id A comma-separated list of scroll IDs to clear   *Deprecated*
-
+      # @option arguments [Hash] :headers Custom HTTP headers
       # @option arguments [Hash] :body A comma-separated list of scroll IDs to clear if none was specified via the scroll_id parameter
       #
       # *Deprecation notice*:
@@ -16,9 +16,11 @@ module Elasticsearch
       # Deprecated since version 7.0.0
       #
       #
-      # @see https://www.elastic.co/guide/en/elasticsearch/reference/7.5/search-request-body.html#_clear_scroll_api
+      # @see https://www.elastic.co/guide/en/elasticsearch/reference/master/search-request-body.html#_clear_scroll_api
       #
       def clear_scroll(arguments = {})
+        headers = arguments.delete(:headers) || {}
+
         arguments = arguments.clone
 
         _scroll_id = arguments.delete(:scroll_id)
@@ -28,11 +30,11 @@ module Elasticsearch
                    "_search/scroll/#{Utils.__listify(_scroll_id)}"
                  else
                    "_search/scroll"
-end
+    end
         params = {}
 
         body = arguments[:body]
-        perform_request(method, path, params, body).body
+        perform_request(method, path, params, body, headers).body
       end
     end
     end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/cluster/allocation_explain.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/cluster/allocation_explain.rb
@@ -10,12 +10,14 @@ module Elasticsearch
         #
         # @option arguments [Boolean] :include_yes_decisions Return 'YES' decisions in explanation (default: false)
         # @option arguments [Boolean] :include_disk_info Return information about disk usage and shard sizes (default: false)
-
+        # @option arguments [Hash] :headers Custom HTTP headers
         # @option arguments [Hash] :body The index, shard, and primary flag to explain. Empty means 'explain the first unassigned shard'
         #
-        # @see https://www.elastic.co/guide/en/elasticsearch/reference/7.5/cluster-allocation-explain.html
+        # @see https://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-allocation-explain.html
         #
         def allocation_explain(arguments = {})
+          headers = arguments.delete(:headers) || {}
+
           arguments = arguments.clone
 
           method = Elasticsearch::API::HTTP_GET
@@ -23,7 +25,7 @@ module Elasticsearch
           params = Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
 
           body = arguments[:body]
-          perform_request(method, path, params, body).body
+          perform_request(method, path, params, body, headers).body
         end
 
         # Register this action with its valid params when the module is loaded.

--- a/elasticsearch-api/lib/elasticsearch/api/actions/cluster/delete_component_template.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/cluster/delete_component_template.rb
@@ -11,12 +11,14 @@ module Elasticsearch
         # @option arguments [String] :name The name of the template
         # @option arguments [Time] :timeout Explicit operation timeout
         # @option arguments [Time] :master_timeout Specify timeout for connection to master
-
+        # @option arguments [Hash] :headers Custom HTTP headers
         #
-        # @see https://www.elastic.co/guide/en/elasticsearch/reference/7.5/indices-component-templates.html
+        # @see https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-component-templates.html
         #
         def delete_component_template(arguments = {})
           raise ArgumentError, "Required argument 'name' missing" unless arguments[:name]
+
+          headers = arguments.delete(:headers) || {}
 
           arguments = arguments.clone
 
@@ -27,7 +29,7 @@ module Elasticsearch
           params = Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
 
           body = nil
-          perform_request(method, path, params, body).body
+          perform_request(method, path, params, body, headers).body
         end
 
         # Register this action with its valid params when the module is loaded.

--- a/elasticsearch-api/lib/elasticsearch/api/actions/cluster/exists_component_template.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/cluster/exists_component_template.rb
@@ -6,34 +6,39 @@ module Elasticsearch
   module API
     module Cluster
       module Actions
-        # Returns a list of any cluster-level changes (e.g. create index, update mapping,
-        # allocate or fail shard) which have not yet been executed.
+        # Returns information about whether a particular component template exist
         #
+        # @option arguments [String] :name The name of the template
+        # @option arguments [Time] :master_timeout Explicit operation timeout for connection to master node
         # @option arguments [Boolean] :local Return local information, do not retrieve the state from master node (default: false)
-        # @option arguments [Time] :master_timeout Specify timeout for connection to master
         # @option arguments [Hash] :headers Custom HTTP headers
         #
-        # @see https://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-pending.html
+        # @see https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-component-templates.html
         #
-        def pending_tasks(arguments = {})
+        def exists_component_template(arguments = {})
+          raise ArgumentError, "Required argument 'name' missing" unless arguments[:name]
+
           headers = arguments.delete(:headers) || {}
 
           arguments = arguments.clone
 
-          method = Elasticsearch::API::HTTP_GET
-          path   = "_cluster/pending_tasks"
+          _name = arguments.delete(:name)
+
+          method = Elasticsearch::API::HTTP_HEAD
+          path   = "_component_template/#{Utils.__listify(_name)}"
           params = Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
 
           body = nil
           perform_request(method, path, params, body, headers).body
         end
 
+        alias_method :exists_component_template?, :exists_component_template
         # Register this action with its valid params when the module is loaded.
         #
         # @since 6.2.0
-        ParamsRegistry.register(:pending_tasks, [
-          :local,
-          :master_timeout
+        ParamsRegistry.register(:exists_component_template, [
+          :master_timeout,
+          :local
         ].freeze)
 end
       end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/cluster/get_component_template.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/cluster/get_component_template.rb
@@ -11,11 +11,13 @@ module Elasticsearch
         # @option arguments [List] :name The comma separated names of the component templates
         # @option arguments [Time] :master_timeout Explicit operation timeout for connection to master node
         # @option arguments [Boolean] :local Return local information, do not retrieve the state from master node (default: false)
-
+        # @option arguments [Hash] :headers Custom HTTP headers
         #
-        # @see https://www.elastic.co/guide/en/elasticsearch/reference/7.5/indices-component-templates.html
+        # @see https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-component-templates.html
         #
         def get_component_template(arguments = {})
+          headers = arguments.delete(:headers) || {}
+
           arguments = arguments.clone
 
           _name = arguments.delete(:name)
@@ -25,11 +27,11 @@ module Elasticsearch
                      "_component_template/#{Utils.__listify(_name)}"
                    else
                      "_component_template"
-end
+      end
           params = Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
 
           body = nil
-          perform_request(method, path, params, body).body
+          perform_request(method, path, params, body, headers).body
         end
 
         # Register this action with its valid params when the module is loaded.

--- a/elasticsearch-api/lib/elasticsearch/api/actions/cluster/get_settings.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/cluster/get_settings.rb
@@ -12,11 +12,13 @@ module Elasticsearch
         # @option arguments [Time] :master_timeout Explicit operation timeout for connection to master node
         # @option arguments [Time] :timeout Explicit operation timeout
         # @option arguments [Boolean] :include_defaults Whether to return all default clusters setting.
-
+        # @option arguments [Hash] :headers Custom HTTP headers
         #
-        # @see https://www.elastic.co/guide/en/elasticsearch/reference/7.5/cluster-update-settings.html
+        # @see https://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-update-settings.html
         #
         def get_settings(arguments = {})
+          headers = arguments.delete(:headers) || {}
+
           arguments = arguments.clone
 
           method = Elasticsearch::API::HTTP_GET
@@ -24,7 +26,7 @@ module Elasticsearch
           params = Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
 
           body = nil
-          perform_request(method, path, params, body).body
+          perform_request(method, path, params, body, headers).body
         end
 
         # Register this action with its valid params when the module is loaded.

--- a/elasticsearch-api/lib/elasticsearch/api/actions/cluster/health.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/cluster/health.rb
@@ -28,10 +28,13 @@ module Elasticsearch
         # @option arguments [String] :wait_for_status Wait until cluster is in a specific state
         #   (options: green,yellow,red)
 
+        # @option arguments [Hash] :headers Custom HTTP headers
         #
-        # @see https://www.elastic.co/guide/en/elasticsearch/reference/7.5/cluster-health.html
+        # @see https://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-health.html
         #
         def health(arguments = {})
+          headers = arguments.delete(:headers) || {}
+
           arguments = arguments.clone
 
           _index = arguments.delete(:index)
@@ -41,11 +44,11 @@ module Elasticsearch
                      "_cluster/health/#{Utils.__listify(_index)}"
                    else
                      "_cluster/health"
-end
+      end
           params = Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
 
           body = nil
-          perform_request(method, path, params, body).body
+          perform_request(method, path, params, body, headers).body
         end
 
         # Register this action with its valid params when the module is loaded.

--- a/elasticsearch-api/lib/elasticsearch/api/actions/cluster/put_component_template.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/cluster/put_component_template.rb
@@ -12,14 +12,16 @@ module Elasticsearch
         # @option arguments [Boolean] :create Whether the index template should only be added if new or can also replace an existing one
         # @option arguments [Time] :timeout Explicit operation timeout
         # @option arguments [Time] :master_timeout Specify timeout for connection to master
-
+        # @option arguments [Hash] :headers Custom HTTP headers
         # @option arguments [Hash] :body The template definition (*Required*)
         #
-        # @see https://www.elastic.co/guide/en/elasticsearch/reference/7.5/indices-component-templates.html
+        # @see https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-component-templates.html
         #
         def put_component_template(arguments = {})
           raise ArgumentError, "Required argument 'body' missing" unless arguments[:body]
           raise ArgumentError, "Required argument 'name' missing" unless arguments[:name]
+
+          headers = arguments.delete(:headers) || {}
 
           arguments = arguments.clone
 
@@ -30,7 +32,7 @@ module Elasticsearch
           params = Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
 
           body = arguments[:body]
-          perform_request(method, path, params, body).body
+          perform_request(method, path, params, body, headers).body
         end
 
         # Register this action with its valid params when the module is loaded.

--- a/elasticsearch-api/lib/elasticsearch/api/actions/cluster/put_settings.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/cluster/put_settings.rb
@@ -11,13 +11,15 @@ module Elasticsearch
         # @option arguments [Boolean] :flat_settings Return settings in flat format (default: false)
         # @option arguments [Time] :master_timeout Explicit operation timeout for connection to master node
         # @option arguments [Time] :timeout Explicit operation timeout
-
+        # @option arguments [Hash] :headers Custom HTTP headers
         # @option arguments [Hash] :body The settings to be updated. Can be either `transient` or `persistent` (survives cluster restart). (*Required*)
         #
-        # @see https://www.elastic.co/guide/en/elasticsearch/reference/7.5/cluster-update-settings.html
+        # @see https://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-update-settings.html
         #
         def put_settings(arguments = {})
           raise ArgumentError, "Required argument 'body' missing" unless arguments[:body]
+
+          headers = arguments.delete(:headers) || {}
 
           arguments = arguments.clone
 
@@ -26,7 +28,7 @@ module Elasticsearch
           params = Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
 
           body = arguments[:body] || {}
-          perform_request(method, path, params, body).body
+          perform_request(method, path, params, body, headers).body
         end
 
         # Register this action with its valid params when the module is loaded.

--- a/elasticsearch-api/lib/elasticsearch/api/actions/cluster/remote_info.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/cluster/remote_info.rb
@@ -8,11 +8,13 @@ module Elasticsearch
       module Actions
         # Returns the information about configured remote clusters.
         #
-
+        # @option arguments [Hash] :headers Custom HTTP headers
         #
-        # @see https://www.elastic.co/guide/en/elasticsearch/reference/7.5/cluster-remote-info.html
+        # @see https://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-remote-info.html
         #
         def remote_info(arguments = {})
+          headers = arguments.delete(:headers) || {}
+
           arguments = arguments.clone
 
           method = Elasticsearch::API::HTTP_GET
@@ -20,7 +22,7 @@ module Elasticsearch
           params = {}
 
           body = nil
-          perform_request(method, path, params, body).body
+          perform_request(method, path, params, body, headers).body
         end
 end
       end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/cluster/reroute.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/cluster/reroute.rb
@@ -16,12 +16,14 @@ module Elasticsearch
 
         # @option arguments [Time] :master_timeout Explicit operation timeout for connection to master node
         # @option arguments [Time] :timeout Explicit operation timeout
-
+        # @option arguments [Hash] :headers Custom HTTP headers
         # @option arguments [Hash] :body The definition of `commands` to perform (`move`, `cancel`, `allocate`)
         #
-        # @see https://www.elastic.co/guide/en/elasticsearch/reference/7.5/cluster-reroute.html
+        # @see https://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-reroute.html
         #
         def reroute(arguments = {})
+          headers = arguments.delete(:headers) || {}
+
           arguments = arguments.clone
 
           method = Elasticsearch::API::HTTP_POST
@@ -29,7 +31,7 @@ module Elasticsearch
           params = Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
 
           body = arguments[:body] || {}
-          perform_request(method, path, params, body).body
+          perform_request(method, path, params, body, headers).body
         end
 
         # Register this action with its valid params when the module is loaded.

--- a/elasticsearch-api/lib/elasticsearch/api/actions/cluster/state.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/cluster/state.rb
@@ -22,10 +22,13 @@ module Elasticsearch
         # @option arguments [String] :expand_wildcards Whether to expand wildcard expression to concrete indices that are open, closed or both.
         #   (options: open,closed,hidden,none,all)
 
+        # @option arguments [Hash] :headers Custom HTTP headers
         #
-        # @see https://www.elastic.co/guide/en/elasticsearch/reference/7.5/cluster-state.html
+        # @see https://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-state.html
         #
         def state(arguments = {})
+          headers = arguments.delete(:headers) || {}
+
           arguments = arguments.clone
 
           _metric = arguments.delete(:metric)
@@ -39,11 +42,11 @@ module Elasticsearch
                      "_cluster/state/#{Utils.__listify(_metric)}"
                    else
                      "_cluster/state"
-end
+      end
           params = Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
 
           body = nil
-          perform_request(method, path, params, body).body
+          perform_request(method, path, params, body, headers).body
         end
 
         # Register this action with its valid params when the module is loaded.

--- a/elasticsearch-api/lib/elasticsearch/api/actions/cluster/stats.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/cluster/stats.rb
@@ -11,11 +11,13 @@ module Elasticsearch
         # @option arguments [List] :node_id A comma-separated list of node IDs or names to limit the returned information; use `_local` to return information from the node you're connecting to, leave empty to get information from all nodes
         # @option arguments [Boolean] :flat_settings Return settings in flat format (default: false)
         # @option arguments [Time] :timeout Explicit operation timeout
-
+        # @option arguments [Hash] :headers Custom HTTP headers
         #
-        # @see https://www.elastic.co/guide/en/elasticsearch/reference/7.5/cluster-stats.html
+        # @see https://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-stats.html
         #
         def stats(arguments = {})
+          headers = arguments.delete(:headers) || {}
+
           arguments = arguments.clone
 
           _node_id = arguments.delete(:node_id)
@@ -25,11 +27,11 @@ module Elasticsearch
                      "_cluster/stats/nodes/#{Utils.__listify(_node_id)}"
                    else
                      "_cluster/stats"
-end
+      end
           params = Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
 
           body = nil
-          perform_request(method, path, params, body).body
+          perform_request(method, path, params, body, headers).body
         end
 
         # Register this action with its valid params when the module is loaded.

--- a/elasticsearch-api/lib/elasticsearch/api/actions/count.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/count.rb
@@ -27,7 +27,7 @@ module Elasticsearch
       # @option arguments [String] :df The field to use as default where no field prefix is given in the query string
       # @option arguments [Boolean] :lenient Specify whether format-based query failures (such as providing text to a numeric field) should be ignored
       # @option arguments [Number] :terminate_after The maximum count for each shard, upon reaching which the query execution will terminate early
-
+      # @option arguments [Hash] :headers Custom HTTP headers
       # @option arguments [Hash] :body A query to restrict the results specified with the Query DSL (optional)
       #
       # *Deprecation notice*:
@@ -35,9 +35,11 @@ module Elasticsearch
       # Deprecated since version 7.0.0
       #
       #
-      # @see https://www.elastic.co/guide/en/elasticsearch/reference/7.5/search-count.html
+      # @see https://www.elastic.co/guide/en/elasticsearch/reference/master/search-count.html
       #
       def count(arguments = {})
+        headers = arguments.delete(:headers) || {}
+
         arguments = arguments.clone
 
         _index = arguments.delete(:index)
@@ -48,7 +50,7 @@ module Elasticsearch
                    Elasticsearch::API::HTTP_POST
                  else
                    Elasticsearch::API::HTTP_GET
-end
+    end
 
         path = if _index && _type
                  "#{Utils.__listify(_index)}/#{Utils.__listify(_type)}/_count"
@@ -56,11 +58,11 @@ end
                  "#{Utils.__listify(_index)}/_count"
                else
                  "_count"
-end
+    end
         params = Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
 
         body = arguments[:body]
-        perform_request(method, path, params, body).body
+        perform_request(method, path, params, body, headers).body
       end
 
       # Register this action with its valid params when the module is loaded.

--- a/elasticsearch-api/lib/elasticsearch/api/actions/create.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/create.rb
@@ -23,7 +23,7 @@ module Elasticsearch
       #   (options: internal,external,external_gte)
 
       # @option arguments [String] :pipeline The pipeline id to preprocess incoming documents with
-
+      # @option arguments [Hash] :headers Custom HTTP headers
       # @option arguments [Hash] :body The document (*Required*)
       #
       # *Deprecation notice*:
@@ -31,7 +31,7 @@ module Elasticsearch
       # Deprecated since version 7.0.0
       #
       #
-      # @see https://www.elastic.co/guide/en/elasticsearch/reference/7.5/docs-index_.html
+      # @see https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-index_.html
       #
       def create(arguments = {})
         if arguments[:id]

--- a/elasticsearch-api/lib/elasticsearch/api/actions/delete.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/delete.rb
@@ -22,17 +22,20 @@ module Elasticsearch
       # @option arguments [String] :version_type Specific version type
       #   (options: internal,external,external_gte,force)
 
+      # @option arguments [Hash] :headers Custom HTTP headers
       #
       # *Deprecation notice*:
       # Specifying types in urls has been deprecated
       # Deprecated since version 7.0.0
       #
       #
-      # @see https://www.elastic.co/guide/en/elasticsearch/reference/7.5/docs-delete.html
+      # @see https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-delete.html
       #
       def delete(arguments = {})
         raise ArgumentError, "Required argument 'index' missing" unless arguments[:index]
         raise ArgumentError, "Required argument 'id' missing" unless arguments[:id]
+
+        headers = arguments.delete(:headers) || {}
 
         arguments = arguments.clone
 
@@ -52,9 +55,9 @@ module Elasticsearch
 
         body = nil
         if Array(arguments[:ignore]).include?(404)
-          Utils.__rescue_from_not_found { perform_request(method, path, params, body).body }
+          Utils.__rescue_from_not_found { perform_request(method, path, params, body, headers).body }
         else
-          perform_request(method, path, params, body).body
+          perform_request(method, path, params, body, headers).body
         end
       end
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/delete_by_query.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/delete_by_query.rb
@@ -50,7 +50,7 @@ module Elasticsearch
       # @option arguments [Boolean] :wait_for_completion Should the request should block until the delete by query is complete.
       # @option arguments [Number] :requests_per_second The throttle for this request in sub-requests per second. -1 means no throttle.
       # @option arguments [Number|string] :slices The number of slices this task should be divided into. Defaults to 1, meaning the task isn't sliced into subtasks. Can be set to `auto`.
-
+      # @option arguments [Hash] :headers Custom HTTP headers
       # @option arguments [Hash] :body The search definition using the Query DSL (*Required*)
       #
       # *Deprecation notice*:
@@ -58,11 +58,13 @@ module Elasticsearch
       # Deprecated since version 7.0.0
       #
       #
-      # @see https://www.elastic.co/guide/en/elasticsearch/reference/7.5/docs-delete-by-query.html
+      # @see https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-delete-by-query.html
       #
       def delete_by_query(arguments = {})
         raise ArgumentError, "Required argument 'body' missing" unless arguments[:body]
         raise ArgumentError, "Required argument 'index' missing" unless arguments[:index]
+
+        headers = arguments.delete(:headers) || {}
 
         arguments = arguments.clone
 
@@ -79,7 +81,7 @@ module Elasticsearch
         params = Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
 
         body = arguments[:body]
-        perform_request(method, path, params, body).body
+        perform_request(method, path, params, body, headers).body
       end
 
       # Register this action with its valid params when the module is loaded.

--- a/elasticsearch-api/lib/elasticsearch/api/actions/delete_by_query_rethrottle.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/delete_by_query_rethrottle.rb
@@ -9,12 +9,14 @@ module Elasticsearch
       #
       # @option arguments [String] :task_id The task id to rethrottle
       # @option arguments [Number] :requests_per_second The throttle to set on this request in floating sub-requests per second. -1 means set no throttle.  (*Required*)
-
+      # @option arguments [Hash] :headers Custom HTTP headers
       #
-      # @see https://www.elastic.co/guide/en/elasticsearch/reference/7.5/docs-delete-by-query.html
+      # @see https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-delete-by-query.html
       #
       def delete_by_query_rethrottle(arguments = {})
         raise ArgumentError, "Required argument 'task_id' missing" unless arguments[:task_id]
+
+        headers = arguments.delete(:headers) || {}
 
         arguments = arguments.clone
 
@@ -25,7 +27,7 @@ module Elasticsearch
         params = Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
 
         body = nil
-        perform_request(method, path, params, body).body
+        perform_request(method, path, params, body, headers).body
       end
 
       # Register this action with its valid params when the module is loaded.

--- a/elasticsearch-api/lib/elasticsearch/api/actions/delete_script.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/delete_script.rb
@@ -10,12 +10,14 @@ module Elasticsearch
       # @option arguments [String] :id Script ID
       # @option arguments [Time] :timeout Explicit operation timeout
       # @option arguments [Time] :master_timeout Specify timeout for connection to master
-
+      # @option arguments [Hash] :headers Custom HTTP headers
       #
-      # @see https://www.elastic.co/guide/en/elasticsearch/reference/7.5/modules-scripting.html
+      # @see https://www.elastic.co/guide/en/elasticsearch/reference/master/modules-scripting.html
       #
       def delete_script(arguments = {})
         raise ArgumentError, "Required argument 'id' missing" unless arguments[:id]
+
+        headers = arguments.delete(:headers) || {}
 
         arguments = arguments.clone
 
@@ -26,7 +28,7 @@ module Elasticsearch
         params = Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
 
         body = nil
-        perform_request(method, path, params, body).body
+        perform_request(method, path, params, body, headers).body
       end
 
       # Register this action with its valid params when the module is loaded.

--- a/elasticsearch-api/lib/elasticsearch/api/actions/exists.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/exists.rb
@@ -22,17 +22,20 @@ module Elasticsearch
       # @option arguments [String] :version_type Specific version type
       #   (options: internal,external,external_gte,force)
 
+      # @option arguments [Hash] :headers Custom HTTP headers
       #
       # *Deprecation notice*:
       # Specifying types in urls has been deprecated
       # Deprecated since version 7.0.0
       #
       #
-      # @see https://www.elastic.co/guide/en/elasticsearch/reference/7.5/docs-get.html
+      # @see https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-get.html
       #
       def exists(arguments = {})
         raise ArgumentError, "Required argument 'index' missing" unless arguments[:index]
         raise ArgumentError, "Required argument 'id' missing" unless arguments[:id]
+
+        headers = arguments.delete(:headers) || {}
 
         arguments = arguments.clone
 
@@ -53,7 +56,7 @@ module Elasticsearch
         body = nil
 
         Utils.__rescue_from_not_found do
-          perform_request(method, path, params, body).status == 200 ? true : false
+          perform_request(method, path, params, body, headers).status == 200 ? true : false
         end
       end
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/exists_source.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/exists_source.rb
@@ -21,17 +21,20 @@ module Elasticsearch
       # @option arguments [String] :version_type Specific version type
       #   (options: internal,external,external_gte,force)
 
+      # @option arguments [Hash] :headers Custom HTTP headers
       #
       # *Deprecation notice*:
       # Specifying types in urls has been deprecated
       # Deprecated since version 7.0.0
       #
       #
-      # @see https://www.elastic.co/guide/en/elasticsearch/reference/7.5/docs-get.html
+      # @see https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-get.html
       #
       def exists_source(arguments = {})
         raise ArgumentError, "Required argument 'index' missing" unless arguments[:index]
         raise ArgumentError, "Required argument 'id' missing" unless arguments[:id]
+
+        headers = arguments.delete(:headers) || {}
 
         arguments = arguments.clone
 
@@ -50,7 +53,7 @@ module Elasticsearch
         params = Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
 
         body = nil
-        perform_request(method, path, params, body).body
+        perform_request(method, path, params, body, headers).body
       end
 
       alias_method :exists_source?, :exists_source

--- a/elasticsearch-api/lib/elasticsearch/api/actions/explain.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/explain.rb
@@ -24,7 +24,7 @@ module Elasticsearch
       # @option arguments [List] :_source True or false to return the _source field or not, or a list of fields to return
       # @option arguments [List] :_source_excludes A list of fields to exclude from the returned _source field
       # @option arguments [List] :_source_includes A list of fields to extract and return from the _source field
-
+      # @option arguments [Hash] :headers Custom HTTP headers
       # @option arguments [Hash] :body The query definition using the Query DSL
       #
       # *Deprecation notice*:
@@ -32,11 +32,13 @@ module Elasticsearch
       # Deprecated since version 7.0.0
       #
       #
-      # @see https://www.elastic.co/guide/en/elasticsearch/reference/7.5/search-explain.html
+      # @see https://www.elastic.co/guide/en/elasticsearch/reference/master/search-explain.html
       #
       def explain(arguments = {})
         raise ArgumentError, "Required argument 'index' missing" unless arguments[:index]
         raise ArgumentError, "Required argument 'id' missing" unless arguments[:id]
+
+        headers = arguments.delete(:headers) || {}
 
         arguments = arguments.clone
 
@@ -55,7 +57,7 @@ module Elasticsearch
         params = Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
 
         body = arguments[:body]
-        perform_request(method, path, params, body).body
+        perform_request(method, path, params, body, headers).body
       end
 
       # Register this action with its valid params when the module is loaded.

--- a/elasticsearch-api/lib/elasticsearch/api/actions/field_caps.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/field_caps.rb
@@ -15,11 +15,13 @@ module Elasticsearch
       #   (options: open,closed,hidden,none,all)
 
       # @option arguments [Boolean] :include_unmapped Indicates whether unmapped fields should be included in the response.
-
+      # @option arguments [Hash] :headers Custom HTTP headers
       #
-      # @see https://www.elastic.co/guide/en/elasticsearch/reference/7.5/search-field-caps.html
+      # @see https://www.elastic.co/guide/en/elasticsearch/reference/master/search-field-caps.html
       #
       def field_caps(arguments = {})
+        headers = arguments.delete(:headers) || {}
+
         arguments = arguments.clone
 
         _index = arguments.delete(:index)
@@ -29,11 +31,11 @@ module Elasticsearch
                    "#{Utils.__listify(_index)}/_field_caps"
                  else
                    "_field_caps"
-end
+    end
         params = Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
 
         body = nil
-        perform_request(method, path, params, body).body
+        perform_request(method, path, params, body, headers).body
       end
 
       # Register this action with its valid params when the module is loaded.

--- a/elasticsearch-api/lib/elasticsearch/api/actions/get.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/get.rb
@@ -22,17 +22,20 @@ module Elasticsearch
       # @option arguments [String] :version_type Specific version type
       #   (options: internal,external,external_gte,force)
 
+      # @option arguments [Hash] :headers Custom HTTP headers
       #
       # *Deprecation notice*:
       # Specifying types in urls has been deprecated
       # Deprecated since version 7.0.0
       #
       #
-      # @see https://www.elastic.co/guide/en/elasticsearch/reference/7.5/docs-get.html
+      # @see https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-get.html
       #
       def get(arguments = {})
         raise ArgumentError, "Required argument 'index' missing" unless arguments[:index]
         raise ArgumentError, "Required argument 'id' missing" unless arguments[:id]
+
+        headers = arguments.delete(:headers) || {}
 
         arguments = arguments.clone
 
@@ -52,9 +55,9 @@ module Elasticsearch
 
         body = nil
         if Array(arguments[:ignore]).include?(404)
-          Utils.__rescue_from_not_found { perform_request(method, path, params, body).body }
+          Utils.__rescue_from_not_found { perform_request(method, path, params, body, headers).body }
         else
-          perform_request(method, path, params, body).body
+          perform_request(method, path, params, body, headers).body
         end
       end
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/get_script.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/get_script.rb
@@ -9,12 +9,14 @@ module Elasticsearch
       #
       # @option arguments [String] :id Script ID
       # @option arguments [Time] :master_timeout Specify timeout for connection to master
-
+      # @option arguments [Hash] :headers Custom HTTP headers
       #
-      # @see https://www.elastic.co/guide/en/elasticsearch/reference/7.5/modules-scripting.html
+      # @see https://www.elastic.co/guide/en/elasticsearch/reference/master/modules-scripting.html
       #
       def get_script(arguments = {})
         raise ArgumentError, "Required argument 'id' missing" unless arguments[:id]
+
+        headers = arguments.delete(:headers) || {}
 
         arguments = arguments.clone
 
@@ -25,7 +27,7 @@ module Elasticsearch
         params = Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
 
         body = nil
-        perform_request(method, path, params, body).body
+        perform_request(method, path, params, body, headers).body
       end
 
       # Register this action with its valid params when the module is loaded.

--- a/elasticsearch-api/lib/elasticsearch/api/actions/get_script_context.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/get_script_context.rb
@@ -7,11 +7,13 @@ module Elasticsearch
     module Actions
       # Returns all script contexts.
       #
-
+      # @option arguments [Hash] :headers Custom HTTP headers
       #
-      # @see [TODO]
+      # @see https://www.elastic.co/guide/en/elasticsearch/painless/master/painless-contexts.html
       #
       def get_script_context(arguments = {})
+        headers = arguments.delete(:headers) || {}
+
         arguments = arguments.clone
 
         method = Elasticsearch::API::HTTP_GET
@@ -19,7 +21,7 @@ module Elasticsearch
         params = {}
 
         body = nil
-        perform_request(method, path, params, body).body
+        perform_request(method, path, params, body, headers).body
       end
     end
     end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/get_script_languages.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/get_script_languages.rb
@@ -7,11 +7,13 @@ module Elasticsearch
     module Actions
       # Returns available script types, languages and contexts
       #
-
+      # @option arguments [Hash] :headers Custom HTTP headers
       #
-      # @see [TODO]
+      # @see https://www.elastic.co/guide/en/elasticsearch/reference/master/modules-scripting.html
       #
       def get_script_languages(arguments = {})
+        headers = arguments.delete(:headers) || {}
+
         arguments = arguments.clone
 
         method = Elasticsearch::API::HTTP_GET
@@ -19,7 +21,7 @@ module Elasticsearch
         params = {}
 
         body = nil
-        perform_request(method, path, params, body).body
+        perform_request(method, path, params, body, headers).body
       end
     end
     end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/get_source.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/get_source.rb
@@ -21,17 +21,20 @@ module Elasticsearch
       # @option arguments [String] :version_type Specific version type
       #   (options: internal,external,external_gte,force)
 
+      # @option arguments [Hash] :headers Custom HTTP headers
       #
       # *Deprecation notice*:
       # Specifying types in urls has been deprecated
       # Deprecated since version 7.0.0
       #
       #
-      # @see https://www.elastic.co/guide/en/elasticsearch/reference/7.5/docs-get.html
+      # @see https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-get.html
       #
       def get_source(arguments = {})
         raise ArgumentError, "Required argument 'index' missing" unless arguments[:index]
         raise ArgumentError, "Required argument 'id' missing" unless arguments[:id]
+
+        headers = arguments.delete(:headers) || {}
 
         arguments = arguments.clone
 
@@ -50,7 +53,7 @@ module Elasticsearch
         params = Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
 
         body = nil
-        perform_request(method, path, params, body).body
+        perform_request(method, path, params, body, headers).body
       end
 
       # Register this action with its valid params when the module is loaded.

--- a/elasticsearch-api/lib/elasticsearch/api/actions/index.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/index.rb
@@ -26,7 +26,7 @@ module Elasticsearch
       # @option arguments [Number] :if_seq_no only perform the index operation if the last operation that has changed the document has the specified sequence number
       # @option arguments [Number] :if_primary_term only perform the index operation if the last operation that has changed the document has the specified primary term
       # @option arguments [String] :pipeline The pipeline id to preprocess incoming documents with
-
+      # @option arguments [Hash] :headers Custom HTTP headers
       # @option arguments [Hash] :body The document (*Required*)
       #
       # *Deprecation notice*:
@@ -34,11 +34,13 @@ module Elasticsearch
       # Deprecated since version 7.0.0
       #
       #
-      # @see https://www.elastic.co/guide/en/elasticsearch/reference/7.5/docs-index_.html
+      # @see https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-index_.html
       #
       def index(arguments = {})
         raise ArgumentError, "Required argument 'body' missing" unless arguments[:body]
         raise ArgumentError, "Required argument 'index' missing" unless arguments[:index]
+
+        headers = arguments.delete(:headers) || {}
 
         arguments = arguments.clone
 
@@ -61,7 +63,7 @@ module Elasticsearch
         params = Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
 
         body = arguments[:body]
-        perform_request(method, path, params, body).body
+        perform_request(method, path, params, body, headers).body
       end
 
       # Register this action with its valid params when the module is loaded.

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/analyze.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/analyze.rb
@@ -10,12 +10,14 @@ module Elasticsearch
         #
         # @option arguments [String] :index The name of the index to scope the operation
         # @option arguments [String] :index The name of the index to scope the operation
-
+        # @option arguments [Hash] :headers Custom HTTP headers
         # @option arguments [Hash] :body Define analyzer/tokenizer parameters and the text on which the analysis should be performed
         #
-        # @see https://www.elastic.co/guide/en/elasticsearch/reference/7.5/indices-analyze.html
+        # @see https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-analyze.html
         #
         def analyze(arguments = {})
+          headers = arguments.delete(:headers) || {}
+
           arguments = arguments.clone
 
           _index = arguments.delete(:index)
@@ -25,11 +27,11 @@ module Elasticsearch
                      "#{Utils.__listify(_index)}/_analyze"
                    else
                      "_analyze"
-end
+      end
           params = Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
 
           body = arguments[:body]
-          perform_request(method, path, params, body).body
+          perform_request(method, path, params, body, headers).body
         end
 
         # Register this action with its valid params when the module is loaded.

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/clear_cache.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/clear_cache.rb
@@ -19,11 +19,13 @@ module Elasticsearch
 
         # @option arguments [List] :index A comma-separated list of index name to limit the operation
         # @option arguments [Boolean] :request Clear request cache
-
+        # @option arguments [Hash] :headers Custom HTTP headers
         #
-        # @see https://www.elastic.co/guide/en/elasticsearch/reference/7.5/indices-clearcache.html
+        # @see https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-clearcache.html
         #
         def clear_cache(arguments = {})
+          headers = arguments.delete(:headers) || {}
+
           arguments = arguments.clone
 
           _index = arguments.delete(:index)
@@ -33,11 +35,11 @@ module Elasticsearch
                      "#{Utils.__listify(_index)}/_cache/clear"
                    else
                      "_cache/clear"
-end
+      end
           params = Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
 
           body = nil
-          perform_request(method, path, params, body).body
+          perform_request(method, path, params, body, headers).body
         end
 
         # Register this action with its valid params when the module is loaded.

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/clone.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/clone.rb
@@ -13,14 +13,16 @@ module Elasticsearch
         # @option arguments [Time] :timeout Explicit operation timeout
         # @option arguments [Time] :master_timeout Specify timeout for connection to master
         # @option arguments [String] :wait_for_active_shards Set the number of active shards to wait for on the cloned index before the operation returns.
-
+        # @option arguments [Hash] :headers Custom HTTP headers
         # @option arguments [Hash] :body The configuration for the target index (`settings` and `aliases`)
         #
-        # @see https://www.elastic.co/guide/en/elasticsearch/reference/7.5/indices-clone-index.html
+        # @see https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-clone-index.html
         #
         def clone(arguments = {})
           raise ArgumentError, "Required argument 'index' missing" unless arguments[:index]
           raise ArgumentError, "Required argument 'target' missing" unless arguments[:target]
+
+          headers = arguments.delete(:headers) || {}
 
           arguments = arguments.clone
 
@@ -33,7 +35,7 @@ module Elasticsearch
           params = Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
 
           body = arguments[:body]
-          perform_request(method, path, params, body).body
+          perform_request(method, path, params, body, headers).body
         end
 
         # Register this action with its valid params when the module is loaded.

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/close.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/close.rb
@@ -17,12 +17,14 @@ module Elasticsearch
         #   (options: open,closed,hidden,none,all)
 
         # @option arguments [String] :wait_for_active_shards Sets the number of active shards to wait for before the operation returns.
-
+        # @option arguments [Hash] :headers Custom HTTP headers
         #
-        # @see https://www.elastic.co/guide/en/elasticsearch/reference/7.5/indices-open-close.html
+        # @see https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-open-close.html
         #
         def close(arguments = {})
           raise ArgumentError, "Required argument 'index' missing" unless arguments[:index]
+
+          headers = arguments.delete(:headers) || {}
 
           arguments = arguments.clone
 
@@ -33,7 +35,7 @@ module Elasticsearch
           params = Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
 
           body = nil
-          perform_request(method, path, params, body).body
+          perform_request(method, path, params, body, headers).body
         end
 
         # Register this action with its valid params when the module is loaded.

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/create.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/create.rb
@@ -13,13 +13,15 @@ module Elasticsearch
         # @option arguments [String] :wait_for_active_shards Set the number of active shards to wait for before the operation returns.
         # @option arguments [Time] :timeout Explicit operation timeout
         # @option arguments [Time] :master_timeout Specify timeout for connection to master
-
+        # @option arguments [Hash] :headers Custom HTTP headers
         # @option arguments [Hash] :body The configuration for the index (`settings` and `mappings`)
         #
-        # @see https://www.elastic.co/guide/en/elasticsearch/reference/7.5/indices-create-index.html
+        # @see https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-create-index.html
         #
         def create(arguments = {})
           raise ArgumentError, "Required argument 'index' missing" unless arguments[:index]
+
+          headers = arguments.delete(:headers) || {}
 
           arguments = arguments.clone
 
@@ -30,7 +32,7 @@ module Elasticsearch
           params = Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
 
           body = arguments[:body]
-          perform_request(method, path, params, body).body
+          perform_request(method, path, params, body, headers).body
         end
 
         # Register this action with its valid params when the module is loaded.

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/create_data_stream.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/create_data_stream.rb
@@ -9,14 +9,16 @@ module Elasticsearch
         # Creates or updates a data stream
         #
         # @option arguments [String] :name The name of the data stream
-
+        # @option arguments [Hash] :headers Custom HTTP headers
         # @option arguments [Hash] :body The data stream definition (*Required*)
         #
-        # @see https://www.elastic.co/guide/en/elasticsearch/reference/7.5/data-streams.html
+        # @see https://www.elastic.co/guide/en/elasticsearch/reference/master/data-streams.html
         #
         def create_data_stream(arguments = {})
           raise ArgumentError, "Required argument 'body' missing" unless arguments[:body]
           raise ArgumentError, "Required argument 'name' missing" unless arguments[:name]
+
+          headers = arguments.delete(:headers) || {}
 
           arguments = arguments.clone
 
@@ -27,7 +29,7 @@ module Elasticsearch
           params = {}
 
           body = arguments[:body]
-          perform_request(method, path, params, body).body
+          perform_request(method, path, params, body, headers).body
         end
 end
       end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/delete.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/delete.rb
@@ -16,11 +16,14 @@ module Elasticsearch
         # @option arguments [String] :expand_wildcards Whether wildcard expressions should get expanded to open or closed indices (default: open)
         #   (options: open,closed,hidden,none,all)
 
+        # @option arguments [Hash] :headers Custom HTTP headers
         #
-        # @see https://www.elastic.co/guide/en/elasticsearch/reference/7.5/indices-delete-index.html
+        # @see https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-delete-index.html
         #
         def delete(arguments = {})
           raise ArgumentError, "Required argument 'index' missing" unless arguments[:index]
+
+          headers = arguments.delete(:headers) || {}
 
           arguments = arguments.clone
 
@@ -32,9 +35,9 @@ module Elasticsearch
 
           body = nil
           if Array(arguments[:ignore]).include?(404)
-            Utils.__rescue_from_not_found { perform_request(method, path, params, body).body }
+            Utils.__rescue_from_not_found { perform_request(method, path, params, body, headers).body }
           else
-            perform_request(method, path, params, body).body
+            perform_request(method, path, params, body, headers).body
           end
         end
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/delete_alias.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/delete_alias.rb
@@ -12,13 +12,15 @@ module Elasticsearch
         # @option arguments [List] :name A comma-separated list of aliases to delete (supports wildcards); use `_all` to delete all aliases for the specified indices.
         # @option arguments [Time] :timeout Explicit timestamp for the document
         # @option arguments [Time] :master_timeout Specify timeout for connection to master
-
+        # @option arguments [Hash] :headers Custom HTTP headers
         #
-        # @see https://www.elastic.co/guide/en/elasticsearch/reference/7.5/indices-aliases.html
+        # @see https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-aliases.html
         #
         def delete_alias(arguments = {})
           raise ArgumentError, "Required argument 'index' missing" unless arguments[:index]
           raise ArgumentError, "Required argument 'name' missing" unless arguments[:name]
+
+          headers = arguments.delete(:headers) || {}
 
           arguments = arguments.clone
 
@@ -33,7 +35,7 @@ module Elasticsearch
           params = Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
 
           body = nil
-          perform_request(method, path, params, body).body
+          perform_request(method, path, params, body, headers).body
         end
 
         # Register this action with its valid params when the module is loaded.

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/delete_data_stream.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/delete_data_stream.rb
@@ -9,12 +9,14 @@ module Elasticsearch
         # Deletes a data stream.
         #
         # @option arguments [String] :name The name of the data stream
-
+        # @option arguments [Hash] :headers Custom HTTP headers
         #
-        # @see https://www.elastic.co/guide/en/elasticsearch/reference/7.5/data-streams.html
+        # @see https://www.elastic.co/guide/en/elasticsearch/reference/master/data-streams.html
         #
         def delete_data_stream(arguments = {})
           raise ArgumentError, "Required argument 'name' missing" unless arguments[:name]
+
+          headers = arguments.delete(:headers) || {}
 
           arguments = arguments.clone
 
@@ -25,7 +27,7 @@ module Elasticsearch
           params = {}
 
           body = nil
-          perform_request(method, path, params, body).body
+          perform_request(method, path, params, body, headers).body
         end
 end
       end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/delete_index_template.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/delete_index_template.rb
@@ -11,12 +11,14 @@ module Elasticsearch
         # @option arguments [String] :name The name of the template
         # @option arguments [Time] :timeout Explicit operation timeout
         # @option arguments [Time] :master_timeout Specify timeout for connection to master
-
+        # @option arguments [Hash] :headers Custom HTTP headers
         #
-        # @see https://www.elastic.co/guide/en/elasticsearch/reference/7.5/indices-templates.html
+        # @see https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-templates.html
         #
         def delete_index_template(arguments = {})
           raise ArgumentError, "Required argument 'name' missing" unless arguments[:name]
+
+          headers = arguments.delete(:headers) || {}
 
           arguments = arguments.clone
 
@@ -27,7 +29,7 @@ module Elasticsearch
           params = Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
 
           body = nil
-          perform_request(method, path, params, body).body
+          perform_request(method, path, params, body, headers).body
         end
 
         # Register this action with its valid params when the module is loaded.

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/delete_template.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/delete_template.rb
@@ -11,12 +11,14 @@ module Elasticsearch
         # @option arguments [String] :name The name of the template
         # @option arguments [Time] :timeout Explicit operation timeout
         # @option arguments [Time] :master_timeout Specify timeout for connection to master
-
+        # @option arguments [Hash] :headers Custom HTTP headers
         #
-        # @see https://www.elastic.co/guide/en/elasticsearch/reference/7.5/indices-templates.html
+        # @see https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-templates.html
         #
         def delete_template(arguments = {})
           raise ArgumentError, "Required argument 'name' missing" unless arguments[:name]
+
+          headers = arguments.delete(:headers) || {}
 
           arguments = arguments.clone
 
@@ -28,9 +30,9 @@ module Elasticsearch
 
           body = nil
           if Array(arguments[:ignore]).include?(404)
-            Utils.__rescue_from_not_found { perform_request(method, path, params, body).body }
+            Utils.__rescue_from_not_found { perform_request(method, path, params, body, headers).body }
           else
-            perform_request(method, path, params, body).body
+            perform_request(method, path, params, body, headers).body
           end
         end
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/exists.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/exists.rb
@@ -17,12 +17,14 @@ module Elasticsearch
 
         # @option arguments [Boolean] :flat_settings Return settings in flat format (default: false)
         # @option arguments [Boolean] :include_defaults Whether to return all default setting for each of the indices.
-
+        # @option arguments [Hash] :headers Custom HTTP headers
         #
-        # @see https://www.elastic.co/guide/en/elasticsearch/reference/7.5/indices-exists.html
+        # @see https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-exists.html
         #
         def exists(arguments = {})
           raise ArgumentError, "Required argument 'index' missing" unless arguments[:index]
+
+          headers = arguments.delete(:headers) || {}
 
           arguments = arguments.clone
 
@@ -35,7 +37,7 @@ module Elasticsearch
           body = nil
 
           Utils.__rescue_from_not_found do
-            perform_request(method, path, params, body).status == 200 ? true : false
+            perform_request(method, path, params, body, headers).status == 200 ? true : false
           end
         end
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/exists_alias.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/exists_alias.rb
@@ -16,12 +16,14 @@ module Elasticsearch
         #   (options: open,closed,hidden,none,all)
 
         # @option arguments [Boolean] :local Return local information, do not retrieve the state from master node (default: false)
-
+        # @option arguments [Hash] :headers Custom HTTP headers
         #
-        # @see https://www.elastic.co/guide/en/elasticsearch/reference/7.5/indices-aliases.html
+        # @see https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-aliases.html
         #
         def exists_alias(arguments = {})
           raise ArgumentError, "Required argument 'name' missing" unless arguments[:name]
+
+          headers = arguments.delete(:headers) || {}
 
           arguments = arguments.clone
 
@@ -40,7 +42,7 @@ module Elasticsearch
           body = nil
 
           Utils.__rescue_from_not_found do
-            perform_request(method, path, params, body).status == 200 ? true : false
+            perform_request(method, path, params, body, headers).status == 200 ? true : false
           end
         end
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/exists_template.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/exists_template.rb
@@ -12,12 +12,14 @@ module Elasticsearch
         # @option arguments [Boolean] :flat_settings Return settings in flat format (default: false)
         # @option arguments [Time] :master_timeout Explicit operation timeout for connection to master node
         # @option arguments [Boolean] :local Return local information, do not retrieve the state from master node (default: false)
-
+        # @option arguments [Hash] :headers Custom HTTP headers
         #
-        # @see https://www.elastic.co/guide/en/elasticsearch/reference/7.5/indices-templates.html
+        # @see https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-templates.html
         #
         def exists_template(arguments = {})
           raise ArgumentError, "Required argument 'name' missing" unless arguments[:name]
+
+          headers = arguments.delete(:headers) || {}
 
           arguments = arguments.clone
 
@@ -30,7 +32,7 @@ module Elasticsearch
           body = nil
 
           Utils.__rescue_from_not_found do
-            perform_request(method, path, params, body).status == 200 ? true : false
+            perform_request(method, path, params, body, headers).status == 200 ? true : false
           end
         end
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/exists_type.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/exists_type.rb
@@ -16,13 +16,15 @@ module Elasticsearch
         #   (options: open,closed,hidden,none,all)
 
         # @option arguments [Boolean] :local Return local information, do not retrieve the state from master node (default: false)
-
+        # @option arguments [Hash] :headers Custom HTTP headers
         #
-        # @see https://www.elastic.co/guide/en/elasticsearch/reference/7.5/indices-types-exists.html
+        # @see https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-types-exists.html
         #
         def exists_type(arguments = {})
           raise ArgumentError, "Required argument 'index' missing" unless arguments[:index]
           raise ArgumentError, "Required argument 'type' missing" unless arguments[:type]
+
+          headers = arguments.delete(:headers) || {}
 
           arguments = arguments.clone
 
@@ -37,7 +39,7 @@ module Elasticsearch
           body = nil
 
           Utils.__rescue_from_not_found do
-            perform_request(method, path, params, body).status == 200 ? true : false
+            perform_request(method, path, params, body, headers).status == 200 ? true : false
           end
         end
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/flush.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/flush.rb
@@ -16,10 +16,13 @@ module Elasticsearch
         # @option arguments [String] :expand_wildcards Whether to expand wildcard expression to concrete indices that are open, closed or both.
         #   (options: open,closed,hidden,none,all)
 
+        # @option arguments [Hash] :headers Custom HTTP headers
         #
-        # @see https://www.elastic.co/guide/en/elasticsearch/reference/7.5/indices-flush.html
+        # @see https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-flush.html
         #
         def flush(arguments = {})
+          headers = arguments.delete(:headers) || {}
+
           arguments = arguments.clone
 
           _index = arguments.delete(:index)
@@ -29,11 +32,11 @@ module Elasticsearch
                      "#{Utils.__listify(_index)}/_flush"
                    else
                      "_flush"
-end
+      end
           params = Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
 
           body = nil
-          perform_request(method, path, params, body).body
+          perform_request(method, path, params, body, headers).body
         end
 
         # Register this action with its valid params when the module is loaded.

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/flush_synced.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/flush_synced.rb
@@ -14,10 +14,13 @@ module Elasticsearch
         # @option arguments [String] :expand_wildcards Whether to expand wildcard expression to concrete indices that are open, closed or both.
         #   (options: open,closed,none,all)
 
+        # @option arguments [Hash] :headers Custom HTTP headers
         #
-        # @see https://www.elastic.co/guide/en/elasticsearch/reference/7.5/indices-synced-flush-api.html
+        # @see https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-synced-flush-api.html
         #
         def flush_synced(arguments = {})
+          headers = arguments.delete(:headers) || {}
+
           arguments = arguments.clone
 
           _index = arguments.delete(:index)
@@ -27,14 +30,14 @@ module Elasticsearch
                      "#{Utils.__listify(_index)}/_flush/synced"
                    else
                      "_flush/synced"
-end
+      end
           params = Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
 
           body = nil
           if Array(arguments[:ignore]).include?(404)
-            Utils.__rescue_from_not_found { perform_request(method, path, params, body).body }
+            Utils.__rescue_from_not_found { perform_request(method, path, params, body, headers).body }
           else
-            perform_request(method, path, params, body).body
+            perform_request(method, path, params, body, headers).body
           end
         end
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/forcemerge.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/forcemerge.rb
@@ -17,11 +17,13 @@ module Elasticsearch
 
         # @option arguments [Number] :max_num_segments The number of segments the index should be merged into (default: dynamic)
         # @option arguments [Boolean] :only_expunge_deletes Specify whether the operation should only expunge deleted documents
-
+        # @option arguments [Hash] :headers Custom HTTP headers
         #
-        # @see https://www.elastic.co/guide/en/elasticsearch/reference/7.5/indices-forcemerge.html
+        # @see https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-forcemerge.html
         #
         def forcemerge(arguments = {})
+          headers = arguments.delete(:headers) || {}
+
           arguments = arguments.clone
 
           _index = arguments.delete(:index)
@@ -31,11 +33,11 @@ module Elasticsearch
                      "#{Utils.__listify(_index)}/_forcemerge"
                    else
                      "_forcemerge"
-end
+      end
           params = Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
 
           body = nil
-          perform_request(method, path, params, body).body
+          perform_request(method, path, params, body, headers).body
         end
 
         # Register this action with its valid params when the module is loaded.

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/get.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/get.rb
@@ -19,12 +19,14 @@ module Elasticsearch
         # @option arguments [Boolean] :flat_settings Return settings in flat format (default: false)
         # @option arguments [Boolean] :include_defaults Whether to return all default setting for each of the indices.
         # @option arguments [Time] :master_timeout Specify timeout for connection to master
-
+        # @option arguments [Hash] :headers Custom HTTP headers
         #
-        # @see https://www.elastic.co/guide/en/elasticsearch/reference/7.5/indices-get-index.html
+        # @see https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-get-index.html
         #
         def get(arguments = {})
           raise ArgumentError, "Required argument 'index' missing" unless arguments[:index]
+
+          headers = arguments.delete(:headers) || {}
 
           arguments = arguments.clone
 
@@ -35,7 +37,7 @@ module Elasticsearch
           params = Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
 
           body = nil
-          perform_request(method, path, params, body).body
+          perform_request(method, path, params, body, headers).body
         end
 
         # Register this action with its valid params when the module is loaded.

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/get_alias.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/get_alias.rb
@@ -16,11 +16,13 @@ module Elasticsearch
         #   (options: open,closed,hidden,none,all)
 
         # @option arguments [Boolean] :local Return local information, do not retrieve the state from master node (default: false)
-
+        # @option arguments [Hash] :headers Custom HTTP headers
         #
-        # @see https://www.elastic.co/guide/en/elasticsearch/reference/7.5/indices-aliases.html
+        # @see https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-aliases.html
         #
         def get_alias(arguments = {})
+          headers = arguments.delete(:headers) || {}
+
           arguments = arguments.clone
 
           _name = arguments.delete(:name)
@@ -36,11 +38,11 @@ module Elasticsearch
                      "_alias/#{Utils.__listify(_name)}"
                    else
                      "_alias"
-end
+      end
           params = Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
 
           body = nil
-          perform_request(method, path, params, body).body
+          perform_request(method, path, params, body, headers).body
         end
 
         # Register this action with its valid params when the module is loaded.

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/get_data_streams.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/get_data_streams.rb
@@ -8,12 +8,14 @@ module Elasticsearch
       module Actions
         # Returns data streams.
         #
-        # @option arguments [List] :name The comma separated names of data streams
-
+        # @option arguments [String] :name The name or wildcard expression of the requested data streams
+        # @option arguments [Hash] :headers Custom HTTP headers
         #
-        # @see https://www.elastic.co/guide/en/elasticsearch/reference/7.5/data-streams.html
+        # @see https://www.elastic.co/guide/en/elasticsearch/reference/master/data-streams.html
         #
         def get_data_streams(arguments = {})
+          headers = arguments.delete(:headers) || {}
+
           arguments = arguments.clone
 
           _name = arguments.delete(:name)
@@ -23,11 +25,11 @@ module Elasticsearch
                      "_data_streams/#{Utils.__listify(_name)}"
                    else
                      "_data_streams"
-end
+      end
           params = {}
 
           body = nil
-          perform_request(method, path, params, body).body
+          perform_request(method, path, params, body, headers).body
         end
 end
       end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/get_field_mapping.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/get_field_mapping.rb
@@ -19,18 +19,20 @@ module Elasticsearch
         #   (options: open,closed,hidden,none,all)
 
         # @option arguments [Boolean] :local Return local information, do not retrieve the state from master node (default: false)
-
+        # @option arguments [Hash] :headers Custom HTTP headers
         #
         # *Deprecation notice*:
         # Specifying types in urls has been deprecated
         # Deprecated since version 7.0.0
         #
         #
-        # @see https://www.elastic.co/guide/en/elasticsearch/reference/7.5/indices-get-field-mapping.html
+        # @see https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-get-field-mapping.html
         #
         def get_field_mapping(arguments = {})
           _fields = arguments.delete(:field) || arguments.delete(:fields)
           raise ArgumentError, "Required argument 'field' missing" unless _fields
+
+          headers = arguments.delete(:headers) || {}
 
           arguments = arguments.clone
 
@@ -51,7 +53,7 @@ module Elasticsearch
           params = Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
 
           body = nil
-          perform_request(method, path, params, body).body
+          perform_request(method, path, params, body, headers).body
         end
 
         # Register this action with its valid params when the module is loaded.

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/get_index_template.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/get_index_template.rb
@@ -12,11 +12,13 @@ module Elasticsearch
         # @option arguments [Boolean] :flat_settings Return settings in flat format (default: false)
         # @option arguments [Time] :master_timeout Explicit operation timeout for connection to master node
         # @option arguments [Boolean] :local Return local information, do not retrieve the state from master node (default: false)
-
+        # @option arguments [Hash] :headers Custom HTTP headers
         #
-        # @see https://www.elastic.co/guide/en/elasticsearch/reference/7.5/indices-templates.html
+        # @see https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-templates.html
         #
         def get_index_template(arguments = {})
+          headers = arguments.delete(:headers) || {}
+
           arguments = arguments.clone
 
           _name = arguments.delete(:name)
@@ -26,11 +28,11 @@ module Elasticsearch
                      "_index_template/#{Utils.__listify(_name)}"
                    else
                      "_index_template"
-end
+      end
           params = Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
 
           body = nil
-          perform_request(method, path, params, body).body
+          perform_request(method, path, params, body, headers).body
         end
 
         # Register this action with its valid params when the module is loaded.

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/get_mapping.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/get_mapping.rb
@@ -18,16 +18,18 @@ module Elasticsearch
 
         # @option arguments [Time] :master_timeout Specify timeout for connection to master
         # @option arguments [Boolean] :local Return local information, do not retrieve the state from master node (default: false)
-
+        # @option arguments [Hash] :headers Custom HTTP headers
         #
         # *Deprecation notice*:
         # Specifying types in urls has been deprecated
         # Deprecated since version 7.0.0
         #
         #
-        # @see https://www.elastic.co/guide/en/elasticsearch/reference/7.5/indices-get-mapping.html
+        # @see https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-get-mapping.html
         #
         def get_mapping(arguments = {})
+          headers = arguments.delete(:headers) || {}
+
           arguments = arguments.clone
 
           _index = arguments.delete(:index)
@@ -43,11 +45,11 @@ module Elasticsearch
                      "_mapping/#{Utils.__listify(_type)}"
                    else
                      "_mapping"
-end
+      end
           params = Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
 
           body = nil
-          perform_request(method, path, params, body).body
+          perform_request(method, path, params, body, headers).body
         end
 
         # Register this action with its valid params when the module is loaded.

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/get_settings.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/get_settings.rb
@@ -19,11 +19,13 @@ module Elasticsearch
         # @option arguments [Boolean] :flat_settings Return settings in flat format (default: false)
         # @option arguments [Boolean] :local Return local information, do not retrieve the state from master node (default: false)
         # @option arguments [Boolean] :include_defaults Whether to return all default setting for each of the indices.
-
+        # @option arguments [Hash] :headers Custom HTTP headers
         #
-        # @see https://www.elastic.co/guide/en/elasticsearch/reference/7.5/indices-get-settings.html
+        # @see https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-get-settings.html
         #
         def get_settings(arguments = {})
+          headers = arguments.delete(:headers) || {}
+
           arguments = arguments.clone
 
           _index = arguments.delete(:index)
@@ -39,11 +41,11 @@ module Elasticsearch
                      "_settings/#{Utils.__listify(_name)}"
                    else
                      "_settings"
-end
+      end
           params = Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
 
           body = nil
-          perform_request(method, path, params, body).body
+          perform_request(method, path, params, body, headers).body
         end
 
         # Register this action with its valid params when the module is loaded.

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/get_template.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/get_template.rb
@@ -13,11 +13,13 @@ module Elasticsearch
         # @option arguments [Boolean] :flat_settings Return settings in flat format (default: false)
         # @option arguments [Time] :master_timeout Explicit operation timeout for connection to master node
         # @option arguments [Boolean] :local Return local information, do not retrieve the state from master node (default: false)
-
+        # @option arguments [Hash] :headers Custom HTTP headers
         #
-        # @see https://www.elastic.co/guide/en/elasticsearch/reference/7.5/indices-templates.html
+        # @see https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-templates.html
         #
         def get_template(arguments = {})
+          headers = arguments.delete(:headers) || {}
+
           arguments = arguments.clone
 
           _name = arguments.delete(:name)
@@ -27,11 +29,11 @@ module Elasticsearch
                      "_template/#{Utils.__listify(_name)}"
                    else
                      "_template"
-end
+      end
           params = Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
 
           body = nil
-          perform_request(method, path, params, body).body
+          perform_request(method, path, params, body, headers).body
         end
 
         # Register this action with its valid params when the module is loaded.

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/get_upgrade.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/get_upgrade.rb
@@ -14,10 +14,13 @@ module Elasticsearch
         # @option arguments [String] :expand_wildcards Whether to expand wildcard expression to concrete indices that are open, closed or both.
         #   (options: open,closed,hidden,none,all)
 
+        # @option arguments [Hash] :headers Custom HTTP headers
         #
-        # @see https://www.elastic.co/guide/en/elasticsearch/reference/7.5/indices-upgrade.html
+        # @see https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-upgrade.html
         #
         def get_upgrade(arguments = {})
+          headers = arguments.delete(:headers) || {}
+
           arguments = arguments.clone
 
           _index = arguments.delete(:index)
@@ -27,11 +30,11 @@ module Elasticsearch
                      "#{Utils.__listify(_index)}/_upgrade"
                    else
                      "_upgrade"
-end
+      end
           params = Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
 
           body = nil
-          perform_request(method, path, params, body).body
+          perform_request(method, path, params, body, headers).body
         end
 
         # Register this action with its valid params when the module is loaded.

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/open.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/open.rb
@@ -17,12 +17,14 @@ module Elasticsearch
         #   (options: open,closed,hidden,none,all)
 
         # @option arguments [String] :wait_for_active_shards Sets the number of active shards to wait for before the operation returns.
-
+        # @option arguments [Hash] :headers Custom HTTP headers
         #
-        # @see https://www.elastic.co/guide/en/elasticsearch/reference/7.5/indices-open-close.html
+        # @see https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-open-close.html
         #
         def open(arguments = {})
           raise ArgumentError, "Required argument 'index' missing" unless arguments[:index]
+
+          headers = arguments.delete(:headers) || {}
 
           arguments = arguments.clone
 
@@ -33,7 +35,7 @@ module Elasticsearch
           params = Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
 
           body = nil
-          perform_request(method, path, params, body).body
+          perform_request(method, path, params, body, headers).body
         end
 
         # Register this action with its valid params when the module is loaded.

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/put_alias.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/put_alias.rb
@@ -12,14 +12,16 @@ module Elasticsearch
         # @option arguments [String] :name The name of the alias to be created or updated
         # @option arguments [Time] :timeout Explicit timestamp for the document
         # @option arguments [Time] :master_timeout Specify timeout for connection to master
-
+        # @option arguments [Hash] :headers Custom HTTP headers
         # @option arguments [Hash] :body The settings for the alias, such as `routing` or `filter`
         #
-        # @see https://www.elastic.co/guide/en/elasticsearch/reference/7.5/indices-aliases.html
+        # @see https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-aliases.html
         #
         def put_alias(arguments = {})
           raise ArgumentError, "Required argument 'index' missing" unless arguments[:index]
           raise ArgumentError, "Required argument 'name' missing" unless arguments[:name]
+
+          headers = arguments.delete(:headers) || {}
 
           arguments = arguments.clone
 
@@ -34,7 +36,7 @@ module Elasticsearch
           params = Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
 
           body = arguments[:body]
-          perform_request(method, path, params, body).body
+          perform_request(method, path, params, body, headers).body
         end
 
         # Register this action with its valid params when the module is loaded.

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/put_index_template.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/put_index_template.rb
@@ -12,14 +12,16 @@ module Elasticsearch
         # @option arguments [Number] :order The order for this template when merging multiple matching ones (higher numbers are merged later, overriding the lower numbers)
         # @option arguments [Boolean] :create Whether the index template should only be added if new or can also replace an existing one
         # @option arguments [Time] :master_timeout Specify timeout for connection to master
-
+        # @option arguments [Hash] :headers Custom HTTP headers
         # @option arguments [Hash] :body The template definition (*Required*)
         #
-        # @see https://www.elastic.co/guide/en/elasticsearch/reference/7.5/indices-templates.html
+        # @see https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-templates.html
         #
         def put_index_template(arguments = {})
           raise ArgumentError, "Required argument 'body' missing" unless arguments[:body]
           raise ArgumentError, "Required argument 'name' missing" unless arguments[:name]
+
+          headers = arguments.delete(:headers) || {}
 
           arguments = arguments.clone
 
@@ -30,7 +32,7 @@ module Elasticsearch
           params = Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
 
           body = arguments[:body]
-          perform_request(method, path, params, body).body
+          perform_request(method, path, params, body, headers).body
         end
 
         # Register this action with its valid params when the module is loaded.

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/put_mapping.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/put_mapping.rb
@@ -18,6 +18,7 @@ module Elasticsearch
         # @option arguments [String] :expand_wildcards Whether to expand wildcard expression to concrete indices that are open, closed or both.
         #   (options: open,closed,hidden,none,all)
 
+        # @option arguments [Hash] :headers Custom HTTP headers
         # @option arguments [Hash] :body The mapping definition (*Required*)
         #
         # *Deprecation notice*:
@@ -25,10 +26,12 @@ module Elasticsearch
         # Deprecated since version 7.0.0
         #
         #
-        # @see https://www.elastic.co/guide/en/elasticsearch/reference/7.5/indices-put-mapping.html
+        # @see https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-put-mapping.html
         #
         def put_mapping(arguments = {})
           raise ArgumentError, "Required argument 'body' missing" unless arguments[:body]
+
+          headers = arguments.delete(:headers) || {}
 
           arguments = arguments.clone
 
@@ -47,7 +50,7 @@ module Elasticsearch
           params = Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
 
           body = arguments[:body]
-          perform_request(method, path, params, body).body
+          perform_request(method, path, params, body, headers).body
         end
 
         # Register this action with its valid params when the module is loaded.

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/put_settings.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/put_settings.rb
@@ -18,13 +18,15 @@ module Elasticsearch
         #   (options: open,closed,hidden,none,all)
 
         # @option arguments [Boolean] :flat_settings Return settings in flat format (default: false)
-
+        # @option arguments [Hash] :headers Custom HTTP headers
         # @option arguments [Hash] :body The index settings to be updated (*Required*)
         #
-        # @see https://www.elastic.co/guide/en/elasticsearch/reference/7.5/indices-update-settings.html
+        # @see https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-update-settings.html
         #
         def put_settings(arguments = {})
           raise ArgumentError, "Required argument 'body' missing" unless arguments[:body]
+
+          headers = arguments.delete(:headers) || {}
 
           arguments = arguments.clone
 
@@ -39,7 +41,7 @@ module Elasticsearch
           params = Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
 
           body = arguments[:body]
-          perform_request(method, path, params, body).body
+          perform_request(method, path, params, body, headers).body
         end
 
         # Register this action with its valid params when the module is loaded.

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/put_template.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/put_template.rb
@@ -13,14 +13,16 @@ module Elasticsearch
         # @option arguments [Number] :order The order for this template when merging multiple matching ones (higher numbers are merged later, overriding the lower numbers)
         # @option arguments [Boolean] :create Whether the index template should only be added if new or can also replace an existing one
         # @option arguments [Time] :master_timeout Specify timeout for connection to master
-
+        # @option arguments [Hash] :headers Custom HTTP headers
         # @option arguments [Hash] :body The template definition (*Required*)
         #
-        # @see https://www.elastic.co/guide/en/elasticsearch/reference/7.5/indices-templates.html
+        # @see https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-templates.html
         #
         def put_template(arguments = {})
           raise ArgumentError, "Required argument 'body' missing" unless arguments[:body]
           raise ArgumentError, "Required argument 'name' missing" unless arguments[:name]
+
+          headers = arguments.delete(:headers) || {}
 
           arguments = arguments.clone
 
@@ -31,7 +33,7 @@ module Elasticsearch
           params = Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
 
           body = arguments[:body]
-          perform_request(method, path, params, body).body
+          perform_request(method, path, params, body, headers).body
         end
 
         # Register this action with its valid params when the module is loaded.

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/recovery.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/recovery.rb
@@ -11,11 +11,13 @@ module Elasticsearch
         # @option arguments [List] :index A comma-separated list of index names; use `_all` or empty string to perform the operation on all indices
         # @option arguments [Boolean] :detailed Whether to display detailed information about shard recovery
         # @option arguments [Boolean] :active_only Display only those recoveries that are currently on-going
-
+        # @option arguments [Hash] :headers Custom HTTP headers
         #
-        # @see https://www.elastic.co/guide/en/elasticsearch/reference/7.5/indices-recovery.html
+        # @see https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-recovery.html
         #
         def recovery(arguments = {})
+          headers = arguments.delete(:headers) || {}
+
           arguments = arguments.clone
 
           _index = arguments.delete(:index)
@@ -25,11 +27,11 @@ module Elasticsearch
                      "#{Utils.__listify(_index)}/_recovery"
                    else
                      "_recovery"
-end
+      end
           params = Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
 
           body = nil
-          perform_request(method, path, params, body).body
+          perform_request(method, path, params, body, headers).body
         end
 
         # Register this action with its valid params when the module is loaded.

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/refresh.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/refresh.rb
@@ -14,10 +14,13 @@ module Elasticsearch
         # @option arguments [String] :expand_wildcards Whether to expand wildcard expression to concrete indices that are open, closed or both.
         #   (options: open,closed,hidden,none,all)
 
+        # @option arguments [Hash] :headers Custom HTTP headers
         #
-        # @see https://www.elastic.co/guide/en/elasticsearch/reference/7.5/indices-refresh.html
+        # @see https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-refresh.html
         #
         def refresh(arguments = {})
+          headers = arguments.delete(:headers) || {}
+
           arguments = arguments.clone
 
           _index = arguments.delete(:index)
@@ -27,11 +30,11 @@ module Elasticsearch
                      "#{Utils.__listify(_index)}/_refresh"
                    else
                      "_refresh"
-end
+      end
           params = Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
 
           body = nil
-          perform_request(method, path, params, body).body
+          perform_request(method, path, params, body, headers).body
         end
 
         # Register this action with its valid params when the module is loaded.

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/rollover.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/rollover.rb
@@ -16,13 +16,15 @@ module Elasticsearch
         # @option arguments [Boolean] :dry_run If set to true the rollover action will only be validated but not actually performed even if a condition matches. The default is false
         # @option arguments [Time] :master_timeout Specify timeout for connection to master
         # @option arguments [String] :wait_for_active_shards Set the number of active shards to wait for on the newly created rollover index before the operation returns.
-
+        # @option arguments [Hash] :headers Custom HTTP headers
         # @option arguments [Hash] :body The conditions that needs to be met for executing rollover
         #
-        # @see https://www.elastic.co/guide/en/elasticsearch/reference/7.5/indices-rollover-index.html
+        # @see https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-rollover-index.html
         #
         def rollover(arguments = {})
           raise ArgumentError, "Required argument 'alias' missing" unless arguments[:alias]
+
+          headers = arguments.delete(:headers) || {}
 
           arguments = arguments.clone
 
@@ -39,7 +41,7 @@ module Elasticsearch
           params = Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
 
           body = arguments[:body]
-          perform_request(method, path, params, body).body
+          perform_request(method, path, params, body, headers).body
         end
 
         # Register this action with its valid params when the module is loaded.

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/segments.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/segments.rb
@@ -15,11 +15,13 @@ module Elasticsearch
         #   (options: open,closed,hidden,none,all)
 
         # @option arguments [Boolean] :verbose Includes detailed memory usage by Lucene.
-
+        # @option arguments [Hash] :headers Custom HTTP headers
         #
-        # @see https://www.elastic.co/guide/en/elasticsearch/reference/7.5/indices-segments.html
+        # @see https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-segments.html
         #
         def segments(arguments = {})
+          headers = arguments.delete(:headers) || {}
+
           arguments = arguments.clone
 
           _index = arguments.delete(:index)
@@ -29,11 +31,11 @@ module Elasticsearch
                      "#{Utils.__listify(_index)}/_segments"
                    else
                      "_segments"
-end
+      end
           params = Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
 
           body = nil
-          perform_request(method, path, params, body).body
+          perform_request(method, path, params, body, headers).body
         end
 
         # Register this action with its valid params when the module is loaded.

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/shard_stores.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/shard_stores.rb
@@ -17,10 +17,13 @@ module Elasticsearch
         # @option arguments [String] :expand_wildcards Whether to expand wildcard expression to concrete indices that are open, closed or both.
         #   (options: open,closed,hidden,none,all)
 
+        # @option arguments [Hash] :headers Custom HTTP headers
         #
-        # @see https://www.elastic.co/guide/en/elasticsearch/reference/7.5/indices-shards-stores.html
+        # @see https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-shards-stores.html
         #
         def shard_stores(arguments = {})
+          headers = arguments.delete(:headers) || {}
+
           arguments = arguments.clone
 
           _index = arguments.delete(:index)
@@ -30,11 +33,11 @@ module Elasticsearch
                      "#{Utils.__listify(_index)}/_shard_stores"
                    else
                      "_shard_stores"
-end
+      end
           params = Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
 
           body = nil
-          perform_request(method, path, params, body).body
+          perform_request(method, path, params, body, headers).body
         end
 
         # Register this action with its valid params when the module is loaded.

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/shrink.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/shrink.rb
@@ -14,14 +14,16 @@ module Elasticsearch
         # @option arguments [Time] :timeout Explicit operation timeout
         # @option arguments [Time] :master_timeout Specify timeout for connection to master
         # @option arguments [String] :wait_for_active_shards Set the number of active shards to wait for on the shrunken index before the operation returns.
-
+        # @option arguments [Hash] :headers Custom HTTP headers
         # @option arguments [Hash] :body The configuration for the target index (`settings` and `aliases`)
         #
-        # @see https://www.elastic.co/guide/en/elasticsearch/reference/7.5/indices-shrink-index.html
+        # @see https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-shrink-index.html
         #
         def shrink(arguments = {})
           raise ArgumentError, "Required argument 'index' missing" unless arguments[:index]
           raise ArgumentError, "Required argument 'target' missing" unless arguments[:target]
+
+          headers = arguments.delete(:headers) || {}
 
           arguments = arguments.clone
 
@@ -34,7 +36,7 @@ module Elasticsearch
           params = Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
 
           body = arguments[:body]
-          perform_request(method, path, params, body).body
+          perform_request(method, path, params, body, headers).body
         end
 
         # Register this action with its valid params when the module is loaded.

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/split.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/split.rb
@@ -14,14 +14,16 @@ module Elasticsearch
         # @option arguments [Time] :timeout Explicit operation timeout
         # @option arguments [Time] :master_timeout Specify timeout for connection to master
         # @option arguments [String] :wait_for_active_shards Set the number of active shards to wait for on the shrunken index before the operation returns.
-
+        # @option arguments [Hash] :headers Custom HTTP headers
         # @option arguments [Hash] :body The configuration for the target index (`settings` and `aliases`)
         #
-        # @see https://www.elastic.co/guide/en/elasticsearch/reference/7.5/indices-split-index.html
+        # @see https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-split-index.html
         #
         def split(arguments = {})
           raise ArgumentError, "Required argument 'index' missing" unless arguments[:index]
           raise ArgumentError, "Required argument 'target' missing" unless arguments[:target]
+
+          headers = arguments.delete(:headers) || {}
 
           arguments = arguments.clone
 
@@ -34,7 +36,7 @@ module Elasticsearch
           params = Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
 
           body = arguments[:body]
-          perform_request(method, path, params, body).body
+          perform_request(method, path, params, body, headers).body
         end
 
         # Register this action with its valid params when the module is loaded.

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/stats.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/stats.rb
@@ -26,11 +26,13 @@ module Elasticsearch
         #   (options: open,closed,hidden,none,all)
 
         # @option arguments [Boolean] :forbid_closed_indices If set to false stats will also collected from closed indices if explicitly specified or if expand_wildcards expands to closed indices
-
+        # @option arguments [Hash] :headers Custom HTTP headers
         #
-        # @see https://www.elastic.co/guide/en/elasticsearch/reference/7.5/indices-stats.html
+        # @see https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-stats.html
         #
         def stats(arguments = {})
+          headers = arguments.delete(:headers) || {}
+
           method = HTTP_GET
           parts  = Utils.__extract_parts arguments, ParamsRegistry.get(:stats_parts)
           path   = Utils.__pathify Utils.__listify(arguments[:index]), '_stats', Utils.__listify(parts)
@@ -39,7 +41,7 @@ module Elasticsearch
           params[:groups] = Utils.__listify(params[:groups], :escape => false) if params[:groups]
 
           body = nil
-          perform_request(method, path, params, body).body
+          perform_request(method, path, params, body, headers).body
         end
 
         # Register this action with its valid params when the module is loaded.

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/update_aliases.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/update_aliases.rb
@@ -10,13 +10,15 @@ module Elasticsearch
         #
         # @option arguments [Time] :timeout Request timeout
         # @option arguments [Time] :master_timeout Specify timeout for connection to master
-
+        # @option arguments [Hash] :headers Custom HTTP headers
         # @option arguments [Hash] :body The definition of `actions` to perform (*Required*)
         #
-        # @see https://www.elastic.co/guide/en/elasticsearch/reference/7.5/indices-aliases.html
+        # @see https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-aliases.html
         #
         def update_aliases(arguments = {})
           raise ArgumentError, "Required argument 'body' missing" unless arguments[:body]
+
+          headers = arguments.delete(:headers) || {}
 
           arguments = arguments.clone
 
@@ -25,7 +27,7 @@ module Elasticsearch
           params = Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
 
           body = arguments[:body]
-          perform_request(method, path, params, body).body
+          perform_request(method, path, params, body, headers).body
         end
 
         # Register this action with its valid params when the module is loaded.

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/upgrade.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/upgrade.rb
@@ -16,11 +16,13 @@ module Elasticsearch
         # @option arguments [Boolean] :ignore_unavailable Whether specified concrete indices should be ignored when unavailable (missing or closed)
         # @option arguments [Boolean] :wait_for_completion Specify whether the request should block until the all segments are upgraded (default: false)
         # @option arguments [Boolean] :only_ancient_segments If true, only ancient (an older Lucene major release) segments will be upgraded
-
+        # @option arguments [Hash] :headers Custom HTTP headers
         #
-        # @see https://www.elastic.co/guide/en/elasticsearch/reference/7.5/indices-upgrade.html
+        # @see https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-upgrade.html
         #
         def upgrade(arguments = {})
+          headers = arguments.delete(:headers) || {}
+
           arguments = arguments.clone
 
           _index = arguments.delete(:index)
@@ -30,11 +32,11 @@ module Elasticsearch
                      "#{Utils.__listify(_index)}/_upgrade"
                    else
                      "_upgrade"
-end
+      end
           params = Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
 
           body = nil
-          perform_request(method, path, params, body).body
+          perform_request(method, path, params, body, headers).body
         end
 
         # Register this action with its valid params when the module is loaded.

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/validate_query.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/validate_query.rb
@@ -26,7 +26,7 @@ module Elasticsearch
         # @option arguments [Boolean] :lenient Specify whether format-based query failures (such as providing text to a numeric field) should be ignored
         # @option arguments [Boolean] :rewrite Provide a more detailed explanation showing the actual Lucene query that will be executed.
         # @option arguments [Boolean] :all_shards Execute validation on all shards instead of one random shard per index
-
+        # @option arguments [Hash] :headers Custom HTTP headers
         # @option arguments [Hash] :body The query definition specified with the Query DSL
         #
         # *Deprecation notice*:
@@ -34,9 +34,11 @@ module Elasticsearch
         # Deprecated since version 7.0.0
         #
         #
-        # @see https://www.elastic.co/guide/en/elasticsearch/reference/7.5/search-validate.html
+        # @see https://www.elastic.co/guide/en/elasticsearch/reference/master/search-validate.html
         #
         def validate_query(arguments = {})
+          headers = arguments.delete(:headers) || {}
+
           arguments = arguments.clone
 
           _index = arguments.delete(:index)
@@ -50,11 +52,11 @@ module Elasticsearch
                      "#{Utils.__listify(_index)}/_validate/query"
                    else
                      "_validate/query"
-end
+      end
           params = Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
 
           body = arguments[:body]
-          perform_request(method, path, params, body).body
+          perform_request(method, path, params, body, headers).body
         end
 
         # Register this action with its valid params when the module is loaded.

--- a/elasticsearch-api/lib/elasticsearch/api/actions/info.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/info.rb
@@ -7,11 +7,13 @@ module Elasticsearch
     module Actions
       # Returns basic information about the cluster.
       #
-
+      # @option arguments [Hash] :headers Custom HTTP headers
       #
-      # @see https://www.elastic.co/guide/en/elasticsearch/reference/7.5/index.html
+      # @see https://www.elastic.co/guide/en/elasticsearch/reference/current/index.html
       #
       def info(arguments = {})
+        headers = arguments.delete(:headers) || {}
+
         arguments = arguments.clone
 
         method = Elasticsearch::API::HTTP_GET
@@ -19,7 +21,7 @@ module Elasticsearch
         params = {}
 
         body = nil
-        perform_request(method, path, params, body).body
+        perform_request(method, path, params, body, headers).body
       end
     end
     end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/ingest/delete_pipeline.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/ingest/delete_pipeline.rb
@@ -11,12 +11,14 @@ module Elasticsearch
         # @option arguments [String] :id Pipeline ID
         # @option arguments [Time] :master_timeout Explicit operation timeout for connection to master node
         # @option arguments [Time] :timeout Explicit operation timeout
-
+        # @option arguments [Hash] :headers Custom HTTP headers
         #
-        # @see https://www.elastic.co/guide/en/elasticsearch/reference/7.5/delete-pipeline-api.html
+        # @see https://www.elastic.co/guide/en/elasticsearch/reference/master/delete-pipeline-api.html
         #
         def delete_pipeline(arguments = {})
           raise ArgumentError, "Required argument 'id' missing" unless arguments[:id]
+
+          headers = arguments.delete(:headers) || {}
 
           arguments = arguments.clone
 
@@ -27,7 +29,7 @@ module Elasticsearch
           params = Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
 
           body = nil
-          perform_request(method, path, params, body).body
+          perform_request(method, path, params, body, headers).body
         end
 
         # Register this action with its valid params when the module is loaded.

--- a/elasticsearch-api/lib/elasticsearch/api/actions/ingest/get_pipeline.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/ingest/get_pipeline.rb
@@ -10,11 +10,13 @@ module Elasticsearch
         #
         # @option arguments [String] :id Comma separated list of pipeline ids. Wildcards supported
         # @option arguments [Time] :master_timeout Explicit operation timeout for connection to master node
-
+        # @option arguments [Hash] :headers Custom HTTP headers
         #
-        # @see https://www.elastic.co/guide/en/elasticsearch/reference/7.5/get-pipeline-api.html
+        # @see https://www.elastic.co/guide/en/elasticsearch/reference/master/get-pipeline-api.html
         #
         def get_pipeline(arguments = {})
+          headers = arguments.delete(:headers) || {}
+
           arguments = arguments.clone
 
           _id = arguments.delete(:id)
@@ -24,11 +26,11 @@ module Elasticsearch
                      "_ingest/pipeline/#{Utils.__listify(_id)}"
                    else
                      "_ingest/pipeline"
-end
+      end
           params = Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
 
           body = nil
-          perform_request(method, path, params, body).body
+          perform_request(method, path, params, body, headers).body
         end
 
         # Register this action with its valid params when the module is loaded.

--- a/elasticsearch-api/lib/elasticsearch/api/actions/ingest/processor_grok.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/ingest/processor_grok.rb
@@ -8,11 +8,13 @@ module Elasticsearch
       module Actions
         # Returns a list of the built-in patterns.
         #
-
+        # @option arguments [Hash] :headers Custom HTTP headers
         #
-        # @see https://www.elastic.co/guide/en/elasticsearch/reference/7.5/grok-processor.html#grok-processor-rest-get
+        # @see https://www.elastic.co/guide/en/elasticsearch/reference/master/grok-processor.html#grok-processor-rest-get
         #
         def processor_grok(arguments = {})
+          headers = arguments.delete(:headers) || {}
+
           arguments = arguments.clone
 
           method = Elasticsearch::API::HTTP_GET
@@ -20,7 +22,7 @@ module Elasticsearch
           params = {}
 
           body = nil
-          perform_request(method, path, params, body).body
+          perform_request(method, path, params, body, headers).body
         end
 end
       end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/ingest/put_pipeline.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/ingest/put_pipeline.rb
@@ -11,14 +11,16 @@ module Elasticsearch
         # @option arguments [String] :id Pipeline ID
         # @option arguments [Time] :master_timeout Explicit operation timeout for connection to master node
         # @option arguments [Time] :timeout Explicit operation timeout
-
+        # @option arguments [Hash] :headers Custom HTTP headers
         # @option arguments [Hash] :body The ingest definition (*Required*)
         #
-        # @see https://www.elastic.co/guide/en/elasticsearch/reference/7.5/put-pipeline-api.html
+        # @see https://www.elastic.co/guide/en/elasticsearch/reference/master/put-pipeline-api.html
         #
         def put_pipeline(arguments = {})
           raise ArgumentError, "Required argument 'body' missing" unless arguments[:body]
           raise ArgumentError, "Required argument 'id' missing" unless arguments[:id]
+
+          headers = arguments.delete(:headers) || {}
 
           arguments = arguments.clone
 
@@ -29,7 +31,7 @@ module Elasticsearch
           params = Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
 
           body = arguments[:body]
-          perform_request(method, path, params, body).body
+          perform_request(method, path, params, body, headers).body
         end
 
         # Register this action with its valid params when the module is loaded.

--- a/elasticsearch-api/lib/elasticsearch/api/actions/ingest/simulate.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/ingest/simulate.rb
@@ -10,13 +10,15 @@ module Elasticsearch
         #
         # @option arguments [String] :id Pipeline ID
         # @option arguments [Boolean] :verbose Verbose mode. Display data output for each processor in executed pipeline
-
+        # @option arguments [Hash] :headers Custom HTTP headers
         # @option arguments [Hash] :body The simulate definition (*Required*)
         #
-        # @see https://www.elastic.co/guide/en/elasticsearch/reference/7.5/simulate-pipeline-api.html
+        # @see https://www.elastic.co/guide/en/elasticsearch/reference/master/simulate-pipeline-api.html
         #
         def simulate(arguments = {})
           raise ArgumentError, "Required argument 'body' missing" unless arguments[:body]
+
+          headers = arguments.delete(:headers) || {}
 
           arguments = arguments.clone
 
@@ -31,7 +33,7 @@ module Elasticsearch
           params = Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
 
           body = arguments[:body]
-          perform_request(method, path, params, body).body
+          perform_request(method, path, params, body, headers).body
         end
 
         # Register this action with its valid params when the module is loaded.

--- a/elasticsearch-api/lib/elasticsearch/api/actions/mget.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/mget.rb
@@ -17,7 +17,7 @@ module Elasticsearch
       # @option arguments [List] :_source True or false to return the _source field or not, or a list of fields to return
       # @option arguments [List] :_source_excludes A list of fields to exclude from the returned _source field
       # @option arguments [List] :_source_includes A list of fields to extract and return from the _source field
-
+      # @option arguments [Hash] :headers Custom HTTP headers
       # @option arguments [Hash] :body Document identifiers; can be either `docs` (containing full document information) or `ids` (when index and type is provided in the URL. (*Required*)
       #
       # *Deprecation notice*:
@@ -25,10 +25,12 @@ module Elasticsearch
       # Deprecated since version 7.0.0
       #
       #
-      # @see https://www.elastic.co/guide/en/elasticsearch/reference/7.5/docs-multi-get.html
+      # @see https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-multi-get.html
       #
       def mget(arguments = {})
         raise ArgumentError, "Required argument 'body' missing" unless arguments[:body]
+
+        headers = arguments.delete(:headers) || {}
 
         arguments = arguments.clone
 
@@ -47,7 +49,7 @@ module Elasticsearch
         params = Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
 
         body = arguments[:body]
-        perform_request(method, path, params, body).body
+        perform_request(method, path, params, body, headers).body
       end
 
       # Register this action with its valid params when the module is loaded.

--- a/elasticsearch-api/lib/elasticsearch/api/actions/msearch.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/msearch.rb
@@ -18,7 +18,7 @@ module Elasticsearch
       # @option arguments [Number] :max_concurrent_shard_requests The number of concurrent shard requests each sub search executes concurrently per node. This value should be used to limit the impact of the search on the cluster in order to limit the number of concurrent shard requests
       # @option arguments [Boolean] :rest_total_hits_as_int Indicates whether hits.total should be rendered as an integer or an object in the rest search response
       # @option arguments [Boolean] :ccs_minimize_roundtrips Indicates whether network round-trips should be minimized as part of cross-cluster search requests execution
-
+      # @option arguments [Hash] :headers Custom HTTP headers
       # @option arguments [Hash] :body The request definitions (metadata-search request definition pairs), separated by newlines (*Required*)
       #
       # *Deprecation notice*:
@@ -26,10 +26,12 @@ module Elasticsearch
       # Deprecated since version 7.0.0
       #
       #
-      # @see https://www.elastic.co/guide/en/elasticsearch/reference/7.5/search-multi-search.html
+      # @see https://www.elastic.co/guide/en/elasticsearch/reference/master/search-multi-search.html
       #
       def msearch(arguments = {})
         raise ArgumentError, "Required argument 'body' missing" unless arguments[:body]
+
+        headers = arguments.delete(:headers) || {}
 
         arguments = arguments.clone
 
@@ -72,7 +74,8 @@ module Elasticsearch
           payload = body
       end
 
-        perform_request(method, path, params, payload, { "Content-Type" => "application/x-ndjson" }).body
+        headers.merge!("Content-Type" => "application/x-ndjson")
+        perform_request(method, path, params, payload, headers).body
       end
 
       # Register this action with its valid params when the module is loaded.

--- a/elasticsearch-api/lib/elasticsearch/api/actions/msearch_template.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/msearch_template.rb
@@ -16,7 +16,7 @@ module Elasticsearch
       # @option arguments [Number] :max_concurrent_searches Controls the maximum number of concurrent searches the multi search api will execute
       # @option arguments [Boolean] :rest_total_hits_as_int Indicates whether hits.total should be rendered as an integer or an object in the rest search response
       # @option arguments [Boolean] :ccs_minimize_roundtrips Indicates whether network round-trips should be minimized as part of cross-cluster search requests execution
-
+      # @option arguments [Hash] :headers Custom HTTP headers
       # @option arguments [Hash] :body The request definitions (metadata-search request definition pairs), separated by newlines (*Required*)
       #
       # *Deprecation notice*:
@@ -24,10 +24,12 @@ module Elasticsearch
       # Deprecated since version 7.0.0
       #
       #
-      # @see https://www.elastic.co/guide/en/elasticsearch/reference/7.5/search-multi-search.html
+      # @see https://www.elastic.co/guide/en/elasticsearch/reference/current/search-multi-search.html
       #
       def msearch_template(arguments = {})
         raise ArgumentError, "Required argument 'body' missing" unless arguments[:body]
+
+        headers = arguments.delete(:headers) || {}
 
         arguments = arguments.clone
 
@@ -56,7 +58,8 @@ module Elasticsearch
           payload = body
       end
 
-        perform_request(method, path, params, payload, { "Content-Type" => "application/x-ndjson" }).body
+        headers.merge!("Content-Type" => "application/x-ndjson")
+        perform_request(method, path, params, payload, headers).body
       end
 
       # Register this action with its valid params when the module is loaded.

--- a/elasticsearch-api/lib/elasticsearch/api/actions/mtermvectors.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/mtermvectors.rb
@@ -23,6 +23,7 @@ module Elasticsearch
       # @option arguments [String] :version_type Specific version type
       #   (options: internal,external,external_gte,force)
 
+      # @option arguments [Hash] :headers Custom HTTP headers
       # @option arguments [Hash] :body Define ids, documents, parameters or a list of parameters per document here. You must at least provide a list of document ids. See documentation.
       #
       # *Deprecation notice*:
@@ -30,9 +31,11 @@ module Elasticsearch
       # Deprecated since version 7.0.0
       #
       #
-      # @see https://www.elastic.co/guide/en/elasticsearch/reference/7.5/docs-multi-termvectors.html
+      # @see https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-multi-termvectors.html
       #
       def mtermvectors(arguments = {})
+        headers = arguments.delete(:headers) || {}
+
         arguments = arguments.clone
         ids = arguments.delete(:ids)
 
@@ -47,7 +50,7 @@ module Elasticsearch
                    "#{Utils.__listify(_index)}/_mtermvectors"
                  else
                    "_mtermvectors"
-end
+    end
         params = Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
 
         if ids
@@ -55,7 +58,7 @@ end
         else
           body = arguments[:body]
     end
-        perform_request(method, path, params, body).body
+        perform_request(method, path, params, body, headers).body
       end
 
       # Register this action with its valid params when the module is loaded.

--- a/elasticsearch-api/lib/elasticsearch/api/actions/nodes/hot_threads.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/nodes/hot_threads.rb
@@ -17,16 +17,18 @@ module Elasticsearch
         #   (options: cpu,wait,block)
 
         # @option arguments [Time] :timeout Explicit operation timeout
-
+        # @option arguments [Hash] :headers Custom HTTP headers
         #
         # *Deprecation notice*:
         # The hot accepts /_cluster/nodes as prefix for backwards compatibility reasons
         # Deprecated since version 7.0.0
         #
         #
-        # @see https://www.elastic.co/guide/en/elasticsearch/reference/7.5/cluster-nodes-hot-threads.html
+        # @see https://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-nodes-hot-threads.html
         #
         def hot_threads(arguments = {})
+          headers = arguments.delete(:headers) || {}
+
           arguments = arguments.clone
 
           _node_id = arguments.delete(:node_id)
@@ -36,11 +38,11 @@ module Elasticsearch
                      "_cluster/nodes/#{Utils.__listify(_node_id)}/hot_threads"
                    else
                      "_cluster/nodes/hot_threads"
-end
+      end
           params = Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
 
           body = nil
-          perform_request(method, path, params, body).body
+          perform_request(method, path, params, body, headers).body
         end
 
         # Register this action with its valid params when the module is loaded.

--- a/elasticsearch-api/lib/elasticsearch/api/actions/nodes/info.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/nodes/info.rb
@@ -14,11 +14,13 @@ module Elasticsearch
 
         # @option arguments [Boolean] :flat_settings Return settings in flat format (default: false)
         # @option arguments [Time] :timeout Explicit operation timeout
-
+        # @option arguments [Hash] :headers Custom HTTP headers
         #
-        # @see https://www.elastic.co/guide/en/elasticsearch/reference/7.5/cluster-nodes-info.html
+        # @see https://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-nodes-info.html
         #
         def info(arguments = {})
+          headers = arguments.delete(:headers) || {}
+
           arguments = arguments.clone
 
           _node_id = arguments.delete(:node_id)
@@ -34,11 +36,11 @@ module Elasticsearch
                      "_nodes/#{Utils.__listify(_metric)}"
                    else
                      "_nodes"
-end
+      end
           params = Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
 
           body = nil
-          perform_request(method, path, params, body).body
+          perform_request(method, path, params, body, headers).body
         end
 
         # Register this action with its valid params when the module is loaded.

--- a/elasticsearch-api/lib/elasticsearch/api/actions/nodes/reload_secure_settings.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/nodes/reload_secure_settings.rb
@@ -10,11 +10,13 @@ module Elasticsearch
         #
         # @option arguments [List] :node_id A comma-separated list of node IDs to span the reload/reinit call. Should stay empty because reloading usually involves all cluster nodes.
         # @option arguments [Time] :timeout Explicit operation timeout
-
+        # @option arguments [Hash] :headers Custom HTTP headers
         #
-        # @see https://www.elastic.co/guide/en/elasticsearch/reference/7.5/secure-settings.html#reloadable-secure-settings
+        # @see https://www.elastic.co/guide/en/elasticsearch/reference/master/secure-settings.html#reloadable-secure-settings
         #
         def reload_secure_settings(arguments = {})
+          headers = arguments.delete(:headers) || {}
+
           arguments = arguments.clone
 
           _node_id = arguments.delete(:node_id)
@@ -24,11 +26,11 @@ module Elasticsearch
                      "_nodes/#{Utils.__listify(_node_id)}/reload_secure_settings"
                    else
                      "_nodes/reload_secure_settings"
-end
+      end
           params = Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
 
           body = nil
-          perform_request(method, path, params, body).body
+          perform_request(method, path, params, body, headers).body
         end
 
         # Register this action with its valid params when the module is loaded.

--- a/elasticsearch-api/lib/elasticsearch/api/actions/nodes/stats.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/nodes/stats.rb
@@ -25,11 +25,13 @@ module Elasticsearch
         # @option arguments [List] :types A comma-separated list of document types for the `indexing` index metric
         # @option arguments [Time] :timeout Explicit operation timeout
         # @option arguments [Boolean] :include_segment_file_sizes Whether to report the aggregated disk usage of each one of the Lucene index files (only applies if segment stats are requested)
-
+        # @option arguments [Hash] :headers Custom HTTP headers
         #
-        # @see https://www.elastic.co/guide/en/elasticsearch/reference/7.5/cluster-nodes-stats.html
+        # @see https://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-nodes-stats.html
         #
         def stats(arguments = {})
+          headers = arguments.delete(:headers) || {}
+
           arguments = arguments.clone
 
           _node_id = arguments.delete(:node_id)
@@ -51,11 +53,11 @@ module Elasticsearch
                      "_nodes/stats/#{Utils.__listify(_metric)}"
                    else
                      "_nodes/stats"
-end
+      end
           params = Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
 
           body = nil
-          perform_request(method, path, params, body).body
+          perform_request(method, path, params, body, headers).body
         end
 
         # Register this action with its valid params when the module is loaded.

--- a/elasticsearch-api/lib/elasticsearch/api/actions/nodes/usage.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/nodes/usage.rb
@@ -13,11 +13,13 @@ module Elasticsearch
         #   (options: _all,rest_actions)
 
         # @option arguments [Time] :timeout Explicit operation timeout
-
+        # @option arguments [Hash] :headers Custom HTTP headers
         #
-        # @see https://www.elastic.co/guide/en/elasticsearch/reference/7.5/cluster-nodes-usage.html
+        # @see https://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-nodes-usage.html
         #
         def usage(arguments = {})
+          headers = arguments.delete(:headers) || {}
+
           arguments = arguments.clone
 
           _node_id = arguments.delete(:node_id)
@@ -33,11 +35,11 @@ module Elasticsearch
                      "_nodes/usage/#{Utils.__listify(_metric)}"
                    else
                      "_nodes/usage"
-end
+      end
           params = Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
 
           body = nil
-          perform_request(method, path, params, body).body
+          perform_request(method, path, params, body, headers).body
         end
 
         # Register this action with its valid params when the module is loaded.

--- a/elasticsearch-api/lib/elasticsearch/api/actions/ping.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/ping.rb
@@ -7,11 +7,13 @@ module Elasticsearch
     module Actions
       # Returns whether the cluster is running.
       #
-
+      # @option arguments [Hash] :headers Custom HTTP headers
       #
-      # @see https://www.elastic.co/guide/en/elasticsearch/reference/7.5/index.html
+      # @see https://www.elastic.co/guide/en/elasticsearch/reference/current/index.html
       #
       def ping(arguments = {})
+        headers = arguments.delete(:headers) || {}
+
         arguments = arguments.clone
 
         method = Elasticsearch::API::HTTP_HEAD
@@ -20,7 +22,7 @@ module Elasticsearch
 
         body = nil
         begin
-        perform_request(method, path, params, body).status == 200 ? true : false
+        perform_request(method, path, params, body, headers).status == 200 ? true : false
         rescue Exception => e
           if e.class.to_s =~ /NotFound|ConnectionFailed/ || e.message =~ /Not *Found|404|ConnectionFailed/i
             false

--- a/elasticsearch-api/lib/elasticsearch/api/actions/put_script.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/put_script.rb
@@ -12,14 +12,16 @@ module Elasticsearch
       # @option arguments [Time] :timeout Explicit operation timeout
       # @option arguments [Time] :master_timeout Specify timeout for connection to master
       # @option arguments [String] :context Context name to compile script against
-
+      # @option arguments [Hash] :headers Custom HTTP headers
       # @option arguments [Hash] :body The document (*Required*)
       #
-      # @see https://www.elastic.co/guide/en/elasticsearch/reference/7.5/modules-scripting.html
+      # @see https://www.elastic.co/guide/en/elasticsearch/reference/master/modules-scripting.html
       #
       def put_script(arguments = {})
         raise ArgumentError, "Required argument 'body' missing" unless arguments[:body]
         raise ArgumentError, "Required argument 'id' missing" unless arguments[:id]
+
+        headers = arguments.delete(:headers) || {}
 
         arguments = arguments.clone
 
@@ -36,7 +38,7 @@ module Elasticsearch
         params = Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
 
         body = arguments[:body]
-        perform_request(method, path, params, body).body
+        perform_request(method, path, params, body, headers).body
       end
 
       # Register this action with its valid params when the module is loaded.

--- a/elasticsearch-api/lib/elasticsearch/api/actions/rank_eval.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/rank_eval.rb
@@ -16,12 +16,15 @@ module Elasticsearch
       # @option arguments [String] :search_type Search operation type
       #   (options: query_then_fetch,dfs_query_then_fetch)
 
+      # @option arguments [Hash] :headers Custom HTTP headers
       # @option arguments [Hash] :body The ranking evaluation search definition, including search requests, document ratings and ranking metric definition. (*Required*)
       #
-      # @see https://www.elastic.co/guide/en/elasticsearch/reference/7.5/search-rank-eval.html
+      # @see https://www.elastic.co/guide/en/elasticsearch/reference/master/search-rank-eval.html
       #
       def rank_eval(arguments = {})
         raise ArgumentError, "Required argument 'body' missing" unless arguments[:body]
+
+        headers = arguments.delete(:headers) || {}
 
         arguments = arguments.clone
 
@@ -36,7 +39,7 @@ module Elasticsearch
         params = Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
 
         body = arguments[:body]
-        perform_request(method, path, params, body).body
+        perform_request(method, path, params, body, headers).body
       end
 
       # Register this action with its valid params when the module is loaded.

--- a/elasticsearch-api/lib/elasticsearch/api/actions/reindex.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/reindex.rb
@@ -17,13 +17,15 @@ module Elasticsearch
       # @option arguments [Time] :scroll Control how long to keep the search context alive
       # @option arguments [Number|string] :slices The number of slices this task should be divided into. Defaults to 1, meaning the task isn't sliced into subtasks. Can be set to `auto`.
       # @option arguments [Number] :max_docs Maximum number of documents to process (default: all documents)
-
+      # @option arguments [Hash] :headers Custom HTTP headers
       # @option arguments [Hash] :body The search definition using the Query DSL and the prototype for the index request. (*Required*)
       #
-      # @see https://www.elastic.co/guide/en/elasticsearch/reference/7.5/docs-reindex.html
+      # @see https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-reindex.html
       #
       def reindex(arguments = {})
         raise ArgumentError, "Required argument 'body' missing" unless arguments[:body]
+
+        headers = arguments.delete(:headers) || {}
 
         arguments = arguments.clone
 
@@ -32,7 +34,7 @@ module Elasticsearch
         params = Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
 
         body = arguments[:body]
-        perform_request(method, path, params, body).body
+        perform_request(method, path, params, body, headers).body
       end
 
       # Register this action with its valid params when the module is loaded.

--- a/elasticsearch-api/lib/elasticsearch/api/actions/reindex_rethrottle.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/reindex_rethrottle.rb
@@ -9,12 +9,14 @@ module Elasticsearch
       #
       # @option arguments [String] :task_id The task id to rethrottle
       # @option arguments [Number] :requests_per_second The throttle to set on this request in floating sub-requests per second. -1 means set no throttle.  (*Required*)
-
+      # @option arguments [Hash] :headers Custom HTTP headers
       #
-      # @see https://www.elastic.co/guide/en/elasticsearch/reference/7.5/docs-reindex.html
+      # @see https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-reindex.html
       #
       def reindex_rethrottle(arguments = {})
         raise ArgumentError, "Required argument 'task_id' missing" unless arguments[:task_id]
+
+        headers = arguments.delete(:headers) || {}
 
         arguments = arguments.clone
 
@@ -25,7 +27,7 @@ module Elasticsearch
         params = Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
 
         body = nil
-        perform_request(method, path, params, body).body
+        perform_request(method, path, params, body, headers).body
       end
 
       # Register this action with its valid params when the module is loaded.

--- a/elasticsearch-api/lib/elasticsearch/api/actions/render_search_template.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/render_search_template.rb
@@ -8,12 +8,14 @@ module Elasticsearch
       # Allows to use the Mustache language to pre-render a search definition.
       #
       # @option arguments [String] :id The id of the stored search template
-
+      # @option arguments [Hash] :headers Custom HTTP headers
       # @option arguments [Hash] :body The search definition template and its params
       #
-      # @see https://www.elastic.co/guide/en/elasticsearch/reference/7.5/search-template.html#_validating_templates
+      # @see https://www.elastic.co/guide/en/elasticsearch/reference/current/search-template.html#_validating_templates
       #
       def render_search_template(arguments = {})
+        headers = arguments.delete(:headers) || {}
+
         arguments = arguments.clone
 
         _id = arguments.delete(:id)
@@ -23,11 +25,11 @@ module Elasticsearch
                    "_render/template/#{Utils.__listify(_id)}"
                  else
                    "_render/template"
-end
+    end
         params = {}
 
         body = arguments[:body]
-        perform_request(method, path, params, body).body
+        perform_request(method, path, params, body, headers).body
       end
     end
     end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/scripts_painless_execute.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/scripts_painless_execute.rb
@@ -7,12 +7,14 @@ module Elasticsearch
     module Actions
       # Allows an arbitrary script to be executed and a result to be returned
       #
-
+      # @option arguments [Hash] :headers Custom HTTP headers
       # @option arguments [Hash] :body The script to execute
       #
-      # @see https://www.elastic.co/guide/en/elasticsearch/painless/7.5/painless-execute-api.html
+      # @see https://www.elastic.co/guide/en/elasticsearch/painless/master/painless-execute-api.html
       #
       def scripts_painless_execute(arguments = {})
+        headers = arguments.delete(:headers) || {}
+
         arguments = arguments.clone
 
         method = Elasticsearch::API::HTTP_GET
@@ -20,7 +22,7 @@ module Elasticsearch
         params = {}
 
         body = arguments[:body]
-        perform_request(method, path, params, body).body
+        perform_request(method, path, params, body, headers).body
       end
     end
     end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/scroll.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/scroll.rb
@@ -11,7 +11,7 @@ module Elasticsearch
       # @option arguments [Time] :scroll Specify how long a consistent view of the index should be maintained for scrolled search
       # @option arguments [String] :scroll_id The scroll ID for scrolled search
       # @option arguments [Boolean] :rest_total_hits_as_int Indicates whether hits.total should be rendered as an integer or an object in the rest search response
-
+      # @option arguments [Hash] :headers Custom HTTP headers
       # @option arguments [Hash] :body The scroll ID if not passed by URL or query parameter.
       #
       # *Deprecation notice*:
@@ -19,9 +19,11 @@ module Elasticsearch
       # Deprecated since version 7.0.0
       #
       #
-      # @see https://www.elastic.co/guide/en/elasticsearch/reference/7.5/search-request-body.html#request-body-search-scroll
+      # @see https://www.elastic.co/guide/en/elasticsearch/reference/master/search-request-body.html#request-body-search-scroll
       #
       def scroll(arguments = {})
+        headers = arguments.delete(:headers) || {}
+
         arguments = arguments.clone
 
         _scroll_id = arguments.delete(:scroll_id)
@@ -31,11 +33,11 @@ module Elasticsearch
                    "_search/scroll/#{Utils.__listify(_scroll_id)}"
                  else
                    "_search/scroll"
-end
+    end
         params = Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
 
         body = arguments[:body]
-        perform_request(method, path, params, body).body
+        perform_request(method, path, params, body, headers).body
       end
 
       # Register this action with its valid params when the module is loaded.

--- a/elasticsearch-api/lib/elasticsearch/api/actions/search.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/search.rb
@@ -59,7 +59,7 @@ module Elasticsearch
       # @option arguments [Number] :max_concurrent_shard_requests The number of concurrent shard requests per node this search executes concurrently. This value should be used to limit the impact of the search on the cluster in order to limit the number of concurrent shard requests
       # @option arguments [Number] :pre_filter_shard_size A threshold that enforces a pre-filter roundtrip to prefilter search shards based on query rewriting if the number of shards the search request expands to exceeds the threshold. This filter roundtrip can limit the number of shards significantly if for instance a shard can not match any documents based on its rewrite method ie. if date filters are mandatory to match but the shard bounds and the query are disjoint.
       # @option arguments [Boolean] :rest_total_hits_as_int Indicates whether hits.total should be rendered as an integer or an object in the rest search response
-
+      # @option arguments [Hash] :headers Custom HTTP headers
       # @option arguments [Hash] :body The search definition using the Query DSL
       #
       # *Deprecation notice*:
@@ -67,9 +67,11 @@ module Elasticsearch
       # Deprecated since version 7.0.0
       #
       #
-      # @see https://www.elastic.co/guide/en/elasticsearch/reference/7.5/search-search.html
+      # @see https://www.elastic.co/guide/en/elasticsearch/reference/master/search-search.html
       #
       def search(arguments = {})
+        headers = arguments.delete(:headers) || {}
+
         arguments = arguments.clone
         arguments[:index] = UNDERSCORE_ALL if !arguments[:index] && arguments[:type]
 
@@ -84,11 +86,11 @@ module Elasticsearch
                    "#{Utils.__listify(_index)}/_search"
                  else
                    "_search"
-end
+    end
         params = Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
 
         body = arguments[:body]
-        perform_request(method, path, params, body).body
+        perform_request(method, path, params, body, headers).body
       end
 
       # Register this action with its valid params when the module is loaded.

--- a/elasticsearch-api/lib/elasticsearch/api/actions/search_shards.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/search_shards.rb
@@ -16,10 +16,13 @@ module Elasticsearch
       # @option arguments [String] :expand_wildcards Whether to expand wildcard expression to concrete indices that are open, closed or both.
       #   (options: open,closed,hidden,none,all)
 
+      # @option arguments [Hash] :headers Custom HTTP headers
       #
-      # @see https://www.elastic.co/guide/en/elasticsearch/reference/7.5/search-shards.html
+      # @see https://www.elastic.co/guide/en/elasticsearch/reference/master/search-shards.html
       #
       def search_shards(arguments = {})
+        headers = arguments.delete(:headers) || {}
+
         arguments = arguments.clone
 
         _index = arguments.delete(:index)
@@ -29,11 +32,11 @@ module Elasticsearch
                    "#{Utils.__listify(_index)}/_search_shards"
                  else
                    "_search_shards"
-end
+    end
         params = Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
 
         body = nil
-        perform_request(method, path, params, body).body
+        perform_request(method, path, params, body, headers).body
       end
 
       # Register this action with its valid params when the module is loaded.

--- a/elasticsearch-api/lib/elasticsearch/api/actions/search_template.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/search_template.rb
@@ -26,7 +26,7 @@ module Elasticsearch
       # @option arguments [Boolean] :typed_keys Specify whether aggregation and suggester names should be prefixed by their respective types in the response
       # @option arguments [Boolean] :rest_total_hits_as_int Indicates whether hits.total should be rendered as an integer or an object in the rest search response
       # @option arguments [Boolean] :ccs_minimize_roundtrips Indicates whether network round-trips should be minimized as part of cross-cluster search requests execution
-
+      # @option arguments [Hash] :headers Custom HTTP headers
       # @option arguments [Hash] :body The search definition template and its params (*Required*)
       #
       # *Deprecation notice*:
@@ -34,10 +34,12 @@ module Elasticsearch
       # Deprecated since version 7.0.0
       #
       #
-      # @see https://www.elastic.co/guide/en/elasticsearch/reference/7.5/search-template.html
+      # @see https://www.elastic.co/guide/en/elasticsearch/reference/current/search-template.html
       #
       def search_template(arguments = {})
         raise ArgumentError, "Required argument 'body' missing" unless arguments[:body]
+
+        headers = arguments.delete(:headers) || {}
 
         arguments = arguments.clone
 
@@ -56,7 +58,7 @@ module Elasticsearch
         params = Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
 
         body = arguments[:body]
-        perform_request(method, path, params, body).body
+        perform_request(method, path, params, body, headers).body
       end
 
       # Register this action with its valid params when the module is loaded.

--- a/elasticsearch-api/lib/elasticsearch/api/actions/snapshot/cleanup_repository.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/snapshot/cleanup_repository.rb
@@ -11,13 +11,14 @@ module Elasticsearch
         # @option arguments [String] :repository A repository name
         # @option arguments [Time] :master_timeout Explicit operation timeout for connection to master node
         # @option arguments [Time] :timeout Explicit operation timeout
-
-        # @option arguments [Hash] :body TODO: Description
+        # @option arguments [Hash] :headers Custom HTTP headers
         #
-        # @see https://www.elastic.co/guide/en/elasticsearch/reference/7.5/modules-snapshots.html
+        # @see https://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html
         #
         def cleanup_repository(arguments = {})
           raise ArgumentError, "Required argument 'repository' missing" unless arguments[:repository]
+
+          headers = arguments.delete(:headers) || {}
 
           arguments = arguments.clone
 
@@ -27,8 +28,8 @@ module Elasticsearch
           path   = "_snapshot/#{Utils.__listify(_repository)}/_cleanup"
           params = Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
 
-          body = arguments[:body]
-          perform_request(method, path, params, body).body
+          body = nil
+          perform_request(method, path, params, body, headers).body
         end
 
         # Register this action with its valid params when the module is loaded.

--- a/elasticsearch-api/lib/elasticsearch/api/actions/snapshot/create.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/snapshot/create.rb
@@ -12,14 +12,16 @@ module Elasticsearch
         # @option arguments [String] :snapshot A snapshot name
         # @option arguments [Time] :master_timeout Explicit operation timeout for connection to master node
         # @option arguments [Boolean] :wait_for_completion Should this request wait until the operation has completed before returning
-
+        # @option arguments [Hash] :headers Custom HTTP headers
         # @option arguments [Hash] :body The snapshot definition
         #
-        # @see https://www.elastic.co/guide/en/elasticsearch/reference/7.5/modules-snapshots.html
+        # @see https://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html
         #
         def create(arguments = {})
           raise ArgumentError, "Required argument 'repository' missing" unless arguments[:repository]
           raise ArgumentError, "Required argument 'snapshot' missing" unless arguments[:snapshot]
+
+          headers = arguments.delete(:headers) || {}
 
           arguments = arguments.clone
 
@@ -32,7 +34,7 @@ module Elasticsearch
           params = Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
 
           body = arguments[:body]
-          perform_request(method, path, params, body).body
+          perform_request(method, path, params, body, headers).body
         end
 
         # Register this action with its valid params when the module is loaded.

--- a/elasticsearch-api/lib/elasticsearch/api/actions/snapshot/create_repository.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/snapshot/create_repository.rb
@@ -12,14 +12,16 @@ module Elasticsearch
         # @option arguments [Time] :master_timeout Explicit operation timeout for connection to master node
         # @option arguments [Time] :timeout Explicit operation timeout
         # @option arguments [Boolean] :verify Whether to verify the repository after creation
-
+        # @option arguments [Hash] :headers Custom HTTP headers
         # @option arguments [Hash] :body The repository definition (*Required*)
         #
-        # @see https://www.elastic.co/guide/en/elasticsearch/reference/7.5/modules-snapshots.html
+        # @see https://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html
         #
         def create_repository(arguments = {})
           raise ArgumentError, "Required argument 'body' missing" unless arguments[:body]
           raise ArgumentError, "Required argument 'repository' missing" unless arguments[:repository]
+
+          headers = arguments.delete(:headers) || {}
 
           arguments = arguments.clone
 
@@ -30,7 +32,7 @@ module Elasticsearch
           params = Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
 
           body = arguments[:body]
-          perform_request(method, path, params, body).body
+          perform_request(method, path, params, body, headers).body
         end
 
         # Register this action with its valid params when the module is loaded.

--- a/elasticsearch-api/lib/elasticsearch/api/actions/snapshot/delete.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/snapshot/delete.rb
@@ -11,13 +11,15 @@ module Elasticsearch
         # @option arguments [String] :repository A repository name
         # @option arguments [String] :snapshot A snapshot name
         # @option arguments [Time] :master_timeout Explicit operation timeout for connection to master node
-
+        # @option arguments [Hash] :headers Custom HTTP headers
         #
-        # @see https://www.elastic.co/guide/en/elasticsearch/reference/7.5/modules-snapshots.html
+        # @see https://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html
         #
         def delete(arguments = {})
           raise ArgumentError, "Required argument 'repository' missing" unless arguments[:repository]
           raise ArgumentError, "Required argument 'snapshot' missing" unless arguments[:snapshot]
+
+          headers = arguments.delete(:headers) || {}
 
           arguments = arguments.clone
 
@@ -31,9 +33,9 @@ module Elasticsearch
 
           body = nil
           if Array(arguments[:ignore]).include?(404)
-            Utils.__rescue_from_not_found { perform_request(method, path, params, body).body }
+            Utils.__rescue_from_not_found { perform_request(method, path, params, body, headers).body }
           else
-            perform_request(method, path, params, body).body
+            perform_request(method, path, params, body, headers).body
           end
         end
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/snapshot/delete_repository.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/snapshot/delete_repository.rb
@@ -11,12 +11,14 @@ module Elasticsearch
         # @option arguments [List] :repository A comma-separated list of repository names
         # @option arguments [Time] :master_timeout Explicit operation timeout for connection to master node
         # @option arguments [Time] :timeout Explicit operation timeout
-
+        # @option arguments [Hash] :headers Custom HTTP headers
         #
-        # @see https://www.elastic.co/guide/en/elasticsearch/reference/7.5/modules-snapshots.html
+        # @see https://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html
         #
         def delete_repository(arguments = {})
           raise ArgumentError, "Required argument 'repository' missing" unless arguments[:repository]
+
+          headers = arguments.delete(:headers) || {}
 
           arguments = arguments.clone
 
@@ -28,9 +30,9 @@ module Elasticsearch
 
           body = nil
           if Array(arguments[:ignore]).include?(404)
-            Utils.__rescue_from_not_found { perform_request(method, path, params, body).body }
+            Utils.__rescue_from_not_found { perform_request(method, path, params, body, headers).body }
           else
-            perform_request(method, path, params, body).body
+            perform_request(method, path, params, body, headers).body
           end
         end
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/snapshot/get.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/snapshot/get.rb
@@ -13,13 +13,15 @@ module Elasticsearch
         # @option arguments [Time] :master_timeout Explicit operation timeout for connection to master node
         # @option arguments [Boolean] :ignore_unavailable Whether to ignore unavailable snapshots, defaults to false which means a SnapshotMissingException is thrown
         # @option arguments [Boolean] :verbose Whether to show verbose snapshot info or only show the basic info found in the repository index blob
-
+        # @option arguments [Hash] :headers Custom HTTP headers
         #
-        # @see https://www.elastic.co/guide/en/elasticsearch/reference/7.5/modules-snapshots.html
+        # @see https://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html
         #
         def get(arguments = {})
           raise ArgumentError, "Required argument 'repository' missing" unless arguments[:repository]
           raise ArgumentError, "Required argument 'snapshot' missing" unless arguments[:snapshot]
+
+          headers = arguments.delete(:headers) || {}
 
           arguments = arguments.clone
 
@@ -33,9 +35,9 @@ module Elasticsearch
 
           body = nil
           if Array(arguments[:ignore]).include?(404)
-            Utils.__rescue_from_not_found { perform_request(method, path, params, body).body }
+            Utils.__rescue_from_not_found { perform_request(method, path, params, body, headers).body }
           else
-            perform_request(method, path, params, body).body
+            perform_request(method, path, params, body, headers).body
           end
         end
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/snapshot/get_repository.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/snapshot/get_repository.rb
@@ -11,11 +11,13 @@ module Elasticsearch
         # @option arguments [List] :repository A comma-separated list of repository names
         # @option arguments [Time] :master_timeout Explicit operation timeout for connection to master node
         # @option arguments [Boolean] :local Return local information, do not retrieve the state from master node (default: false)
-
+        # @option arguments [Hash] :headers Custom HTTP headers
         #
-        # @see https://www.elastic.co/guide/en/elasticsearch/reference/7.5/modules-snapshots.html
+        # @see https://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html
         #
         def get_repository(arguments = {})
+          headers = arguments.delete(:headers) || {}
+
           arguments = arguments.clone
 
           _repository = arguments.delete(:repository)
@@ -25,14 +27,14 @@ module Elasticsearch
                      "_snapshot/#{Utils.__listify(_repository)}"
                    else
                      "_snapshot"
-end
+      end
           params = Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
 
           body = nil
           if Array(arguments[:ignore]).include?(404)
-            Utils.__rescue_from_not_found { perform_request(method, path, params, body).body }
+            Utils.__rescue_from_not_found { perform_request(method, path, params, body, headers).body }
           else
-            perform_request(method, path, params, body).body
+            perform_request(method, path, params, body, headers).body
           end
         end
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/snapshot/restore.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/snapshot/restore.rb
@@ -12,14 +12,16 @@ module Elasticsearch
         # @option arguments [String] :snapshot A snapshot name
         # @option arguments [Time] :master_timeout Explicit operation timeout for connection to master node
         # @option arguments [Boolean] :wait_for_completion Should this request wait until the operation has completed before returning
-
+        # @option arguments [Hash] :headers Custom HTTP headers
         # @option arguments [Hash] :body Details of what to restore
         #
-        # @see https://www.elastic.co/guide/en/elasticsearch/reference/7.5/modules-snapshots.html
+        # @see https://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html
         #
         def restore(arguments = {})
           raise ArgumentError, "Required argument 'repository' missing" unless arguments[:repository]
           raise ArgumentError, "Required argument 'snapshot' missing" unless arguments[:snapshot]
+
+          headers = arguments.delete(:headers) || {}
 
           arguments = arguments.clone
 
@@ -32,7 +34,7 @@ module Elasticsearch
           params = Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
 
           body = arguments[:body]
-          perform_request(method, path, params, body).body
+          perform_request(method, path, params, body, headers).body
         end
 
         # Register this action with its valid params when the module is loaded.

--- a/elasticsearch-api/lib/elasticsearch/api/actions/snapshot/status.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/snapshot/status.rb
@@ -12,11 +12,13 @@ module Elasticsearch
         # @option arguments [List] :snapshot A comma-separated list of snapshot names
         # @option arguments [Time] :master_timeout Explicit operation timeout for connection to master node
         # @option arguments [Boolean] :ignore_unavailable Whether to ignore unavailable snapshots, defaults to false which means a SnapshotMissingException is thrown
-
+        # @option arguments [Hash] :headers Custom HTTP headers
         #
-        # @see https://www.elastic.co/guide/en/elasticsearch/reference/7.5/modules-snapshots.html
+        # @see https://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html
         #
         def status(arguments = {})
+          headers = arguments.delete(:headers) || {}
+
           arguments = arguments.clone
 
           _repository = arguments.delete(:repository)
@@ -30,14 +32,14 @@ module Elasticsearch
                      "_snapshot/#{Utils.__listify(_repository)}/_status"
                    else
                      "_snapshot/_status"
-end
+      end
           params = Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
 
           body = nil
           if Array(arguments[:ignore]).include?(404)
-            Utils.__rescue_from_not_found { perform_request(method, path, params, body).body }
+            Utils.__rescue_from_not_found { perform_request(method, path, params, body, headers).body }
           else
-            perform_request(method, path, params, body).body
+            perform_request(method, path, params, body, headers).body
           end
         end
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/snapshot/verify_repository.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/snapshot/verify_repository.rb
@@ -11,12 +11,14 @@ module Elasticsearch
         # @option arguments [String] :repository A repository name
         # @option arguments [Time] :master_timeout Explicit operation timeout for connection to master node
         # @option arguments [Time] :timeout Explicit operation timeout
-
+        # @option arguments [Hash] :headers Custom HTTP headers
         #
-        # @see https://www.elastic.co/guide/en/elasticsearch/reference/7.5/modules-snapshots.html
+        # @see https://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html
         #
         def verify_repository(arguments = {})
           raise ArgumentError, "Required argument 'repository' missing" unless arguments[:repository]
+
+          headers = arguments.delete(:headers) || {}
 
           arguments = arguments.clone
 
@@ -27,7 +29,7 @@ module Elasticsearch
           params = Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
 
           body = nil
-          perform_request(method, path, params, body).body
+          perform_request(method, path, params, body, headers).body
         end
 
         # Register this action with its valid params when the module is loaded.

--- a/elasticsearch-api/lib/elasticsearch/api/actions/tasks/cancel.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/tasks/cancel.rb
@@ -12,11 +12,14 @@ module Elasticsearch
         # @option arguments [List] :nodes A comma-separated list of node IDs or names to limit the returned information; use `_local` to return information from the node you're connecting to, leave empty to get information from all nodes
         # @option arguments [List] :actions A comma-separated list of actions that should be cancelled. Leave empty to cancel all.
         # @option arguments [String] :parent_task_id Cancel tasks with specified parent task id (node_id:task_number). Set to -1 to cancel all.
-
+        # @option arguments [Boolean] :wait_for_completion Should the request block until the cancellation of the task and its child tasks is completed. Defaults to false
+        # @option arguments [Hash] :headers Custom HTTP headers
         #
-        # @see https://www.elastic.co/guide/en/elasticsearch/reference/7.5/tasks.html
+        # @see https://www.elastic.co/guide/en/elasticsearch/reference/master/tasks.html
         #
         def cancel(arguments = {})
+          headers = arguments.delete(:headers) || {}
+
           arguments = arguments.clone
 
           _task_id = arguments.delete(:task_id)
@@ -26,11 +29,11 @@ module Elasticsearch
                      "_tasks/#{Utils.__listify(_task_id)}/_cancel"
                    else
                      "_tasks/_cancel"
-end
+      end
           params = Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
 
           body = nil
-          perform_request(method, path, params, body).body
+          perform_request(method, path, params, body, headers).body
         end
 
         # Register this action with its valid params when the module is loaded.
@@ -39,7 +42,8 @@ end
         ParamsRegistry.register(:cancel, [
           :nodes,
           :actions,
-          :parent_task_id
+          :parent_task_id,
+          :wait_for_completion
         ].freeze)
 end
       end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/tasks/get.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/tasks/get.rb
@@ -11,11 +11,13 @@ module Elasticsearch
         # @option arguments [String] :task_id Return the task with specified id (node_id:task_number)
         # @option arguments [Boolean] :wait_for_completion Wait for the matching tasks to complete (default: false)
         # @option arguments [Time] :timeout Explicit operation timeout
-
+        # @option arguments [Hash] :headers Custom HTTP headers
         #
-        # @see https://www.elastic.co/guide/en/elasticsearch/reference/7.5/tasks.html
+        # @see https://www.elastic.co/guide/en/elasticsearch/reference/master/tasks.html
         #
         def get(arguments = {})
+          headers = arguments.delete(:headers) || {}
+
           arguments = arguments.clone
 
           _task_id = arguments.delete(:task_id)
@@ -25,7 +27,7 @@ module Elasticsearch
           params = Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
 
           body = nil
-          perform_request(method, path, params, body).body
+          perform_request(method, path, params, body, headers).body
         end
 
         # Register this action with its valid params when the module is loaded.

--- a/elasticsearch-api/lib/elasticsearch/api/actions/tasks/list.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/tasks/list.rb
@@ -17,11 +17,13 @@ module Elasticsearch
         #   (options: nodes,parents,none)
 
         # @option arguments [Time] :timeout Explicit operation timeout
-
+        # @option arguments [Hash] :headers Custom HTTP headers
         #
-        # @see https://www.elastic.co/guide/en/elasticsearch/reference/7.5/tasks.html
+        # @see https://www.elastic.co/guide/en/elasticsearch/reference/master/tasks.html
         #
         def list(arguments = {})
+          headers = arguments.delete(:headers) || {}
+
           arguments = arguments.clone
 
           method = Elasticsearch::API::HTTP_GET
@@ -29,7 +31,7 @@ module Elasticsearch
           params = Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
 
           body = nil
-          perform_request(method, path, params, body).body
+          perform_request(method, path, params, body, headers).body
         end
 
         # Register this action with its valid params when the module is loaded.

--- a/elasticsearch-api/lib/elasticsearch/api/actions/termvectors.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/termvectors.rb
@@ -23,6 +23,7 @@ module Elasticsearch
       # @option arguments [String] :version_type Specific version type
       #   (options: internal,external,external_gte,force)
 
+      # @option arguments [Hash] :headers Custom HTTP headers
       # @option arguments [Hash] :body Define parameters and or supply a document to get termvectors for. See documentation.
       #
       # *Deprecation notice*:
@@ -30,10 +31,12 @@ module Elasticsearch
       # Deprecated since version 7.0.0
       #
       #
-      # @see https://www.elastic.co/guide/en/elasticsearch/reference/7.5/docs-termvectors.html
+      # @see https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-termvectors.html
       #
       def termvectors(arguments = {})
         raise ArgumentError, "Required argument 'index' missing" unless arguments[:index]
+
+        headers = arguments.delete(:headers) || {}
 
         arguments = arguments.clone
 
@@ -59,7 +62,7 @@ module Elasticsearch
         params = Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
 
         body = arguments[:body]
-        perform_request(method, path, params, body).body
+        perform_request(method, path, params, body, headers).body
       end
 
       # Deprecated: Use the plural version, {#termvectors}

--- a/elasticsearch-api/lib/elasticsearch/api/actions/update.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/update.rb
@@ -23,7 +23,7 @@ module Elasticsearch
       # @option arguments [Time] :timeout Explicit operation timeout
       # @option arguments [Number] :if_seq_no only perform the update operation if the last operation that has changed the document has the specified sequence number
       # @option arguments [Number] :if_primary_term only perform the update operation if the last operation that has changed the document has the specified primary term
-
+      # @option arguments [Hash] :headers Custom HTTP headers
       # @option arguments [Hash] :body The request definition requires either `script` or partial `doc` (*Required*)
       #
       # *Deprecation notice*:
@@ -31,12 +31,14 @@ module Elasticsearch
       # Deprecated since version 7.0.0
       #
       #
-      # @see https://www.elastic.co/guide/en/elasticsearch/reference/7.5/docs-update.html
+      # @see https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-update.html
       #
       def update(arguments = {})
         raise ArgumentError, "Required argument 'body' missing" unless arguments[:body]
         raise ArgumentError, "Required argument 'index' missing" unless arguments[:index]
         raise ArgumentError, "Required argument 'id' missing" unless arguments[:id]
+
+        headers = arguments.delete(:headers) || {}
 
         arguments = arguments.clone
 
@@ -56,9 +58,9 @@ module Elasticsearch
 
         body = arguments[:body]
         if Array(arguments[:ignore]).include?(404)
-          Utils.__rescue_from_not_found { perform_request(method, path, params, body).body }
+          Utils.__rescue_from_not_found { perform_request(method, path, params, body, headers).body }
         else
-          perform_request(method, path, params, body).body
+          perform_request(method, path, params, body, headers).body
         end
       end
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/update_by_query.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/update_by_query.rb
@@ -53,7 +53,7 @@ module Elasticsearch
       # @option arguments [Boolean] :wait_for_completion Should the request should block until the update by query operation is complete.
       # @option arguments [Number] :requests_per_second The throttle to set on this request in sub-requests per second. -1 means no throttle.
       # @option arguments [Number|string] :slices The number of slices this task should be divided into. Defaults to 1, meaning the task isn't sliced into subtasks. Can be set to `auto`.
-
+      # @option arguments [Hash] :headers Custom HTTP headers
       # @option arguments [Hash] :body The search definition using the Query DSL
       #
       # *Deprecation notice*:
@@ -61,10 +61,12 @@ module Elasticsearch
       # Deprecated since version 7.0.0
       #
       #
-      # @see https://www.elastic.co/guide/en/elasticsearch/reference/7.5/docs-update-by-query.html
+      # @see https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-update-by-query.html
       #
       def update_by_query(arguments = {})
         raise ArgumentError, "Required argument 'index' missing" unless arguments[:index]
+
+        headers = arguments.delete(:headers) || {}
 
         arguments = arguments.clone
 
@@ -81,7 +83,7 @@ module Elasticsearch
         params = Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
 
         body = arguments[:body]
-        perform_request(method, path, params, body).body
+        perform_request(method, path, params, body, headers).body
       end
 
       # Register this action with its valid params when the module is loaded.

--- a/elasticsearch-api/lib/elasticsearch/api/actions/update_by_query_rethrottle.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/update_by_query_rethrottle.rb
@@ -9,12 +9,14 @@ module Elasticsearch
       #
       # @option arguments [String] :task_id The task id to rethrottle
       # @option arguments [Number] :requests_per_second The throttle to set on this request in floating sub-requests per second. -1 means set no throttle.  (*Required*)
-
+      # @option arguments [Hash] :headers Custom HTTP headers
       #
-      # @see https://www.elastic.co/guide/en/elasticsearch/reference/7.5/docs-update-by-query.html
+      # @see https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-update-by-query.html
       #
       def update_by_query_rethrottle(arguments = {})
         raise ArgumentError, "Required argument 'task_id' missing" unless arguments[:task_id]
+
+        headers = arguments.delete(:headers) || {}
 
         arguments = arguments.clone
 
@@ -25,7 +27,7 @@ module Elasticsearch
         params = Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
 
         body = nil
-        perform_request(method, path, params, body).body
+        perform_request(method, path, params, body, headers).body
       end
 
       # Register this action with its valid params when the module is loaded.

--- a/elasticsearch-api/spec/elasticsearch/api/actions/cat/aliases_spec.rb
+++ b/elasticsearch-api/spec/elasticsearch/api/actions/cat/aliases_spec.rb
@@ -12,7 +12,7 @@ describe 'client.cat#aliases' do
         '_cat/aliases',
         {},
         nil,
-        nil
+        {}
     ]
   end
 

--- a/elasticsearch-api/spec/elasticsearch/api/actions/cat/allocation_spec.rb
+++ b/elasticsearch-api/spec/elasticsearch/api/actions/cat/allocation_spec.rb
@@ -12,7 +12,7 @@ describe 'client.cat#allocation' do
         '_cat/allocation',
         {},
         nil,
-        nil
+        {}
     ]
   end
 

--- a/elasticsearch-api/spec/elasticsearch/api/actions/cat/count_spec.rb
+++ b/elasticsearch-api/spec/elasticsearch/api/actions/cat/count_spec.rb
@@ -12,7 +12,7 @@ describe 'client.cat#count' do
         '_cat/count',
         {},
         nil,
-        nil
+        {}
     ]
   end
 

--- a/elasticsearch-api/spec/elasticsearch/api/actions/cat/fielddata_spec.rb
+++ b/elasticsearch-api/spec/elasticsearch/api/actions/cat/fielddata_spec.rb
@@ -12,7 +12,7 @@ describe 'client.cat#fielddata' do
         '_cat/fielddata',
         {},
         nil,
-        nil
+        {}
     ]
   end
 
@@ -28,7 +28,7 @@ describe 'client.cat#fielddata' do
           '_cat/fielddata/foo,bar',
           {},
           nil,
-          nil
+          {}
       ]
     end
 

--- a/elasticsearch-api/spec/elasticsearch/api/actions/cat/health_spec.rb
+++ b/elasticsearch-api/spec/elasticsearch/api/actions/cat/health_spec.rb
@@ -12,7 +12,7 @@ describe 'client.cat#health' do
         '_cat/health',
         {},
         nil,
-        nil
+        {}
     ]
   end
 

--- a/elasticsearch-api/spec/elasticsearch/api/actions/cat/help_spec.rb
+++ b/elasticsearch-api/spec/elasticsearch/api/actions/cat/help_spec.rb
@@ -12,7 +12,7 @@ describe 'client.cat#help' do
         '_cat',
         {},
         nil,
-        nil
+        {}
     ]
   end
 

--- a/elasticsearch-api/spec/elasticsearch/api/actions/cat/indices_spec.rb
+++ b/elasticsearch-api/spec/elasticsearch/api/actions/cat/indices_spec.rb
@@ -12,7 +12,7 @@ describe 'client.cat#indices' do
         '_cat/indices',
         {},
         nil,
-        nil
+        {}
     ]
   end
 

--- a/elasticsearch-api/spec/elasticsearch/api/actions/cat/master_spec.rb
+++ b/elasticsearch-api/spec/elasticsearch/api/actions/cat/master_spec.rb
@@ -12,7 +12,7 @@ describe 'client.cat#master' do
         '_cat/master',
         {},
         nil,
-        nil
+        {}
     ]
   end
 

--- a/elasticsearch-api/spec/elasticsearch/api/actions/cat/nodeattrs_spec.rb
+++ b/elasticsearch-api/spec/elasticsearch/api/actions/cat/nodeattrs_spec.rb
@@ -12,7 +12,7 @@ describe 'client.cat#nodeattrs' do
         '_cat/nodeattrs',
         {},
         nil,
-        nil
+        {}
     ]
   end
 

--- a/elasticsearch-api/spec/elasticsearch/api/actions/cat/nodes_spec.rb
+++ b/elasticsearch-api/spec/elasticsearch/api/actions/cat/nodes_spec.rb
@@ -12,7 +12,7 @@ describe 'client.cat#nodes' do
         '_cat/nodes',
         {},
         nil,
-        nil
+        {}
     ]
   end
 

--- a/elasticsearch-api/spec/elasticsearch/api/actions/cat/pending_tasks_spec.rb
+++ b/elasticsearch-api/spec/elasticsearch/api/actions/cat/pending_tasks_spec.rb
@@ -12,7 +12,7 @@ describe 'client.cat#pending_tasks' do
         '_cat/pending_tasks',
         {},
         nil,
-        nil
+        {}
     ]
   end
 

--- a/elasticsearch-api/spec/elasticsearch/api/actions/cat/plugins_spec.rb
+++ b/elasticsearch-api/spec/elasticsearch/api/actions/cat/plugins_spec.rb
@@ -12,7 +12,7 @@ describe 'client.cat#plugins' do
         '_cat/plugins',
         {},
         nil,
-        nil
+        {}
     ]
   end
 

--- a/elasticsearch-api/spec/elasticsearch/api/actions/cat/recovery_spec.rb
+++ b/elasticsearch-api/spec/elasticsearch/api/actions/cat/recovery_spec.rb
@@ -12,7 +12,7 @@ describe 'client.cat#recovery' do
         '_cat/recovery',
         {},
         nil,
-        nil
+        {}
     ]
   end
 

--- a/elasticsearch-api/spec/elasticsearch/api/actions/cat/repositories_spec.rb
+++ b/elasticsearch-api/spec/elasticsearch/api/actions/cat/repositories_spec.rb
@@ -12,7 +12,7 @@ describe 'client.cat#repositories' do
         '_cat/repositories',
         {},
         nil,
-        nil
+        {}
     ]
   end
 

--- a/elasticsearch-api/spec/elasticsearch/api/actions/cat/segments_spec.rb
+++ b/elasticsearch-api/spec/elasticsearch/api/actions/cat/segments_spec.rb
@@ -12,7 +12,7 @@ describe 'client.cat#segments' do
       url,
       {},
       nil,
-      nil
+      {}
     ]
   end
 

--- a/elasticsearch-api/spec/elasticsearch/api/actions/cat/shards_spec.rb
+++ b/elasticsearch-api/spec/elasticsearch/api/actions/cat/shards_spec.rb
@@ -12,7 +12,7 @@ describe 'client.cat#shards' do
         '_cat/shards',
         {},
         nil,
-        nil
+        {}
     ]
   end
 

--- a/elasticsearch-api/spec/elasticsearch/api/actions/cat/snapshot_spec.rb
+++ b/elasticsearch-api/spec/elasticsearch/api/actions/cat/snapshot_spec.rb
@@ -12,7 +12,7 @@ describe 'client.cat#snapshots' do
         '_cat/snapshots/foo',
         {},
         nil,
-        nil
+        {}
     ]
   end
 

--- a/elasticsearch-api/spec/elasticsearch/api/actions/cat/tasks_spec.rb
+++ b/elasticsearch-api/spec/elasticsearch/api/actions/cat/tasks_spec.rb
@@ -12,7 +12,7 @@ describe 'client.cat#tasks' do
         '_cat/tasks',
         {},
         nil,
-        nil
+        {}
     ]
   end
 

--- a/elasticsearch-api/spec/elasticsearch/api/actions/cat/templates_spec.rb
+++ b/elasticsearch-api/spec/elasticsearch/api/actions/cat/templates_spec.rb
@@ -12,7 +12,7 @@ describe 'client.cat#templates' do
         '_cat/templates',
         {},
         nil,
-        nil
+        {}
     ]
   end
 

--- a/elasticsearch-api/spec/elasticsearch/api/actions/cat/thread_pool_spec.rb
+++ b/elasticsearch-api/spec/elasticsearch/api/actions/cat/thread_pool_spec.rb
@@ -12,7 +12,7 @@ describe 'client.cat#thread_pool' do
         '_cat/thread_pool',
         {},
         nil,
-        nil
+        {}
     ]
   end
 

--- a/elasticsearch-api/spec/elasticsearch/api/actions/clear_scroll_spec.rb
+++ b/elasticsearch-api/spec/elasticsearch/api/actions/clear_scroll_spec.rb
@@ -11,7 +11,8 @@ describe 'client#clear_scroll' do
       'DELETE',
       '_search/scroll/abc123',
       {},
-      nil
+      nil,
+      {}
     ]
   end
 
@@ -26,7 +27,8 @@ describe 'client#clear_scroll' do
           'DELETE',
           '_search/scroll/abc123,def456',
           {},
-          nil
+          nil,
+          {}
       ]
     end
 

--- a/elasticsearch-api/spec/elasticsearch/api/actions/cluster/allocation_explain_spec.rb
+++ b/elasticsearch-api/spec/elasticsearch/api/actions/cluster/allocation_explain_spec.rb
@@ -12,7 +12,7 @@ describe 'client.cluster#allocation_explain' do
         '_cluster/allocation/explain',
         {},
         nil,
-        nil
+        {}
     ]
   end
 

--- a/elasticsearch-api/spec/elasticsearch/api/actions/cluster/get_settings_spec.rb
+++ b/elasticsearch-api/spec/elasticsearch/api/actions/cluster/get_settings_spec.rb
@@ -12,7 +12,7 @@ describe 'client.cluster#get_settings' do
         '_cluster/settings',
         {},
         nil,
-        nil
+        {}
     ]
   end
 

--- a/elasticsearch-api/spec/elasticsearch/api/actions/cluster/health_spec.rb
+++ b/elasticsearch-api/spec/elasticsearch/api/actions/cluster/health_spec.rb
@@ -12,7 +12,7 @@ describe 'client.cluster#health' do
         '_cluster/health',
         {},
         nil,
-        nil
+        {}
     ]
   end
 
@@ -28,7 +28,7 @@ describe 'client.cluster#health' do
           '_cluster/health',
           { level: 'indices' },
           nil,
-          nil
+          {}
       ]
     end
 
@@ -45,7 +45,7 @@ describe 'client.cluster#health' do
           '_cluster/health/foo',
           {},
           nil,
-          nil
+          {}
       ]
     end
 

--- a/elasticsearch-api/spec/elasticsearch/api/actions/cluster/pending_tasks_spec.rb
+++ b/elasticsearch-api/spec/elasticsearch/api/actions/cluster/pending_tasks_spec.rb
@@ -12,7 +12,7 @@ describe 'client.cluster#pending_tasks' do
         '_cluster/pending_tasks',
         {},
         nil,
-        nil
+        {}
     ]
   end
 

--- a/elasticsearch-api/spec/elasticsearch/api/actions/cluster/put_settings_spec.rb
+++ b/elasticsearch-api/spec/elasticsearch/api/actions/cluster/put_settings_spec.rb
@@ -12,7 +12,7 @@ describe 'client.cluster#put_settings' do
         '_cluster/settings',
         {},
         {},
-        nil
+        {}
     ]
   end
 

--- a/elasticsearch-api/spec/elasticsearch/api/actions/cluster/remote_info_spec.rb
+++ b/elasticsearch-api/spec/elasticsearch/api/actions/cluster/remote_info_spec.rb
@@ -12,7 +12,7 @@ describe 'client.cluster#remote_info' do
         '_remote/info',
         {},
         nil,
-        nil
+        {}
     ]
   end
 

--- a/elasticsearch-api/spec/elasticsearch/api/actions/cluster/reroute_spec.rb
+++ b/elasticsearch-api/spec/elasticsearch/api/actions/cluster/reroute_spec.rb
@@ -12,7 +12,7 @@ describe 'client.cluster#reroute' do
         '_cluster/reroute',
         {},
         {},
-        nil
+        {}
     ]
   end
 
@@ -28,7 +28,7 @@ describe 'client.cluster#reroute' do
           '_cluster/reroute',
           {},
           { commands: [ move: { index: 'myindex', shard: 0 }] },
-          nil
+          {}
       ]
     end
 

--- a/elasticsearch-api/spec/elasticsearch/api/actions/cluster/state_spec.rb
+++ b/elasticsearch-api/spec/elasticsearch/api/actions/cluster/state_spec.rb
@@ -12,7 +12,7 @@ describe 'client.cluster#state' do
         '_cluster/state',
         {},
         nil,
-        nil
+        {}
     ]
   end
 
@@ -28,7 +28,7 @@ describe 'client.cluster#state' do
           '_cluster/state/foo,bar',
           {},
           nil,
-          nil
+          {}
       ]
     end
 

--- a/elasticsearch-api/spec/elasticsearch/api/actions/cluster/stats_spec.rb
+++ b/elasticsearch-api/spec/elasticsearch/api/actions/cluster/stats_spec.rb
@@ -12,7 +12,7 @@ describe 'client.cluster#stats' do
         '_cluster/stats',
         {},
         nil,
-        nil
+        {}
     ]
   end
 

--- a/elasticsearch-api/spec/elasticsearch/api/actions/count_spec.rb
+++ b/elasticsearch-api/spec/elasticsearch/api/actions/count_spec.rb
@@ -11,7 +11,8 @@ describe 'client#count' do
       'GET',
       '_count',
       {},
-      nil
+      nil,
+      {}
     ]
   end
 
@@ -26,7 +27,8 @@ describe 'client#count' do
         'GET',
         'foo,bar/t1,t2/_count',
         {},
-        nil
+        nil,
+        {}
       ]
     end
 
@@ -42,7 +44,8 @@ describe 'client#count' do
         'POST',
         '_count',
         {},
-        { match: { foo: 'bar' } }
+        { match: { foo: 'bar' } },
+        {}
       ]
     end
 

--- a/elasticsearch-api/spec/elasticsearch/api/actions/create_document_spec.rb
+++ b/elasticsearch-api/spec/elasticsearch/api/actions/create_document_spec.rb
@@ -11,7 +11,8 @@ describe 'client#create_document' do
         'PUT',
         'foo/bar/123',
         { op_type: 'create' },
-        { foo: 'bar' }
+        { foo: 'bar' },
+        {}
     ]
   end
 
@@ -26,7 +27,8 @@ describe 'client#create_document' do
           'PUT',
           'foo/bar%2Fbam/123',
           { op_type: 'create' },
-          { }
+          {},
+          {}
       ]
     end
 
@@ -42,7 +44,8 @@ describe 'client#create_document' do
           'PUT',
           'foo/bar/1',
           { op_type: 'create' },
-          { foo: 'bar' }
+          { foo: 'bar' },
+          {}
       ]
     end
 
@@ -58,7 +61,8 @@ describe 'client#create_document' do
           'POST',
           'foo/bar',
           { },
-          { foo: 'bar' }
+          { foo: 'bar' },
+          {}
       ]
     end
 

--- a/elasticsearch-api/spec/elasticsearch/api/actions/delete_by_query_spec.rb
+++ b/elasticsearch-api/spec/elasticsearch/api/actions/delete_by_query_spec.rb
@@ -11,7 +11,8 @@ describe 'client#delete_by_query' do
       'POST',
       'foo/_delete_by_query',
       {},
-      { term: {} }
+      { term: {} },
+      {}
     ]
   end
 
@@ -32,7 +33,8 @@ describe 'client#delete_by_query' do
         'POST',
         'foo/tweet,post/_delete_by_query',
         {},
-        { term: {} }
+        { term: {} },
+        {}
       ]
     end
 
@@ -47,7 +49,8 @@ describe 'client#delete_by_query' do
         'POST',
         'foo/_delete_by_query',
         { q: 'foo:bar' },
-        { query: 'query' }
+        { query: 'query' },
+        {}
       ]
     end
 

--- a/elasticsearch-api/spec/elasticsearch/api/actions/delete_document_spec.rb
+++ b/elasticsearch-api/spec/elasticsearch/api/actions/delete_document_spec.rb
@@ -11,7 +11,8 @@ describe 'client#delete' do
         'DELETE',
         'foo/bar/1',
         params,
-        nil
+        nil,
+        {}
     ]
   end
 
@@ -66,7 +67,8 @@ describe 'client#delete' do
           'DELETE',
           'foo%5Ebar/bar%2Fbam/1',
           params,
-          nil
+          nil,
+          {}
       ]
     end
 

--- a/elasticsearch-api/spec/elasticsearch/api/actions/delete_script_spec.rb
+++ b/elasticsearch-api/spec/elasticsearch/api/actions/delete_script_spec.rb
@@ -12,7 +12,8 @@ describe 'client#delete_script' do
           'DELETE',
           '_scripts/foo',
           {},
-          nil
+          nil,
+          {}
       ]
     end
 

--- a/elasticsearch-api/spec/elasticsearch/api/actions/exists_document_spec.rb
+++ b/elasticsearch-api/spec/elasticsearch/api/actions/exists_document_spec.rb
@@ -11,7 +11,8 @@ describe 'client#exists' do
         'HEAD',
         url,
         params,
-        nil
+        nil,
+        {}
     ]
   end
 

--- a/elasticsearch-api/spec/elasticsearch/api/actions/explain_document_spec.rb
+++ b/elasticsearch-api/spec/elasticsearch/api/actions/explain_document_spec.rb
@@ -11,7 +11,8 @@ describe 'client#explain' do
         'GET',
         url,
         params,
-        body
+        body,
+        {}
     ]
   end
 

--- a/elasticsearch-api/spec/elasticsearch/api/actions/field_caps_spec.rb
+++ b/elasticsearch-api/spec/elasticsearch/api/actions/field_caps_spec.rb
@@ -11,7 +11,8 @@ describe 'client#field_caps' do
         'GET',
         'foo/_field_caps',
         { fields: 'bar' },
-        nil
+        nil,
+        {}
     ]
   end
 

--- a/elasticsearch-api/spec/elasticsearch/api/actions/get_document_source_spec.rb
+++ b/elasticsearch-api/spec/elasticsearch/api/actions/get_document_source_spec.rb
@@ -11,7 +11,8 @@ describe 'client#get_source' do
         'GET',
         url,
         params,
-        nil
+        nil,
+        {}
     ]
   end
 

--- a/elasticsearch-api/spec/elasticsearch/api/actions/get_document_spec.rb
+++ b/elasticsearch-api/spec/elasticsearch/api/actions/get_document_spec.rb
@@ -11,7 +11,8 @@ describe 'client#get' do
         'GET',
         url,
         params,
-        nil
+        nil,
+        {}
     ]
   end
 

--- a/elasticsearch-api/spec/elasticsearch/api/actions/get_script_spec.rb
+++ b/elasticsearch-api/spec/elasticsearch/api/actions/get_script_spec.rb
@@ -11,7 +11,8 @@ describe 'client#get_script' do
         'GET',
         url,
         params,
-        nil
+        nil,
+        {}
     ]
   end
 

--- a/elasticsearch-api/spec/elasticsearch/api/actions/index_document_spec.rb
+++ b/elasticsearch-api/spec/elasticsearch/api/actions/index_document_spec.rb
@@ -11,7 +11,8 @@ describe 'client#index' do
         request_type,
         url,
         params,
-        body
+        body,
+        {}
     ]
   end
 

--- a/elasticsearch-api/spec/elasticsearch/api/actions/indices/analyze_spec.rb
+++ b/elasticsearch-api/spec/elasticsearch/api/actions/indices/analyze_spec.rb
@@ -12,7 +12,7 @@ describe 'client.indices#analyze' do
         url,
         params,
         body,
-        nil
+        {}
     ]
   end
 

--- a/elasticsearch-api/spec/elasticsearch/api/actions/indices/clear_cache_spec.rb
+++ b/elasticsearch-api/spec/elasticsearch/api/actions/indices/clear_cache_spec.rb
@@ -12,7 +12,7 @@ describe 'client.indices#clear_cache' do
         url,
         params,
         nil,
-        nil
+        {}
     ]
   end
 

--- a/elasticsearch-api/spec/elasticsearch/api/actions/indices/clone_spec.rb
+++ b/elasticsearch-api/spec/elasticsearch/api/actions/indices/clone_spec.rb
@@ -12,7 +12,7 @@ describe 'client.indices#clone' do
         url,
         params,
         body,
-        nil
+        {}
     ]
   end
 

--- a/elasticsearch-api/spec/elasticsearch/api/actions/indices/close_spec.rb
+++ b/elasticsearch-api/spec/elasticsearch/api/actions/indices/close_spec.rb
@@ -12,7 +12,7 @@ describe 'client.indices#close' do
         url,
         params,
         nil,
-        nil
+        {}
     ]
   end
 

--- a/elasticsearch-api/spec/elasticsearch/api/actions/indices/create_spec.rb
+++ b/elasticsearch-api/spec/elasticsearch/api/actions/indices/create_spec.rb
@@ -12,7 +12,7 @@ describe 'client.indices#create' do
         url,
         params,
         nil,
-        nil
+        {}
     ]
   end
 

--- a/elasticsearch-api/spec/elasticsearch/api/actions/indices/delete_alias_spec.rb
+++ b/elasticsearch-api/spec/elasticsearch/api/actions/indices/delete_alias_spec.rb
@@ -12,7 +12,7 @@ describe 'client.indices#delete_alias' do
         url,
         params,
         nil,
-        nil
+        {}
     ]
   end
 

--- a/elasticsearch-api/spec/elasticsearch/api/actions/indices/delete_spec.rb
+++ b/elasticsearch-api/spec/elasticsearch/api/actions/indices/delete_spec.rb
@@ -12,7 +12,7 @@ describe 'client.indices#delete' do
         url,
         params,
         nil,
-        nil
+        {}
     ]
   end
 

--- a/elasticsearch-api/spec/elasticsearch/api/actions/indices/delete_template_spec.rb
+++ b/elasticsearch-api/spec/elasticsearch/api/actions/indices/delete_template_spec.rb
@@ -12,7 +12,7 @@ describe 'client.indices#delete_template' do
         url,
         params,
         nil,
-        nil
+        {}
     ]
   end
 

--- a/elasticsearch-api/spec/elasticsearch/api/actions/indices/exists_alias_spec.rb
+++ b/elasticsearch-api/spec/elasticsearch/api/actions/indices/exists_alias_spec.rb
@@ -12,7 +12,7 @@ describe 'client.indices#exists_alias' do
         url,
         params,
         nil,
-        nil
+        {}
     ]
   end
 

--- a/elasticsearch-api/spec/elasticsearch/api/actions/indices/exists_spec.rb
+++ b/elasticsearch-api/spec/elasticsearch/api/actions/indices/exists_spec.rb
@@ -12,7 +12,7 @@ describe 'client.indices#exists' do
         url,
         params,
         nil,
-        nil
+        {}
     ]
   end
 

--- a/elasticsearch-api/spec/elasticsearch/api/actions/indices/exists_template_spec.rb
+++ b/elasticsearch-api/spec/elasticsearch/api/actions/indices/exists_template_spec.rb
@@ -12,7 +12,7 @@ describe 'client.indices#exists_template' do
         url,
         params,
         nil,
-        nil
+        {}
     ]
   end
 

--- a/elasticsearch-api/spec/elasticsearch/api/actions/indices/exists_type_spec.rb
+++ b/elasticsearch-api/spec/elasticsearch/api/actions/indices/exists_type_spec.rb
@@ -12,7 +12,7 @@ describe 'client.indices#exists_type' do
         url,
         params,
         nil,
-        nil
+        {}
     ]
   end
 

--- a/elasticsearch-api/spec/elasticsearch/api/actions/indices/flush_spec.rb
+++ b/elasticsearch-api/spec/elasticsearch/api/actions/indices/flush_spec.rb
@@ -12,7 +12,7 @@ describe 'client.indices#flush' do
         url,
         params,
         nil,
-        nil
+        {}
     ]
   end
 

--- a/elasticsearch-api/spec/elasticsearch/api/actions/indices/flush_synced_spec.rb
+++ b/elasticsearch-api/spec/elasticsearch/api/actions/indices/flush_synced_spec.rb
@@ -12,7 +12,7 @@ describe 'client.indices#flush_synced' do
         url,
         params,
         nil,
-        nil
+        {}
     ]
   end
 

--- a/elasticsearch-api/spec/elasticsearch/api/actions/indices/forcemerge_spec.rb
+++ b/elasticsearch-api/spec/elasticsearch/api/actions/indices/forcemerge_spec.rb
@@ -12,7 +12,7 @@ describe 'client.cluster#forcemerge' do
         '_forcemerge',
         {},
         nil,
-        nil
+        {}
     ]
   end
 

--- a/elasticsearch-api/spec/elasticsearch/api/actions/indices/get_alias_spec.rb
+++ b/elasticsearch-api/spec/elasticsearch/api/actions/indices/get_alias_spec.rb
@@ -12,7 +12,7 @@ describe 'client.cluster#get_alias' do
         url,
         {},
         nil,
-        nil
+        {}
     ]
   end
 

--- a/elasticsearch-api/spec/elasticsearch/api/actions/indices/get_field_mapping_spec.rb
+++ b/elasticsearch-api/spec/elasticsearch/api/actions/indices/get_field_mapping_spec.rb
@@ -12,7 +12,7 @@ describe 'client.cluster#get_field_mapping' do
         url,
         {},
         nil,
-        nil
+        {}
     ]
   end
 

--- a/elasticsearch-api/spec/elasticsearch/api/actions/indices/get_mapping_spec.rb
+++ b/elasticsearch-api/spec/elasticsearch/api/actions/indices/get_mapping_spec.rb
@@ -12,7 +12,7 @@ describe 'client.cluster#get_mapping' do
         url,
         {},
         nil,
-        nil
+        {}
     ]
   end
 

--- a/elasticsearch-api/spec/elasticsearch/api/actions/indices/get_settings_spec.rb
+++ b/elasticsearch-api/spec/elasticsearch/api/actions/indices/get_settings_spec.rb
@@ -12,7 +12,7 @@ describe 'client.cluster#get_settings' do
         url,
         {},
         nil,
-        nil
+        {}
     ]
   end
 

--- a/elasticsearch-api/spec/elasticsearch/api/actions/indices/get_spec.rb
+++ b/elasticsearch-api/spec/elasticsearch/api/actions/indices/get_spec.rb
@@ -12,7 +12,7 @@ describe 'client.indices#get' do
         url,
         params,
         nil,
-        nil
+        {}
     ]
   end
 

--- a/elasticsearch-api/spec/elasticsearch/api/actions/indices/open_spec.rb
+++ b/elasticsearch-api/spec/elasticsearch/api/actions/indices/open_spec.rb
@@ -12,7 +12,7 @@ describe 'client.indices#open' do
         url,
         params,
         nil,
-        nil
+        {}
     ]
   end
 

--- a/elasticsearch-api/spec/elasticsearch/api/actions/indices/put_alias_spec.rb
+++ b/elasticsearch-api/spec/elasticsearch/api/actions/indices/put_alias_spec.rb
@@ -12,7 +12,7 @@ describe 'client.cluster#put_alias' do
         url,
         {},
         body,
-        nil
+        {}
     ]
   end
 

--- a/elasticsearch-api/spec/elasticsearch/api/actions/indices/put_mapping_spec.rb
+++ b/elasticsearch-api/spec/elasticsearch/api/actions/indices/put_mapping_spec.rb
@@ -12,7 +12,7 @@ describe 'client.cluster#put_mapping' do
         url,
         {},
         body,
-        nil
+        {}
     ]
   end
 

--- a/elasticsearch-api/spec/elasticsearch/api/actions/indices/put_settings_spec.rb
+++ b/elasticsearch-api/spec/elasticsearch/api/actions/indices/put_settings_spec.rb
@@ -12,7 +12,7 @@ describe 'client.cluster#put_settings' do
         url,
         params,
         body,
-        nil
+        {}
     ]
   end
 

--- a/elasticsearch-api/spec/elasticsearch/api/actions/indices/put_template_spec.rb
+++ b/elasticsearch-api/spec/elasticsearch/api/actions/indices/put_template_spec.rb
@@ -12,7 +12,7 @@ describe 'client.cluster#put_template' do
         url,
         params,
         body,
-        nil
+        {}
     ]
   end
 

--- a/elasticsearch-api/spec/elasticsearch/api/actions/indices/recovery_spec.rb
+++ b/elasticsearch-api/spec/elasticsearch/api/actions/indices/recovery_spec.rb
@@ -12,7 +12,7 @@ describe 'client.cluster#recovery' do
         'foo/_recovery',
         {},
         nil,
-        nil
+        {}
     ]
   end
 

--- a/elasticsearch-api/spec/elasticsearch/api/actions/indices/refresh_spec.rb
+++ b/elasticsearch-api/spec/elasticsearch/api/actions/indices/refresh_spec.rb
@@ -12,7 +12,7 @@ describe 'client.cluster#refresh' do
         url,
         params,
         body,
-        nil
+        {}
     ]
   end
 

--- a/elasticsearch-api/spec/elasticsearch/api/actions/indices/rollover_spec.rb
+++ b/elasticsearch-api/spec/elasticsearch/api/actions/indices/rollover_spec.rb
@@ -12,7 +12,7 @@ describe 'client.cluster#rollover' do
         url,
         params,
         body,
-        nil
+        {}
     ]
   end
 

--- a/elasticsearch-api/spec/elasticsearch/api/actions/indices/segments_spec.rb
+++ b/elasticsearch-api/spec/elasticsearch/api/actions/indices/segments_spec.rb
@@ -12,7 +12,7 @@ describe 'client.cluster#segments' do
         url,
         params,
         body,
-        nil
+        {}
     ]
   end
 

--- a/elasticsearch-api/spec/elasticsearch/api/actions/indices/shard_stores_spec.rb
+++ b/elasticsearch-api/spec/elasticsearch/api/actions/indices/shard_stores_spec.rb
@@ -12,7 +12,7 @@ describe 'client.cluster#shard_stores' do
         '_shard_stores',
         {},
         nil,
-        nil
+        {}
     ]
   end
 

--- a/elasticsearch-api/spec/elasticsearch/api/actions/indices/shrink_spec.rb
+++ b/elasticsearch-api/spec/elasticsearch/api/actions/indices/shrink_spec.rb
@@ -12,7 +12,7 @@ describe 'client.cluster#shrink' do
         'foo/_shrink/bar',
         {},
         nil,
-        nil
+        {}
     ]
   end
 

--- a/elasticsearch-api/spec/elasticsearch/api/actions/indices/split_spec.rb
+++ b/elasticsearch-api/spec/elasticsearch/api/actions/indices/split_spec.rb
@@ -12,7 +12,7 @@ describe 'client.cluster#split' do
         'foo/_split/bar',
         {},
         nil,
-        nil
+        {}
     ]
   end
 

--- a/elasticsearch-api/spec/elasticsearch/api/actions/indices/stats_spec.rb
+++ b/elasticsearch-api/spec/elasticsearch/api/actions/indices/stats_spec.rb
@@ -12,7 +12,7 @@ describe 'client.cluster#stats' do
         url,
         params,
         body,
-        nil
+        {}
     ]
   end
 

--- a/elasticsearch-api/spec/elasticsearch/api/actions/indices/update_aliases_spec.rb
+++ b/elasticsearch-api/spec/elasticsearch/api/actions/indices/update_aliases_spec.rb
@@ -12,7 +12,7 @@ describe 'client.cluster#update_aliases' do
         '_aliases',
         params,
         body,
-        nil
+        {}
     ]
   end
 

--- a/elasticsearch-api/spec/elasticsearch/api/actions/indices/upgrade_spec.rb
+++ b/elasticsearch-api/spec/elasticsearch/api/actions/indices/upgrade_spec.rb
@@ -12,7 +12,7 @@ describe 'client.cluster#upgrade' do
         '_upgrade',
         {},
         nil,
-        nil
+        {}
     ]
   end
 

--- a/elasticsearch-api/spec/elasticsearch/api/actions/indices/validate_query_spec.rb
+++ b/elasticsearch-api/spec/elasticsearch/api/actions/indices/validate_query_spec.rb
@@ -12,7 +12,7 @@ describe 'client.cluster#validate_query' do
         url,
         params,
         body,
-        nil
+        {}
     ]
   end
 

--- a/elasticsearch-api/spec/elasticsearch/api/actions/info_spec.rb
+++ b/elasticsearch-api/spec/elasticsearch/api/actions/info_spec.rb
@@ -11,7 +11,8 @@ describe 'client#info' do
         'GET',
         '',
         { },
-        nil
+        nil,
+        {}
     ]
   end
 

--- a/elasticsearch-api/spec/elasticsearch/api/actions/ingest/delete_pipeline_spec.rb
+++ b/elasticsearch-api/spec/elasticsearch/api/actions/ingest/delete_pipeline_spec.rb
@@ -12,7 +12,7 @@ describe 'client.ingest#delete_pipeline' do
         url,
         {},
         nil,
-        nil
+        {}
     ]
   end
 

--- a/elasticsearch-api/spec/elasticsearch/api/actions/ingest/get_pipeline_spec.rb
+++ b/elasticsearch-api/spec/elasticsearch/api/actions/ingest/get_pipeline_spec.rb
@@ -12,7 +12,7 @@ describe 'client.ingest#get_pipeline' do
         url,
         {},
         nil,
-        nil
+        {}
     ]
   end
 

--- a/elasticsearch-api/spec/elasticsearch/api/actions/ingest/put_pipeline_spec.rb
+++ b/elasticsearch-api/spec/elasticsearch/api/actions/ingest/put_pipeline_spec.rb
@@ -12,7 +12,7 @@ describe 'client.ingest#put_pipeline' do
         url,
         {},
         {},
-        nil
+        {}
     ]
   end
 

--- a/elasticsearch-api/spec/elasticsearch/api/actions/ingest/simulate_spec.rb
+++ b/elasticsearch-api/spec/elasticsearch/api/actions/ingest/simulate_spec.rb
@@ -12,7 +12,7 @@ describe 'client.ingest#simulate' do
         url,
         {},
         {},
-        nil
+        {}
     ]
   end
 

--- a/elasticsearch-api/spec/elasticsearch/api/actions/json_builders_spec.rb
+++ b/elasticsearch-api/spec/elasticsearch/api/actions/json_builders_spec.rb
@@ -13,7 +13,8 @@ describe 'JSON builders' do
           'GET',
           '_search',
           {},
-          body
+          body,
+          {}
       ]
     end
 
@@ -45,7 +46,8 @@ describe 'JSON builders' do
           'GET',
           '_search',
           {},
-          body
+          body,
+          {}
       ]
     end
 

--- a/elasticsearch-api/spec/elasticsearch/api/actions/mget_spec.rb
+++ b/elasticsearch-api/spec/elasticsearch/api/actions/mget_spec.rb
@@ -11,7 +11,8 @@ describe 'client#mget' do
         'GET',
         url,
         params,
-        body
+        body,
+        {}
     ]
   end
 

--- a/elasticsearch-api/spec/elasticsearch/api/actions/mtermvectors_spec.rb
+++ b/elasticsearch-api/spec/elasticsearch/api/actions/mtermvectors_spec.rb
@@ -10,8 +10,9 @@ describe 'client#mtermvectors' do
     [
         'GET',
         'my-index/my-type/_mtermvectors',
-        { },
-        body
+        {},
+        body,
+        {}
     ]
   end
 

--- a/elasticsearch-api/spec/elasticsearch/api/actions/nodes/hot_threads_spec.rb
+++ b/elasticsearch-api/spec/elasticsearch/api/actions/nodes/hot_threads_spec.rb
@@ -12,7 +12,7 @@ describe 'client.nodes#hot_threads' do
         url,
         {},
         nil,
-        nil
+        {}
     ]
   end
 

--- a/elasticsearch-api/spec/elasticsearch/api/actions/nodes/info_spec.rb
+++ b/elasticsearch-api/spec/elasticsearch/api/actions/nodes/info_spec.rb
@@ -12,7 +12,7 @@ describe 'client.nodes#info' do
         url,
         params,
         nil,
-        nil
+        {}
     ]
   end
 

--- a/elasticsearch-api/spec/elasticsearch/api/actions/nodes/reload_secure_settings_spec.rb
+++ b/elasticsearch-api/spec/elasticsearch/api/actions/nodes/reload_secure_settings_spec.rb
@@ -12,7 +12,7 @@ describe 'client#reload_secure_settings' do
         url,
         params,
         nil,
-        nil
+        {}
     ]
   end
 

--- a/elasticsearch-api/spec/elasticsearch/api/actions/nodes/stats_spec.rb
+++ b/elasticsearch-api/spec/elasticsearch/api/actions/nodes/stats_spec.rb
@@ -12,7 +12,7 @@ describe 'client.nodes#stats' do
         url,
         params,
         nil,
-        nil
+        {}
     ]
   end
 

--- a/elasticsearch-api/spec/elasticsearch/api/actions/ping_spec.rb
+++ b/elasticsearch-api/spec/elasticsearch/api/actions/ping_spec.rb
@@ -10,8 +10,9 @@ describe 'client#ping' do
     [
         'HEAD',
         '',
-        { },
-        nil
+        {},
+        nil,
+        {}
     ]
   end
 

--- a/elasticsearch-api/spec/elasticsearch/api/actions/put_script_spec.rb
+++ b/elasticsearch-api/spec/elasticsearch/api/actions/put_script_spec.rb
@@ -15,7 +15,8 @@ describe 'client#put_script' do
         'PUT',
         url,
         {},
-        { script: 'bar', lang: 'groovy' }
+        { script: 'bar', lang: 'groovy' },
+        {}
       ]
     end
 
@@ -30,7 +31,8 @@ describe 'client#put_script' do
         'PUT',
         url,
         {},
-        { script: 'bar' }
+        { script: 'bar' },
+        {}
       ]
     end
 

--- a/elasticsearch-api/spec/elasticsearch/api/actions/reindex_spec.rb
+++ b/elasticsearch-api/spec/elasticsearch/api/actions/reindex_spec.rb
@@ -10,8 +10,9 @@ describe 'client#reindex' do
     [
         'POST',
         '_reindex',
-        { },
-        { }
+        {},
+        {},
+        {}
     ]
   end
 

--- a/elasticsearch-api/spec/elasticsearch/api/actions/render_search_template_spec.rb
+++ b/elasticsearch-api/spec/elasticsearch/api/actions/render_search_template_spec.rb
@@ -11,7 +11,8 @@ describe 'client#render_search_template' do
         'GET',
         '_render/template',
         {},
-        { foo: 'bar' }
+        { foo: 'bar' },
+        {}
       ]
     end
 
@@ -26,7 +27,8 @@ describe 'client#render_search_template' do
         'GET',
         '_render/template/foo',
         {},
-        { foo: 'bar' }
+        { foo: 'bar' },
+        {}
       ]
     end
 

--- a/elasticsearch-api/spec/elasticsearch/api/actions/scroll_spec.rb
+++ b/elasticsearch-api/spec/elasticsearch/api/actions/scroll_spec.rb
@@ -11,7 +11,8 @@ describe 'client#scroll' do
         'GET',
         '_search/scroll/cXVlcn...',
         {},
-        nil
+        nil,
+        {}
       ]
     end
 
@@ -26,7 +27,8 @@ describe 'client#scroll' do
         'GET',
         '_search/scroll',
         {},
-        { scroll_id: 'cXVlcn...' }
+        { scroll_id: 'cXVlcn...' },
+        {}
       ]
     end
 

--- a/elasticsearch-api/spec/elasticsearch/api/actions/search_shards_spec.rb
+++ b/elasticsearch-api/spec/elasticsearch/api/actions/search_shards_spec.rb
@@ -10,8 +10,9 @@ describe 'client#search_shards' do
     [
         'GET',
         '_search_shards',
-        { },
-        nil
+        {},
+        nil,
+        {}
     ]
   end
 

--- a/elasticsearch-api/spec/elasticsearch/api/actions/search_spec.rb
+++ b/elasticsearch-api/spec/elasticsearch/api/actions/search_spec.rb
@@ -11,7 +11,8 @@ describe 'client#search' do
         'GET',
         url,
         params,
-        body
+        body,
+        {}
     ]
   end
 

--- a/elasticsearch-api/spec/elasticsearch/api/actions/search_template_spec.rb
+++ b/elasticsearch-api/spec/elasticsearch/api/actions/search_template_spec.rb
@@ -11,7 +11,8 @@ describe 'client#search_template' do
         'GET',
         'foo/_search/template',
         { },
-        { foo: 'bar' }
+        { foo: 'bar' },
+        {}
     ]
   end
 

--- a/elasticsearch-api/spec/elasticsearch/api/actions/snapshot/create_repository_spec.rb
+++ b/elasticsearch-api/spec/elasticsearch/api/actions/snapshot/create_repository_spec.rb
@@ -12,7 +12,7 @@ describe 'client.snapshot#create_repository' do
         '_snapshot/foo',
         {},
         {},
-        nil
+        {}
     ]
   end
 

--- a/elasticsearch-api/spec/elasticsearch/api/actions/snapshot/create_spec.rb
+++ b/elasticsearch-api/spec/elasticsearch/api/actions/snapshot/create_spec.rb
@@ -12,7 +12,7 @@ describe 'client.snapshot#create' do
         '_snapshot/foo/bar',
         {},
         {},
-        nil
+        {}
     ]
   end
 

--- a/elasticsearch-api/spec/elasticsearch/api/actions/snapshot/delete_repository_spec.rb
+++ b/elasticsearch-api/spec/elasticsearch/api/actions/snapshot/delete_repository_spec.rb
@@ -12,7 +12,7 @@ describe 'client.snapshot#delete_repository' do
         url,
         {},
         nil,
-        nil
+        {}
     ]
   end
 

--- a/elasticsearch-api/spec/elasticsearch/api/actions/snapshot/delete_spec.rb
+++ b/elasticsearch-api/spec/elasticsearch/api/actions/snapshot/delete_spec.rb
@@ -12,7 +12,7 @@ describe 'client.snapshot#delete' do
         '_snapshot/foo/bar',
         {},
         nil,
-        nil
+        {}
     ]
   end
 

--- a/elasticsearch-api/spec/elasticsearch/api/actions/snapshot/get_repository_spec.rb
+++ b/elasticsearch-api/spec/elasticsearch/api/actions/snapshot/get_repository_spec.rb
@@ -12,7 +12,7 @@ describe 'client.snapshot#get_repository' do
         '_snapshot/foo',
         {},
         nil,
-        nil
+        {}
     ]
   end
 

--- a/elasticsearch-api/spec/elasticsearch/api/actions/snapshot/get_spec.rb
+++ b/elasticsearch-api/spec/elasticsearch/api/actions/snapshot/get_spec.rb
@@ -12,7 +12,7 @@ describe 'client.snapshot#get' do
         '_snapshot/foo/bar',
         {},
         nil,
-        nil
+        {}
     ]
   end
 

--- a/elasticsearch-api/spec/elasticsearch/api/actions/snapshot/restore_spec.rb
+++ b/elasticsearch-api/spec/elasticsearch/api/actions/snapshot/restore_spec.rb
@@ -12,7 +12,7 @@ describe 'client.snapshot#restore' do
         '_snapshot/foo/bar/_restore',
         {},
         nil,
-        nil
+        {}
     ]
   end
 

--- a/elasticsearch-api/spec/elasticsearch/api/actions/snapshot/status_spec.rb
+++ b/elasticsearch-api/spec/elasticsearch/api/actions/snapshot/status_spec.rb
@@ -12,7 +12,7 @@ describe 'client.snapshot#status' do
         url,
         {},
         nil,
-        nil
+        {}
     ]
   end
 

--- a/elasticsearch-api/spec/elasticsearch/api/actions/snapshot/verify_repository_spec.rb
+++ b/elasticsearch-api/spec/elasticsearch/api/actions/snapshot/verify_repository_spec.rb
@@ -12,7 +12,7 @@ describe 'client.snapshot#verify_repository' do
         '_snapshot/foo/_verify',
         {},
         nil,
-        nil
+        {}
     ]
   end
 

--- a/elasticsearch-api/spec/elasticsearch/api/actions/tasks/cancel_spec.rb
+++ b/elasticsearch-api/spec/elasticsearch/api/actions/tasks/cancel_spec.rb
@@ -12,7 +12,7 @@ describe 'client.tasks#cancel' do
         url,
         {},
         nil,
-        nil
+        {}
     ]
   end
 

--- a/elasticsearch-api/spec/elasticsearch/api/actions/tasks/get_spec.rb
+++ b/elasticsearch-api/spec/elasticsearch/api/actions/tasks/get_spec.rb
@@ -12,7 +12,7 @@ describe 'client.tasks#get' do
         '_tasks/foo1',
         {},
         nil,
-        nil
+        {}
     ]
   end
 

--- a/elasticsearch-api/spec/elasticsearch/api/actions/tasks/list_spec.rb
+++ b/elasticsearch-api/spec/elasticsearch/api/actions/tasks/list_spec.rb
@@ -12,7 +12,7 @@ describe 'client.tasks#list' do
         url,
         {},
         nil,
-        nil
+        {}
     ]
   end
 

--- a/elasticsearch-api/spec/elasticsearch/api/actions/termvectors_spec.rb
+++ b/elasticsearch-api/spec/elasticsearch/api/actions/termvectors_spec.rb
@@ -11,7 +11,8 @@ describe 'client#termvectors' do
         'GET',
         url,
         params,
-        body
+        body,
+        {}
     ]
   end
 

--- a/elasticsearch-api/spec/elasticsearch/api/actions/update_by_query_spec.rb
+++ b/elasticsearch-api/spec/elasticsearch/api/actions/update_by_query_spec.rb
@@ -10,8 +10,9 @@ describe 'client#update_by_query' do
     [
         'POST',
         'foo/_update_by_query',
-        { },
-        nil
+        {},
+        nil,
+        {}
     ]
   end
 

--- a/elasticsearch-api/spec/elasticsearch/api/actions/update_document_spec.rb
+++ b/elasticsearch-api/spec/elasticsearch/api/actions/update_document_spec.rb
@@ -11,7 +11,8 @@ describe 'client#update' do
         'POST',
         url,
         params,
-        body
+        body,
+        {}
     ]
   end
 

--- a/elasticsearch-api/utils/thor/generator/endpoint_specifics.rb
+++ b/elasticsearch-api/utils/thor/generator/endpoint_specifics.rb
@@ -87,7 +87,7 @@ module Elasticsearch
       def ping_perform_request
         <<~SRC
           begin
-            perform_request(method, path, params, body).status == 200 ? true : false
+            perform_request(method, path, params, body, headers).status == 200 ? true : false
           rescue Exception => e
             if e.class.to_s =~ /NotFound|ConnectionFailed/ || e.message =~ /Not\s*Found|404|ConnectionFailed/i
               false

--- a/elasticsearch-api/utils/thor/templates/_documentation_top.erb
+++ b/elasticsearch-api/utils/thor/templates/_documentation_top.erb
@@ -12,7 +12,8 @@
 <%# URL parameters -%>
 <%- @params.each do |name, info| -%>
   <%= docs_helper(name, info) -%>
-<%- end %>
+<%- end -%>
+# @option arguments [Hash] :headers Custom HTTP headers
 <%= '  '*(@namespace_depth+3) + '# @option arguments [Hash] :body ' + (@spec['body']['description'] ? @spec['body']['description'].strip : 'TODO: Description') + (@spec['body']['required'] ? ' (*Required*)' : '') + "\n" if @spec['body'] -%>
 <% if @deprecation_note -%>
   #
@@ -23,5 +24,5 @@
 <% end -%>
 <%= '  '*(@namespace_depth+3) -%>#
 <%# Documentation link -%>
-<%=  '  '*(@namespace_depth+3) %># @see <%= @spec['documentation']['url'] ? @spec['documentation']['url'].gsub!(/\/(current|master)\//, '/7.5/') : "[TODO]" %>
+<%=  '  '*(@namespace_depth+3) %># @see <%= @spec['documentation']['url'] ? @spec['documentation']['url'] : "[TODO]" %>
 <%= '  '*(@namespace_depth+3) %>#

--- a/elasticsearch-api/utils/thor/templates/_perform_request.erb
+++ b/elasticsearch-api/utils/thor/templates/_perform_request.erb
@@ -16,22 +16,23 @@ when 'mtermvectors'
 <%- end -%>
 <%- if ['bulk', 'msearch', 'msearch_template'].include? @method_name -%>
   <%= self.send("#{@method_name}_body_helper".to_s) %>
-  <%= '  '*(@namespace_depth+4) %>perform_request(method, path, params, payload, {"Content-Type" => "application/x-ndjson"}).body
+  headers.merge!("Content-Type" => "application/x-ndjson")
+  <%= '  '*(@namespace_depth+4) %>perform_request(method, path, params, payload, headers).body
 <%- elsif @method_name == 'ping' -%>
   <%= ping_perform_request %>
 <%- else -%>
   <%- if needs_ignore_404?(@endpoint_name) %>
     <%= __utils %>.__rescue_from_not_found do
-      perform_request(method, path, params, body).status == 200 ? true : false
+      perform_request(method, path, params, body, headers).status == 200 ? true : false
     end
   <%- elsif needs_complex_ignore_404?(@endpoint_name) -%>
     if Array(arguments[:ignore]).include?(404)
-      <%= __utils %>.__rescue_from_not_found { perform_request(method, path, params, body).body }
+      <%= __utils %>.__rescue_from_not_found { perform_request(method, path, params, body, headers).body }
     else
-      perform_request(method, path, params, body).body
+      perform_request(method, path, params, body, headers).body
     end
   <%- else -%>
-      perform_request(method, path, params, body).body
+      perform_request(method, path, params, body, headers).body
   <%- end -%>
 <%- end -%>
 <%= '  '*(@namespace_depth+3) %>end

--- a/elasticsearch-api/utils/thor/templates/method.erb
+++ b/elasticsearch-api/utils/thor/templates/method.erb
@@ -13,7 +13,7 @@ module Elasticsearch
 <%= '  '*(@namespace_depth+2) %>module Actions
 <%= ERB.new(File.new("./thor/templates/_documentation_top.erb").read, trim_mode: '-').result(binding) -%>
 <%# Method definition -%>
-<%= '  '*(@namespace_depth+3) -%>def <%= @method_name %>(arguments={})
+<%= '  '*(@namespace_depth+3) -%>def <%= @method_name %>(arguments = {})
 <%- if @endpoint_name == 'create' -%>
   <%= '  '*(@namespace_depth+3) %>if arguments[:id]
   <%= '  '*(@namespace_depth+3) %>  index arguments.update op_type: 'create'
@@ -30,6 +30,7 @@ module Elasticsearch
       <%= '  '*(@namespace_depth+3) + "raise ArgumentError, \"Required argument '#{required}' missing\" unless arguments[:#{required}]" + "\n" -%>
     <%- end -%>
     <%- end -%>
+    headers = arguments.delete(:headers) || {}
     <%- # Method setup -%>
     <%= ERB.new(File.new("./thor/templates/_method_setup.erb").read, trim_mode: '-').result(binding) %>
     <%- # Perform request -%>

--- a/elasticsearch-transport/README.md
+++ b/elasticsearch-transport/README.md
@@ -78,6 +78,7 @@ Full documentation is available at <http://rubydoc.info/gems/elasticsearch-trans
 * [Connect using an Elastic Cloud ID](#connect-using-an-elastic-cloud-id)
 * [Authentication](#authentication)
 * [Logging](#logging)
+* [Custom HTTP Headers](#custom-http-headers)
 * [Identifying running tasks with X-Opaque-Id](#identifying-running-tasks-with-x-opaque-id)
 * [Setting Timeouts](#setting-timeouts)
 * [Randomizing Hosts](#randomizing-hosts)
@@ -189,30 +190,55 @@ Elasticsearch::Client.new(
 To log requests and responses to standard output with the default logger (an instance of Ruby's {::Logger} class),
 set the `log` argument:
 
-    Elasticsearch::Client.new log: true
+```ruby
+Elasticsearch::Client.new log: true
+```
+
 
 To trace requests and responses in the _Curl_ format, set the `trace` argument:
 
-    Elasticsearch::Client.new trace: true
+```ruby
+Elasticsearch::Client.new trace: true
+```
 
 You can customize the default logger or tracer:
 
+```ruby
     client.transport.logger.formatter = proc { |s, d, p, m| "#{s}: #{m}\n" }
     client.transport.logger.level = Logger::INFO
+```
 
 Or, you can use a custom `::Logger` instance:
 
-    Elasticsearch::Client.new logger: Logger.new(STDERR)
+```ruby
+Elasticsearch::Client.new logger: Logger.new(STDERR)
+```
 
 You can pass the client any conforming logger implementation:
 
-    require 'logging' # https://github.com/TwP/logging/
+```ruby
+require 'logging' # https://github.com/TwP/logging/
 
-    log = Logging.logger['elasticsearch']
-    log.add_appenders Logging.appenders.stdout
-    log.level = :info
+log = Logging.logger['elasticsearch']
+log.add_appenders Logging.appenders.stdout
+log.level = :info
 
-    client = Elasticsearch::Client.new logger: log
+client = Elasticsearch::Client.new logger: log
+```
+
+### Custom HTTP Headers
+
+You can set a custom HTTP header on the client's initializer:
+
+```ruby
+client = Elasticsearch::Client.new(
+  transport_options: {
+    headers:
+      {user_agent: "My Ruby App"}
+  }
+)
+```
+
 ### Identifying running tasks with X-Opaque-Id
 
 The X-Opaque-Id header allows to track certain calls, or associate certain tasks with the client that started them ([more on the Elasticsearch docs](https://www.elastic.co/guide/en/elasticsearch/reference/master/tasks.html#_identifying_running_tasks)). To use this feature, you need to set an id for `opaque_id` on the client on each request. Example:
@@ -330,25 +356,29 @@ preferring HTTP clients with support for persistent connections.
 
 To use the [_Patron_](https://github.com/toland/patron) HTTP, for example, just require it:
 
-    require 'patron'
+```ruby
+require 'patron'
+```
 
 Then, create a new client, and the _Patron_  gem will be used as the "driver":
 
-    client = Elasticsearch::Client.new
+```ruby
+client = Elasticsearch::Client.new
 
-    client.transport.connections.first.connection.builder.handlers
-    # => [Faraday::Adapter::Patron]
+client.transport.connections.first.connection.builder.adapter
+# => Faraday::Adapter::Patron
 
-    10.times do
-      client.nodes.stats(metric: 'http')['nodes'].values.each do |n|
-        puts "#{n['name']} : #{n['http']['total_opened']}"
-      end
-    end
+10.times do
+  client.nodes.stats(metric: 'http')['nodes'].values.each do |n|
+    puts "#{n['name']} : #{n['http']['total_opened']}"
+  end
+end
 
-    # => Stiletoo : 24
-    # => Stiletoo : 24
-    # => Stiletoo : 24
-    # => ...
+# => Stiletoo : 24
+# => Stiletoo : 24
+# => Stiletoo : 24
+# => ...
+```
 
 To use a specific adapter for _Faraday_, pass it as the `adapter` argument:
 

--- a/elasticsearch-transport/spec/elasticsearch/transport/client_spec.rb
+++ b/elasticsearch-transport/spec/elasticsearch/transport/client_spec.rb
@@ -1133,6 +1133,18 @@ describe Elasticsearch::Transport::Client do
         end
       end
     end
+
+    context 'when a header is set on an endpoint request' do
+      let(:client) { described_class.new(host: hosts) }
+      let(:headers) { { 'user-agent' => 'my ruby app' } }
+
+      it 'performs the request with the header' do
+        allow(client).to receive(:perform_request) { OpenStruct.new(body: '') }
+        expect { client.search(headers: headers) }.not_to raise_error
+        expect(client).to have_received(:perform_request)
+          .with('GET', '_search', {}, nil, headers)
+      end
+    end
   end
 
   context 'when the client connects to Elasticsearch' do

--- a/elasticsearch-transport/spec/elasticsearch/transport/client_spec.rb
+++ b/elasticsearch-transport/spec/elasticsearch/transport/client_spec.rb
@@ -1129,7 +1129,7 @@ describe Elasticsearch::Transport::Client do
           allow(client).to receive(:perform_request) { OpenStruct.new(body: '') }
           expect { client.search(opaque_id: 'opaque_id') }.not_to raise_error
           expect(client).to have_received(:perform_request)
-            .with('GET', '_search', { opaque_id: 'opaque_id' }, nil)
+            .with('GET', '_search', { opaque_id: 'opaque_id' }, nil, {})
         end
       end
     end

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/async_search/delete.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/async_search/delete.rb
@@ -7,16 +7,17 @@ module Elasticsearch
     module API
       module AsyncSearch
         module Actions
-          # TODO: Description
-
+          # Deletes an async search by ID. If the search is still running, the search request will be cancelled. Otherwise, the saved search results are deleted.
           #
           # @option arguments [String] :id The async search ID
-
+          # @option arguments [Hash] :headers Custom HTTP headers
           #
           # @see https://www.elastic.co/guide/en/elasticsearch/reference/current/async-search.html
           #
           def delete(arguments = {})
             raise ArgumentError, "Required argument 'id' missing" unless arguments[:id]
+
+            headers = arguments.delete(:headers) || {}
 
             arguments = arguments.clone
 
@@ -27,7 +28,7 @@ module Elasticsearch
             params = {}
 
             body = nil
-            perform_request(method, path, params, body).body
+            perform_request(method, path, params, body, headers).body
           end
       end
     end

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/async_search/get.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/async_search/get.rb
@@ -7,19 +7,20 @@ module Elasticsearch
     module API
       module AsyncSearch
         module Actions
-          # TODO: Description
-
+          # Retrieves the results of a previously submitted async search request given its ID.
           #
           # @option arguments [String] :id The async search ID
           # @option arguments [Time] :wait_for_completion_timeout Specify the time that the request should block waiting for the final response
           # @option arguments [Time] :keep_alive Specify the time interval in which the results (partial or final) for this search will be available
           # @option arguments [Boolean] :typed_keys Specify whether aggregation and suggester names should be prefixed by their respective types in the response
-
+          # @option arguments [Hash] :headers Custom HTTP headers
           #
           # @see https://www.elastic.co/guide/en/elasticsearch/reference/current/async-search.html
           #
           def get(arguments = {})
             raise ArgumentError, "Required argument 'id' missing" unless arguments[:id]
+
+            headers = arguments.delete(:headers) || {}
 
             arguments = arguments.clone
 
@@ -30,7 +31,7 @@ module Elasticsearch
             params = Elasticsearch::API::Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
 
             body = nil
-            perform_request(method, path, params, body).body
+            perform_request(method, path, params, body, headers).body
           end
 
           # Register this action with its valid params when the module is loaded.

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/async_search/submit.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/async_search/submit.rb
@@ -7,8 +7,7 @@ module Elasticsearch
     module API
       module AsyncSearch
         module Actions
-          # TODO: Description
-
+          # Executes a search request asynchronously.
           #
           # @option arguments [List] :index A comma-separated list of index names to search; use `_all` or empty string to perform the operation on all indices
           # @option arguments [Time] :wait_for_completion_timeout Specify the time that the request should block waiting for the final response
@@ -30,7 +29,7 @@ module Elasticsearch
           # @option arguments [Boolean] :ignore_throttled Whether specified concrete, expanded or aliased indices should be ignored when throttled
           # @option arguments [Boolean] :allow_no_indices Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)
           # @option arguments [String] :expand_wildcards Whether to expand wildcard expression to concrete indices that are open, closed or both.
-          #   (options: open,closed,none,all)
+          #   (options: open,closed,hidden,none,all)
 
           # @option arguments [Boolean] :lenient Specify whether format-based query failures (such as providing text to a numeric field) should be ignored
           # @option arguments [String] :preference Specify the node or shard the operation should be performed on (default: random)
@@ -60,12 +59,14 @@ module Elasticsearch
           # @option arguments [Boolean] :version Specify whether to return document version as part of a hit
           # @option arguments [Boolean] :seq_no_primary_term Specify whether to return sequence number and primary term of the last modification of each hit
           # @option arguments [Number] :max_concurrent_shard_requests The number of concurrent shard requests per node this search executes concurrently. This value should be used to limit the impact of the search on the cluster in order to limit the number of concurrent shard requests
-
+          # @option arguments [Hash] :headers Custom HTTP headers
           # @option arguments [Hash] :body The search definition using the Query DSL
           #
           # @see https://www.elastic.co/guide/en/elasticsearch/reference/current/async-search.html
           #
           def submit(arguments = {})
+            headers = arguments.delete(:headers) || {}
+
             arguments = arguments.clone
 
             _index = arguments.delete(:index)
@@ -75,11 +76,11 @@ module Elasticsearch
                        "#{Elasticsearch::API::Utils.__listify(_index)}/_async_search"
                      else
                        "_async_search"
-  end
+            end
             params = Elasticsearch::API::Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
 
             body = arguments[:body]
-            perform_request(method, path, params, body).body
+            perform_request(method, path, params, body, headers).body
           end
 
           # Register this action with its valid params when the module is loaded.

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/cat/ml_data_frame_analytics.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/cat/ml_data_frame_analytics.rb
@@ -7,8 +7,7 @@ module Elasticsearch
     module API
       module Cat
         module Actions
-          # TODO: Description
-
+          # Gets configuration and usage information about data frame analytics jobs.
           #
           # @option arguments [String] :id The ID of the data frame analytics to fetch
           # @option arguments [Boolean] :allow_no_match Whether to ignore if a wildcard expression matches no configs. (This includes `_all` string or when no configs have been specified)
@@ -20,14 +19,16 @@ module Elasticsearch
           # @option arguments [Boolean] :help Return help information
           # @option arguments [List] :s Comma-separated list of column names or column aliases to sort by
           # @option arguments [String] :time The unit in which to display time values
-          #   (options: d (Days),h (Hours),m (Minutes),s (Seconds),ms (Milliseconds),micros (Microseconds),nanos (Nanoseconds))
+          #   (options: d,h,m,s,ms,micros,nanos)
 
           # @option arguments [Boolean] :v Verbose mode. Display column headers
-
+          # @option arguments [Hash] :headers Custom HTTP headers
           #
           # @see http://www.elastic.co/guide/en/elasticsearch/reference/current/cat-dfanalytics.html
           #
           def ml_data_frame_analytics(arguments = {})
+            headers = arguments.delete(:headers) || {}
+
             arguments = arguments.clone
 
             _id = arguments.delete(:id)
@@ -37,11 +38,11 @@ module Elasticsearch
                        "_cat/ml/data_frame/analytics/#{Elasticsearch::API::Utils.__listify(_id)}"
                      else
                        "_cat/ml/data_frame/analytics"
-  end
+            end
             params = Elasticsearch::API::Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
 
             body = nil
-            perform_request(method, path, params, body).body
+            perform_request(method, path, params, body, headers).body
           end
 
           # Register this action with its valid params when the module is loaded.

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/cat/ml_datafeeds.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/cat/ml_datafeeds.rb
@@ -7,8 +7,7 @@ module Elasticsearch
     module API
       module Cat
         module Actions
-          # TODO: Description
-
+          # Gets configuration and usage information about datafeeds.
           #
           # @option arguments [String] :datafeed_id The ID of the datafeeds stats to fetch
           # @option arguments [Boolean] :allow_no_datafeeds Whether to ignore if a wildcard expression matches no datafeeds. (This includes `_all` string or when no datafeeds have been specified)
@@ -17,14 +16,16 @@ module Elasticsearch
           # @option arguments [Boolean] :help Return help information
           # @option arguments [List] :s Comma-separated list of column names or column aliases to sort by
           # @option arguments [String] :time The unit in which to display time values
-          #   (options: d (Days),h (Hours),m (Minutes),s (Seconds),ms (Milliseconds),micros (Microseconds),nanos (Nanoseconds))
+          #   (options: d,h,m,s,ms,micros,nanos)
 
           # @option arguments [Boolean] :v Verbose mode. Display column headers
-
+          # @option arguments [Hash] :headers Custom HTTP headers
           #
           # @see http://www.elastic.co/guide/en/elasticsearch/reference/current/cat-datafeeds.html
           #
           def ml_datafeeds(arguments = {})
+            headers = arguments.delete(:headers) || {}
+
             arguments = arguments.clone
 
             _datafeed_id = arguments.delete(:datafeed_id)
@@ -34,11 +35,11 @@ module Elasticsearch
                        "_cat/ml/datafeeds/#{Elasticsearch::API::Utils.__listify(_datafeed_id)}"
                      else
                        "_cat/ml/datafeeds"
-  end
+            end
             params = Elasticsearch::API::Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
 
             body = nil
-            perform_request(method, path, params, body).body
+            perform_request(method, path, params, body, headers).body
           end
 
           # Register this action with its valid params when the module is loaded.

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/cat/ml_trained_models.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/cat/ml_trained_models.rb
@@ -7,8 +7,7 @@ module Elasticsearch
     module API
       module Cat
         module Actions
-          # TODO: Description
-
+          # Gets configuration and usage information about inference trained models.
           #
           # @option arguments [String] :model_id The ID of the trained models stats to fetch
           # @option arguments [Boolean] :allow_no_match Whether to ignore if a wildcard expression matches no trained models. (This includes `_all` string or when no trained models have been specified)
@@ -22,14 +21,16 @@ module Elasticsearch
           # @option arguments [Boolean] :help Return help information
           # @option arguments [List] :s Comma-separated list of column names or column aliases to sort by
           # @option arguments [String] :time The unit in which to display time values
-          #   (options: d (Days),h (Hours),m (Minutes),s (Seconds),ms (Milliseconds),micros (Microseconds),nanos (Nanoseconds))
+          #   (options: d,h,m,s,ms,micros,nanos)
 
           # @option arguments [Boolean] :v Verbose mode. Display column headers
-
+          # @option arguments [Hash] :headers Custom HTTP headers
           #
           # @see https://www.elastic.co/guide/en/elasticsearch/reference/current/cat-trained-model.html
           #
           def ml_trained_models(arguments = {})
+            headers = arguments.delete(:headers) || {}
+
             arguments = arguments.clone
 
             _model_id = arguments.delete(:model_id)
@@ -39,11 +40,11 @@ module Elasticsearch
                        "_cat/ml/trained_models/#{Elasticsearch::API::Utils.__listify(_model_id)}"
                      else
                        "_cat/ml/trained_models"
-  end
+            end
             params = Elasticsearch::API::Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
 
             body = nil
-            perform_request(method, path, params, body).body
+            perform_request(method, path, params, body, headers).body
           end
 
           # Register this action with its valid params when the module is loaded.

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/cat/transforms.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/cat/transforms.rb
@@ -7,13 +7,12 @@ module Elasticsearch
     module API
       module Cat
         module Actions
-          # Gets configuration and usage information about anomaly detection jobs.
+          # Gets configuration and usage information about transforms.
           #
-          # @option arguments [String] :job_id The ID of the jobs stats to fetch
-          # @option arguments [Boolean] :allow_no_jobs Whether to ignore if a wildcard expression matches no jobs. (This includes `_all` string or when no jobs have been specified)
-          # @option arguments [String] :bytes The unit in which to display byte values
-          #   (options: b,k,kb,m,mb,g,gb,t,tb,p,pb)
-
+          # @option arguments [String] :transform_id The id of the transform for which to get stats. '_all' or '*' implies all transforms
+          # @option arguments [Int] :from skips a number of transform configs, defaults to 0
+          # @option arguments [Int] :size specifies a max number of transforms to get, defaults to 100
+          # @option arguments [Boolean] :allow_no_match Whether to ignore if a wildcard expression matches no transforms. (This includes `_all` string or when no transforms have been specified)
           # @option arguments [String] :format a short version of the Accept header, e.g. json, yaml
           # @option arguments [List] :h Comma-separated list of column names to display
           # @option arguments [Boolean] :help Return help information
@@ -24,20 +23,20 @@ module Elasticsearch
           # @option arguments [Boolean] :v Verbose mode. Display column headers
           # @option arguments [Hash] :headers Custom HTTP headers
           #
-          # @see http://www.elastic.co/guide/en/elasticsearch/reference/current/cat-anomaly-detectors.html
+          # @see https://www.elastic.co/guide/en/elasticsearch/reference/current/cat-transforms.html
           #
-          def ml_jobs(arguments = {})
+          def transforms(arguments = {})
             headers = arguments.delete(:headers) || {}
 
             arguments = arguments.clone
 
-            _job_id = arguments.delete(:job_id)
+            _transform_id = arguments.delete(:transform_id)
 
             method = Elasticsearch::API::HTTP_GET
-            path   = if _job_id
-                       "_cat/ml/anomaly_detectors/#{Elasticsearch::API::Utils.__listify(_job_id)}"
+            path   = if _transform_id
+                       "_cat/transforms/#{Elasticsearch::API::Utils.__listify(_transform_id)}"
                      else
-                       "_cat/ml/anomaly_detectors"
+                       "_cat/transforms"
             end
             params = Elasticsearch::API::Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
 
@@ -48,9 +47,10 @@ module Elasticsearch
           # Register this action with its valid params when the module is loaded.
           #
           # @since 6.2.0
-          ParamsRegistry.register(:ml_jobs, [
-            :allow_no_jobs,
-            :bytes,
+          ParamsRegistry.register(:transforms, [
+            :from,
+            :size,
+            :allow_no_match,
             :format,
             :h,
             :help,

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/data_frame_transform_deprecated/delete_transform.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/data_frame_transform_deprecated/delete_transform.rb
@@ -7,12 +7,11 @@ module Elasticsearch
     module API
       module DataFrameTransformDeprecated
         module Actions
-          # TODO: Description
-
+          # Deletes an existing transform.
           #
           # @option arguments [String] :transform_id The id of the transform to delete
           # @option arguments [Boolean] :force When `true`, the transform is deleted regardless of its current state. The default value is `false`, meaning that the transform must be `stopped` before it can be deleted.
-
+          # @option arguments [Hash] :headers Custom HTTP headers
           #
           # *Deprecation notice*:
           # [_data_frame/transforms/] is deprecated, use [_transform/] in the future.
@@ -24,6 +23,8 @@ module Elasticsearch
           def delete_transform(arguments = {})
             raise ArgumentError, "Required argument 'transform_id' missing" unless arguments[:transform_id]
 
+            headers = arguments.delete(:headers) || {}
+
             arguments = arguments.clone
 
             _transform_id = arguments.delete(:transform_id)
@@ -33,7 +34,7 @@ module Elasticsearch
             params = Elasticsearch::API::Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
 
             body = nil
-            perform_request(method, path, params, body).body
+            perform_request(method, path, params, body, headers).body
           end
 
           # Register this action with its valid params when the module is loaded.

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/data_frame_transform_deprecated/get_transform.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/data_frame_transform_deprecated/get_transform.rb
@@ -7,14 +7,13 @@ module Elasticsearch
     module API
       module DataFrameTransformDeprecated
         module Actions
-          # TODO: Description
-
+          # Retrieves configuration information for transforms.
           #
           # @option arguments [String] :transform_id The id or comma delimited list of id expressions of the transforms to get, '_all' or '*' implies get all transforms
           # @option arguments [Int] :from skips a number of transform configs, defaults to 0
           # @option arguments [Int] :size specifies a max number of transforms to get, defaults to 100
           # @option arguments [Boolean] :allow_no_match Whether to ignore if a wildcard expression matches no transforms. (This includes `_all` string or when no transforms have been specified)
-
+          # @option arguments [Hash] :headers Custom HTTP headers
           #
           # *Deprecation notice*:
           # [_data_frame/transforms/] is deprecated, use [_transform/] in the future.
@@ -24,6 +23,8 @@ module Elasticsearch
           # @see https://www.elastic.co/guide/en/elasticsearch/reference/current/get-transform.html
           #
           def get_transform(arguments = {})
+            headers = arguments.delete(:headers) || {}
+
             arguments = arguments.clone
 
             _transform_id = arguments.delete(:transform_id)
@@ -33,11 +34,11 @@ module Elasticsearch
                        "_data_frame/transforms/#{Elasticsearch::API::Utils.__listify(_transform_id)}"
                      else
                        "_data_frame/transforms"
-  end
+            end
             params = Elasticsearch::API::Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
 
             body = nil
-            perform_request(method, path, params, body).body
+            perform_request(method, path, params, body, headers).body
           end
 
           # Register this action with its valid params when the module is loaded.

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/data_frame_transform_deprecated/get_transform_stats.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/data_frame_transform_deprecated/get_transform_stats.rb
@@ -7,14 +7,13 @@ module Elasticsearch
     module API
       module DataFrameTransformDeprecated
         module Actions
-          # TODO: Description
-
+          # Retrieves usage information for transforms.
           #
           # @option arguments [String] :transform_id The id of the transform for which to get stats. '_all' or '*' implies all transforms
           # @option arguments [Number] :from skips a number of transform stats, defaults to 0
           # @option arguments [Number] :size specifies a max number of transform stats to get, defaults to 100
           # @option arguments [Boolean] :allow_no_match Whether to ignore if a wildcard expression matches no transforms. (This includes `_all` string or when no transforms have been specified)
-
+          # @option arguments [Hash] :headers Custom HTTP headers
           #
           # *Deprecation notice*:
           # [_data_frame/transforms/] is deprecated, use [_transform/] in the future.
@@ -26,6 +25,8 @@ module Elasticsearch
           def get_transform_stats(arguments = {})
             raise ArgumentError, "Required argument 'transform_id' missing" unless arguments[:transform_id]
 
+            headers = arguments.delete(:headers) || {}
+
             arguments = arguments.clone
 
             _transform_id = arguments.delete(:transform_id)
@@ -35,7 +36,7 @@ module Elasticsearch
             params = Elasticsearch::API::Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
 
             body = nil
-            perform_request(method, path, params, body).body
+            perform_request(method, path, params, body, headers).body
           end
 
           # Register this action with its valid params when the module is loaded.

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/data_frame_transform_deprecated/preview_transform.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/data_frame_transform_deprecated/preview_transform.rb
@@ -7,8 +7,9 @@ module Elasticsearch
     module API
       module DataFrameTransformDeprecated
         module Actions
-          # TODO: Description
-
+          # Previews a transform.
+          #
+          # @option arguments [Hash] :headers Custom HTTP headers
           # @option arguments [Hash] :body The definition for the transform to preview (*Required*)
           #
           # *Deprecation notice*:
@@ -21,6 +22,8 @@ module Elasticsearch
           def preview_transform(arguments = {})
             raise ArgumentError, "Required argument 'body' missing" unless arguments[:body]
 
+            headers = arguments.delete(:headers) || {}
+
             arguments = arguments.clone
 
             method = Elasticsearch::API::HTTP_POST
@@ -28,7 +31,7 @@ module Elasticsearch
             params = {}
 
             body = arguments[:body]
-            perform_request(method, path, params, body).body
+            perform_request(method, path, params, body, headers).body
           end
       end
     end

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/data_frame_transform_deprecated/put_transform.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/data_frame_transform_deprecated/put_transform.rb
@@ -7,12 +7,11 @@ module Elasticsearch
     module API
       module DataFrameTransformDeprecated
         module Actions
-          # TODO: Description
-
+          # Instantiates a transform.
           #
           # @option arguments [String] :transform_id The id of the new transform.
           # @option arguments [Boolean] :defer_validation If validations should be deferred until transform starts, defaults to false.
-
+          # @option arguments [Hash] :headers Custom HTTP headers
           # @option arguments [Hash] :body The transform definition (*Required*)
           #
           # *Deprecation notice*:
@@ -26,6 +25,8 @@ module Elasticsearch
             raise ArgumentError, "Required argument 'body' missing" unless arguments[:body]
             raise ArgumentError, "Required argument 'transform_id' missing" unless arguments[:transform_id]
 
+            headers = arguments.delete(:headers) || {}
+
             arguments = arguments.clone
 
             _transform_id = arguments.delete(:transform_id)
@@ -35,7 +36,7 @@ module Elasticsearch
             params = Elasticsearch::API::Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
 
             body = arguments[:body]
-            perform_request(method, path, params, body).body
+            perform_request(method, path, params, body, headers).body
           end
 
           # Register this action with its valid params when the module is loaded.

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/data_frame_transform_deprecated/start_transform.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/data_frame_transform_deprecated/start_transform.rb
@@ -7,12 +7,11 @@ module Elasticsearch
     module API
       module DataFrameTransformDeprecated
         module Actions
-          # TODO: Description
-
+          # Starts one or more transforms.
           #
           # @option arguments [String] :transform_id The id of the transform to start
           # @option arguments [Time] :timeout Controls the time to wait for the transform to start
-
+          # @option arguments [Hash] :headers Custom HTTP headers
           #
           # *Deprecation notice*:
           # [_data_frame/transforms/] is deprecated, use [_transform/] in the future.
@@ -24,6 +23,8 @@ module Elasticsearch
           def start_transform(arguments = {})
             raise ArgumentError, "Required argument 'transform_id' missing" unless arguments[:transform_id]
 
+            headers = arguments.delete(:headers) || {}
+
             arguments = arguments.clone
 
             _transform_id = arguments.delete(:transform_id)
@@ -33,7 +34,7 @@ module Elasticsearch
             params = Elasticsearch::API::Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
 
             body = nil
-            perform_request(method, path, params, body).body
+            perform_request(method, path, params, body, headers).body
           end
 
           # Register this action with its valid params when the module is loaded.

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/data_frame_transform_deprecated/stop_transform.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/data_frame_transform_deprecated/stop_transform.rb
@@ -7,14 +7,13 @@ module Elasticsearch
     module API
       module DataFrameTransformDeprecated
         module Actions
-          # TODO: Description
-
+          # Stops one or more transforms.
           #
           # @option arguments [String] :transform_id The id of the transform to stop
           # @option arguments [Boolean] :wait_for_completion Whether to wait for the transform to fully stop before returning or not. Default to false
           # @option arguments [Time] :timeout Controls the time to wait until the transform has stopped. Default to 30 seconds
           # @option arguments [Boolean] :allow_no_match Whether to ignore if a wildcard expression matches no transforms. (This includes `_all` string or when no transforms have been specified)
-
+          # @option arguments [Hash] :headers Custom HTTP headers
           #
           # *Deprecation notice*:
           # [_data_frame/transforms/] is deprecated, use [_transform/] in the future.
@@ -26,6 +25,8 @@ module Elasticsearch
           def stop_transform(arguments = {})
             raise ArgumentError, "Required argument 'transform_id' missing" unless arguments[:transform_id]
 
+            headers = arguments.delete(:headers) || {}
+
             arguments = arguments.clone
 
             _transform_id = arguments.delete(:transform_id)
@@ -35,7 +36,7 @@ module Elasticsearch
             params = Elasticsearch::API::Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
 
             body = nil
-            perform_request(method, path, params, body).body
+            perform_request(method, path, params, body, headers).body
           end
 
           # Register this action with its valid params when the module is loaded.

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/data_frame_transform_deprecated/update_transform.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/data_frame_transform_deprecated/update_transform.rb
@@ -7,12 +7,11 @@ module Elasticsearch
     module API
       module DataFrameTransformDeprecated
         module Actions
-          # TODO: Description
-
+          # Updates certain properties of a transform.
           #
           # @option arguments [String] :transform_id The id of the transform.  (*Required*)
           # @option arguments [Boolean] :defer_validation If validations should be deferred until transform starts, defaults to false.
-
+          # @option arguments [Hash] :headers Custom HTTP headers
           # @option arguments [Hash] :body The update transform definition (*Required*)
           #
           # *Deprecation notice*:
@@ -26,6 +25,8 @@ module Elasticsearch
             raise ArgumentError, "Required argument 'body' missing" unless arguments[:body]
             raise ArgumentError, "Required argument 'transform_id' missing" unless arguments[:transform_id]
 
+            headers = arguments.delete(:headers) || {}
+
             arguments = arguments.clone
 
             _transform_id = arguments.delete(:transform_id)
@@ -35,7 +36,7 @@ module Elasticsearch
             params = Elasticsearch::API::Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
 
             body = arguments[:body]
-            perform_request(method, path, params, body).body
+            perform_request(method, path, params, body, headers).body
           end
 
           # Register this action with its valid params when the module is loaded.

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/graph/explore.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/graph/explore.rb
@@ -7,14 +7,13 @@ module Elasticsearch
     module API
       module Graph
         module Actions
-          # TODO: Description
-
+          # Explore extracted and summarized information about the documents and terms in an index.
           #
           # @option arguments [List] :index A comma-separated list of index names to search; use `_all` or empty string to perform the operation on all indices
           # @option arguments [List] :type A comma-separated list of document types to search; leave empty to perform the operation on all types   *Deprecated*
           # @option arguments [String] :routing Specific routing value
           # @option arguments [Time] :timeout Explicit operation timeout
-
+          # @option arguments [Hash] :headers Custom HTTP headers
           # @option arguments [Hash] :body Graph Query DSL
           #
           # *Deprecation notice*:
@@ -26,6 +25,8 @@ module Elasticsearch
           #
           def explore(arguments = {})
             raise ArgumentError, "Required argument 'index' missing" unless arguments[:index]
+
+            headers = arguments.delete(:headers) || {}
 
             arguments = arguments.clone
 
@@ -42,7 +43,7 @@ module Elasticsearch
             params = Elasticsearch::API::Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
 
             body = arguments[:body]
-            perform_request(method, path, params, body).body
+            perform_request(method, path, params, body, headers).body
           end
 
           # Register this action with its valid params when the module is loaded.

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/index_lifecycle_management/delete_lifecycle.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/index_lifecycle_management/delete_lifecycle.rb
@@ -7,16 +7,17 @@ module Elasticsearch
     module API
       module IndexLifecycleManagement
         module Actions
-          # TODO: Description
-
+          # Deletes the specified lifecycle policy definition. A currently used policy cannot be deleted.
           #
           # @option arguments [String] :policy The name of the index lifecycle policy
-
+          # @option arguments [Hash] :headers Custom HTTP headers
           #
           # @see https://www.elastic.co/guide/en/elasticsearch/reference/current/ilm-delete-lifecycle.html
           #
           def delete_lifecycle(arguments = {})
             raise ArgumentError, "Required argument 'policy' missing" unless arguments[:policy]
+
+            headers = arguments.delete(:headers) || {}
 
             arguments = arguments.clone
 
@@ -27,7 +28,7 @@ module Elasticsearch
             params = {}
 
             body = nil
-            perform_request(method, path, params, body).body
+            perform_request(method, path, params, body, headers).body
           end
       end
     end

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/index_lifecycle_management/explain_lifecycle.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/index_lifecycle_management/explain_lifecycle.rb
@@ -7,18 +7,19 @@ module Elasticsearch
     module API
       module IndexLifecycleManagement
         module Actions
-          # TODO: Description
-
+          # Retrieves information about the index's current lifecycle state, such as the currently executing phase, action, and step.
           #
           # @option arguments [String] :index The name of the index to explain
           # @option arguments [Boolean] :only_managed filters the indices included in the response to ones managed by ILM
           # @option arguments [Boolean] :only_errors filters the indices included in the response to ones in an ILM error state, implies only_managed
-
+          # @option arguments [Hash] :headers Custom HTTP headers
           #
           # @see https://www.elastic.co/guide/en/elasticsearch/reference/current/ilm-explain-lifecycle.html
           #
           def explain_lifecycle(arguments = {})
             raise ArgumentError, "Required argument 'index' missing" unless arguments[:index]
+
+            headers = arguments.delete(:headers) || {}
 
             arguments = arguments.clone
 
@@ -29,7 +30,7 @@ module Elasticsearch
             params = Elasticsearch::API::Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
 
             body = nil
-            perform_request(method, path, params, body).body
+            perform_request(method, path, params, body, headers).body
           end
 
           # Register this action with its valid params when the module is loaded.

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/index_lifecycle_management/get_lifecycle.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/index_lifecycle_management/get_lifecycle.rb
@@ -7,15 +7,16 @@ module Elasticsearch
     module API
       module IndexLifecycleManagement
         module Actions
-          # TODO: Description
-
+          # Returns the specified policy definition. Includes the policy version and last modified date.
           #
           # @option arguments [String] :policy The name of the index lifecycle policy
-
+          # @option arguments [Hash] :headers Custom HTTP headers
           #
           # @see https://www.elastic.co/guide/en/elasticsearch/reference/current/ilm-get-lifecycle.html
           #
           def get_lifecycle(arguments = {})
+            headers = arguments.delete(:headers) || {}
+
             arguments = arguments.clone
 
             _policy = arguments.delete(:policy)
@@ -25,11 +26,11 @@ module Elasticsearch
                        "_ilm/policy/#{Elasticsearch::API::Utils.__listify(_policy)}"
                      else
                        "_ilm/policy"
-  end
+            end
             params = {}
 
             body = nil
-            perform_request(method, path, params, body).body
+            perform_request(method, path, params, body, headers).body
           end
       end
     end

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/index_lifecycle_management/get_status.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/index_lifecycle_management/get_status.rb
@@ -7,12 +7,15 @@ module Elasticsearch
     module API
       module IndexLifecycleManagement
         module Actions
-          # TODO: Description
-
+          # Retrieves the current index lifecycle management (ILM) status.
+          #
+          # @option arguments [Hash] :headers Custom HTTP headers
           #
           # @see https://www.elastic.co/guide/en/elasticsearch/reference/current/ilm-get-status.html
           #
           def get_status(arguments = {})
+            headers = arguments.delete(:headers) || {}
+
             arguments = arguments.clone
 
             method = Elasticsearch::API::HTTP_GET
@@ -20,7 +23,7 @@ module Elasticsearch
             params = {}
 
             body = nil
-            perform_request(method, path, params, body).body
+            perform_request(method, path, params, body, headers).body
           end
       end
     end

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/index_lifecycle_management/move_to_step.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/index_lifecycle_management/move_to_step.rb
@@ -7,17 +7,18 @@ module Elasticsearch
     module API
       module IndexLifecycleManagement
         module Actions
-          # TODO: Description
-
+          # Manually moves an index into the specified step and executes that step.
           #
           # @option arguments [String] :index The name of the index whose lifecycle step is to change
-
+          # @option arguments [Hash] :headers Custom HTTP headers
           # @option arguments [Hash] :body The new lifecycle step to move to
           #
           # @see https://www.elastic.co/guide/en/elasticsearch/reference/current/ilm-move-to-step.html
           #
           def move_to_step(arguments = {})
             raise ArgumentError, "Required argument 'index' missing" unless arguments[:index]
+
+            headers = arguments.delete(:headers) || {}
 
             arguments = arguments.clone
 
@@ -28,7 +29,7 @@ module Elasticsearch
             params = {}
 
             body = arguments[:body]
-            perform_request(method, path, params, body).body
+            perform_request(method, path, params, body, headers).body
           end
       end
     end

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/index_lifecycle_management/put_lifecycle.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/index_lifecycle_management/put_lifecycle.rb
@@ -7,17 +7,18 @@ module Elasticsearch
     module API
       module IndexLifecycleManagement
         module Actions
-          # TODO: Description
-
+          # Creates a lifecycle policy
           #
           # @option arguments [String] :policy The name of the index lifecycle policy
-
+          # @option arguments [Hash] :headers Custom HTTP headers
           # @option arguments [Hash] :body The lifecycle policy definition to register
           #
           # @see https://www.elastic.co/guide/en/elasticsearch/reference/current/ilm-put-lifecycle.html
           #
           def put_lifecycle(arguments = {})
             raise ArgumentError, "Required argument 'policy' missing" unless arguments[:policy]
+
+            headers = arguments.delete(:headers) || {}
 
             arguments = arguments.clone
 
@@ -28,7 +29,7 @@ module Elasticsearch
             params = {}
 
             body = arguments[:body]
-            perform_request(method, path, params, body).body
+            perform_request(method, path, params, body, headers).body
           end
       end
     end

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/index_lifecycle_management/remove_policy.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/index_lifecycle_management/remove_policy.rb
@@ -7,16 +7,17 @@ module Elasticsearch
     module API
       module IndexLifecycleManagement
         module Actions
-          # TODO: Description
-
+          # Removes the assigned lifecycle policy and stops managing the specified index
           #
           # @option arguments [String] :index The name of the index to remove policy on
-
+          # @option arguments [Hash] :headers Custom HTTP headers
           #
           # @see https://www.elastic.co/guide/en/elasticsearch/reference/current/ilm-remove-policy.html
           #
           def remove_policy(arguments = {})
             raise ArgumentError, "Required argument 'index' missing" unless arguments[:index]
+
+            headers = arguments.delete(:headers) || {}
 
             arguments = arguments.clone
 
@@ -27,7 +28,7 @@ module Elasticsearch
             params = {}
 
             body = nil
-            perform_request(method, path, params, body).body
+            perform_request(method, path, params, body, headers).body
           end
       end
     end

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/index_lifecycle_management/retry.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/index_lifecycle_management/retry.rb
@@ -7,16 +7,17 @@ module Elasticsearch
     module API
       module IndexLifecycleManagement
         module Actions
-          # TODO: Description
-
+          # Retries executing the policy for an index that is in the ERROR step.
           #
           # @option arguments [String] :index The name of the indices (comma-separated) whose failed lifecycle step is to be retry
-
+          # @option arguments [Hash] :headers Custom HTTP headers
           #
           # @see https://www.elastic.co/guide/en/elasticsearch/reference/current/ilm-retry-policy.html
           #
           def retry(arguments = {})
             raise ArgumentError, "Required argument 'index' missing" unless arguments[:index]
+
+            headers = arguments.delete(:headers) || {}
 
             arguments = arguments.clone
 
@@ -27,7 +28,7 @@ module Elasticsearch
             params = {}
 
             body = nil
-            perform_request(method, path, params, body).body
+            perform_request(method, path, params, body, headers).body
           end
       end
     end

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/index_lifecycle_management/start.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/index_lifecycle_management/start.rb
@@ -7,12 +7,15 @@ module Elasticsearch
     module API
       module IndexLifecycleManagement
         module Actions
-          # TODO: Description
-
+          # Start the index lifecycle management (ILM) plugin.
+          #
+          # @option arguments [Hash] :headers Custom HTTP headers
           #
           # @see https://www.elastic.co/guide/en/elasticsearch/reference/current/ilm-start.html
           #
           def start(arguments = {})
+            headers = arguments.delete(:headers) || {}
+
             arguments = arguments.clone
 
             method = Elasticsearch::API::HTTP_POST
@@ -20,7 +23,7 @@ module Elasticsearch
             params = {}
 
             body = nil
-            perform_request(method, path, params, body).body
+            perform_request(method, path, params, body, headers).body
           end
       end
     end

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/index_lifecycle_management/stop.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/index_lifecycle_management/stop.rb
@@ -7,12 +7,15 @@ module Elasticsearch
     module API
       module IndexLifecycleManagement
         module Actions
-          # TODO: Description
-
+          # Halts all lifecycle management operations and stops the index lifecycle management (ILM) plugin
+          #
+          # @option arguments [Hash] :headers Custom HTTP headers
           #
           # @see https://www.elastic.co/guide/en/elasticsearch/reference/current/ilm-stop.html
           #
           def stop(arguments = {})
+            headers = arguments.delete(:headers) || {}
+
             arguments = arguments.clone
 
             method = Elasticsearch::API::HTTP_POST
@@ -20,7 +23,7 @@ module Elasticsearch
             params = {}
 
             body = nil
-            perform_request(method, path, params, body).body
+            perform_request(method, path, params, body, headers).body
           end
       end
     end

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/info.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/info.rb
@@ -6,15 +6,16 @@ module Elasticsearch
   module XPack
     module API
       module Actions
-        # TODO: Description
-
+        # Retrieves information about the installed X-Pack features.
         #
         # @option arguments [List] :categories Comma-separated list of info categories. Can be any of: build, license, features
-
+        # @option arguments [Hash] :headers Custom HTTP headers
         #
         # @see https://www.elastic.co/guide/en/elasticsearch/reference/current/info-api.html
         #
         def info(arguments = {})
+          headers = arguments.delete(:headers) || {}
+
           arguments = arguments.clone
 
           method = Elasticsearch::API::HTTP_GET
@@ -22,7 +23,7 @@ module Elasticsearch
           params = Elasticsearch::API::Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
 
           body = nil
-          perform_request(method, path, params, body).body
+          perform_request(method, path, params, body, headers).body
         end
 
         # Register this action with its valid params when the module is loaded.

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/license/delete.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/license/delete.rb
@@ -7,12 +7,15 @@ module Elasticsearch
     module API
       module License
         module Actions
-          # TODO: Description
-
+          # Deletes licensing information for the cluster
+          #
+          # @option arguments [Hash] :headers Custom HTTP headers
           #
           # @see https://www.elastic.co/guide/en/elasticsearch/reference/master/delete-license.html
           #
           def delete(arguments = {})
+            headers = arguments.delete(:headers) || {}
+
             arguments = arguments.clone
 
             method = Elasticsearch::API::HTTP_DELETE
@@ -20,7 +23,7 @@ module Elasticsearch
             params = {}
 
             body = nil
-            perform_request(method, path, params, body).body
+            perform_request(method, path, params, body, headers).body
           end
       end
     end

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/license/get.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/license/get.rb
@@ -7,16 +7,17 @@ module Elasticsearch
     module API
       module License
         module Actions
-          # TODO: Description
-
+          # Retrieves licensing information for the cluster
           #
           # @option arguments [Boolean] :local Return local information, do not retrieve the state from master node (default: false)
           # @option arguments [Boolean] :accept_enterprise If the active license is an enterprise license, return type as 'enterprise' (default: false)
-
+          # @option arguments [Hash] :headers Custom HTTP headers
           #
           # @see https://www.elastic.co/guide/en/elasticsearch/reference/master/get-license.html
           #
           def get(arguments = {})
+            headers = arguments.delete(:headers) || {}
+
             arguments = arguments.clone
 
             method = Elasticsearch::API::HTTP_GET
@@ -24,7 +25,7 @@ module Elasticsearch
             params = Elasticsearch::API::Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
 
             body = nil
-            perform_request(method, path, params, body).body
+            perform_request(method, path, params, body, headers).body
           end
 
           # Register this action with its valid params when the module is loaded.

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/license/get_basic_status.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/license/get_basic_status.rb
@@ -7,12 +7,15 @@ module Elasticsearch
     module API
       module License
         module Actions
-          # TODO: Description
-
+          # Retrieves information about the status of the basic license.
+          #
+          # @option arguments [Hash] :headers Custom HTTP headers
           #
           # @see https://www.elastic.co/guide/en/elasticsearch/reference/master/get-basic-status.html
           #
           def get_basic_status(arguments = {})
+            headers = arguments.delete(:headers) || {}
+
             arguments = arguments.clone
 
             method = Elasticsearch::API::HTTP_GET
@@ -20,7 +23,7 @@ module Elasticsearch
             params = {}
 
             body = nil
-            perform_request(method, path, params, body).body
+            perform_request(method, path, params, body, headers).body
           end
       end
     end

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/license/get_trial_status.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/license/get_trial_status.rb
@@ -7,12 +7,15 @@ module Elasticsearch
     module API
       module License
         module Actions
-          # TODO: Description
-
+          # Retrieves information about the status of the trial license.
+          #
+          # @option arguments [Hash] :headers Custom HTTP headers
           #
           # @see https://www.elastic.co/guide/en/elasticsearch/reference/master/get-trial-status.html
           #
           def get_trial_status(arguments = {})
+            headers = arguments.delete(:headers) || {}
+
             arguments = arguments.clone
 
             method = Elasticsearch::API::HTTP_GET
@@ -20,7 +23,7 @@ module Elasticsearch
             params = {}
 
             body = nil
-            perform_request(method, path, params, body).body
+            perform_request(method, path, params, body, headers).body
           end
       end
     end

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/license/post.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/license/post.rb
@@ -7,16 +7,17 @@ module Elasticsearch
     module API
       module License
         module Actions
-          # TODO: Description
-
+          # Updates the license for the cluster.
           #
           # @option arguments [Boolean] :acknowledge whether the user has acknowledged acknowledge messages (default: false)
-
+          # @option arguments [Hash] :headers Custom HTTP headers
           # @option arguments [Hash] :body licenses to be installed
           #
           # @see https://www.elastic.co/guide/en/elasticsearch/reference/master/update-license.html
           #
           def post(arguments = {})
+            headers = arguments.delete(:headers) || {}
+
             arguments = arguments.clone
 
             method = Elasticsearch::API::HTTP_PUT
@@ -24,7 +25,7 @@ module Elasticsearch
             params = Elasticsearch::API::Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
 
             body = arguments[:body]
-            perform_request(method, path, params, body).body
+            perform_request(method, path, params, body, headers).body
           end
 
           # Register this action with its valid params when the module is loaded.

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/license/post_start_basic.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/license/post_start_basic.rb
@@ -7,15 +7,16 @@ module Elasticsearch
     module API
       module License
         module Actions
-          # TODO: Description
-
+          # Starts an indefinite basic license.
           #
           # @option arguments [Boolean] :acknowledge whether the user has acknowledged acknowledge messages (default: false)
-
+          # @option arguments [Hash] :headers Custom HTTP headers
           #
           # @see https://www.elastic.co/guide/en/elasticsearch/reference/master/start-basic.html
           #
           def post_start_basic(arguments = {})
+            headers = arguments.delete(:headers) || {}
+
             arguments = arguments.clone
 
             method = Elasticsearch::API::HTTP_POST
@@ -23,7 +24,7 @@ module Elasticsearch
             params = Elasticsearch::API::Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
 
             body = nil
-            perform_request(method, path, params, body).body
+            perform_request(method, path, params, body, headers).body
           end
 
           # Register this action with its valid params when the module is loaded.

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/license/post_start_trial.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/license/post_start_trial.rb
@@ -7,16 +7,17 @@ module Elasticsearch
     module API
       module License
         module Actions
-          # TODO: Description
-
+          # starts a limited time trial license.
           #
           # @option arguments [String] :type The type of trial license to generate (default: "trial")
           # @option arguments [Boolean] :acknowledge whether the user has acknowledged acknowledge messages (default: false)
-
+          # @option arguments [Hash] :headers Custom HTTP headers
           #
           # @see https://www.elastic.co/guide/en/elasticsearch/reference/master/start-trial.html
           #
           def post_start_trial(arguments = {})
+            headers = arguments.delete(:headers) || {}
+
             arguments = arguments.clone
 
             method = Elasticsearch::API::HTTP_POST
@@ -24,7 +25,7 @@ module Elasticsearch
             params = Elasticsearch::API::Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
 
             body = nil
-            perform_request(method, path, params, body).body
+            perform_request(method, path, params, body, headers).body
           end
 
           # Register this action with its valid params when the module is loaded.

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/machine_learning/close_job.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/machine_learning/close_job.rb
@@ -7,20 +7,21 @@ module Elasticsearch
     module API
       module MachineLearning
         module Actions
-          # TODO: Description
-
+          # Closes one or more anomaly detection jobs. A job can be opened and closed multiple times throughout its lifecycle.
           #
           # @option arguments [String] :job_id The name of the job to close
           # @option arguments [Boolean] :allow_no_jobs Whether to ignore if a wildcard expression matches no jobs. (This includes `_all` string or when no jobs have been specified)
           # @option arguments [Boolean] :force True if the job should be forcefully closed
           # @option arguments [Time] :timeout Controls the time to wait until a job has closed. Default to 30 minutes
-
+          # @option arguments [Hash] :headers Custom HTTP headers
           # @option arguments [Hash] :body The URL params optionally sent in the body
           #
           # @see https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-close-job.html
           #
           def close_job(arguments = {})
             raise ArgumentError, "Required argument 'job_id' missing" unless arguments[:job_id]
+
+            headers = arguments.delete(:headers) || {}
 
             arguments = arguments.clone
 
@@ -31,7 +32,7 @@ module Elasticsearch
             params = Elasticsearch::API::Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
 
             body = arguments[:body]
-            perform_request(method, path, params, body).body
+            perform_request(method, path, params, body, headers).body
           end
 
           # Register this action with its valid params when the module is loaded.

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/machine_learning/delete_calendar.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/machine_learning/delete_calendar.rb
@@ -7,16 +7,17 @@ module Elasticsearch
     module API
       module MachineLearning
         module Actions
-          # TODO: Description
-
+          # Deletes a calendar.
           #
           # @option arguments [String] :calendar_id The ID of the calendar to delete
-
+          # @option arguments [Hash] :headers Custom HTTP headers
           #
-          # @see [TODO]
+          # @see https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-delete-calendar.html
           #
           def delete_calendar(arguments = {})
             raise ArgumentError, "Required argument 'calendar_id' missing" unless arguments[:calendar_id]
+
+            headers = arguments.delete(:headers) || {}
 
             arguments = arguments.clone
 
@@ -27,7 +28,7 @@ module Elasticsearch
             params = {}
 
             body = nil
-            perform_request(method, path, params, body).body
+            perform_request(method, path, params, body, headers).body
           end
       end
     end

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/machine_learning/delete_calendar_event.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/machine_learning/delete_calendar_event.rb
@@ -7,18 +7,19 @@ module Elasticsearch
     module API
       module MachineLearning
         module Actions
-          # TODO: Description
-
+          # Deletes scheduled events from a calendar.
           #
           # @option arguments [String] :calendar_id The ID of the calendar to modify
           # @option arguments [String] :event_id The ID of the event to remove from the calendar
-
+          # @option arguments [Hash] :headers Custom HTTP headers
           #
-          # @see [TODO]
+          # @see https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-delete-calendar-event.html
           #
           def delete_calendar_event(arguments = {})
             raise ArgumentError, "Required argument 'calendar_id' missing" unless arguments[:calendar_id]
             raise ArgumentError, "Required argument 'event_id' missing" unless arguments[:event_id]
+
+            headers = arguments.delete(:headers) || {}
 
             arguments = arguments.clone
 
@@ -31,7 +32,7 @@ module Elasticsearch
             params = {}
 
             body = nil
-            perform_request(method, path, params, body).body
+            perform_request(method, path, params, body, headers).body
           end
       end
     end

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/machine_learning/delete_calendar_job.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/machine_learning/delete_calendar_job.rb
@@ -7,18 +7,19 @@ module Elasticsearch
     module API
       module MachineLearning
         module Actions
-          # TODO: Description
-
+          # Deletes anomaly detection jobs from a calendar.
           #
           # @option arguments [String] :calendar_id The ID of the calendar to modify
           # @option arguments [String] :job_id The ID of the job to remove from the calendar
-
+          # @option arguments [Hash] :headers Custom HTTP headers
           #
-          # @see [TODO]
+          # @see https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-delete-calendar-job.html
           #
           def delete_calendar_job(arguments = {})
             raise ArgumentError, "Required argument 'calendar_id' missing" unless arguments[:calendar_id]
             raise ArgumentError, "Required argument 'job_id' missing" unless arguments[:job_id]
+
+            headers = arguments.delete(:headers) || {}
 
             arguments = arguments.clone
 
@@ -31,7 +32,7 @@ module Elasticsearch
             params = {}
 
             body = nil
-            perform_request(method, path, params, body).body
+            perform_request(method, path, params, body, headers).body
           end
       end
     end

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/machine_learning/delete_data_frame_analytics.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/machine_learning/delete_data_frame_analytics.rb
@@ -7,17 +7,18 @@ module Elasticsearch
     module API
       module MachineLearning
         module Actions
-          # TODO: Description
-
+          # Deletes an existing data frame analytics job.
           #
           # @option arguments [String] :id The ID of the data frame analytics to delete
           # @option arguments [Boolean] :force True if the job should be forcefully deleted
-
+          # @option arguments [Hash] :headers Custom HTTP headers
           #
           # @see https://www.elastic.co/guide/en/elasticsearch/reference/current/delete-dfanalytics.html
           #
           def delete_data_frame_analytics(arguments = {})
             raise ArgumentError, "Required argument 'id' missing" unless arguments[:id]
+
+            headers = arguments.delete(:headers) || {}
 
             arguments = arguments.clone
 
@@ -28,7 +29,7 @@ module Elasticsearch
             params = Elasticsearch::API::Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
 
             body = nil
-            perform_request(method, path, params, body).body
+            perform_request(method, path, params, body, headers).body
           end
 
           # Register this action with its valid params when the module is loaded.

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/machine_learning/delete_datafeed.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/machine_learning/delete_datafeed.rb
@@ -7,17 +7,18 @@ module Elasticsearch
     module API
       module MachineLearning
         module Actions
-          # TODO: Description
-
+          # Deletes an existing datafeed.
           #
           # @option arguments [String] :datafeed_id The ID of the datafeed to delete
           # @option arguments [Boolean] :force True if the datafeed should be forcefully deleted
-
+          # @option arguments [Hash] :headers Custom HTTP headers
           #
           # @see https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-delete-datafeed.html
           #
           def delete_datafeed(arguments = {})
             raise ArgumentError, "Required argument 'datafeed_id' missing" unless arguments[:datafeed_id]
+
+            headers = arguments.delete(:headers) || {}
 
             arguments = arguments.clone
 
@@ -28,7 +29,7 @@ module Elasticsearch
             params = Elasticsearch::API::Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
 
             body = nil
-            perform_request(method, path, params, body).body
+            perform_request(method, path, params, body, headers).body
           end
 
           # Register this action with its valid params when the module is loaded.

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/machine_learning/delete_expired_data.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/machine_learning/delete_expired_data.rb
@@ -7,12 +7,15 @@ module Elasticsearch
     module API
       module MachineLearning
         module Actions
-          # TODO: Description
-
+          # Deletes expired and unused machine learning data.
           #
-          # @see [TODO]
+          # @option arguments [Hash] :headers Custom HTTP headers
+          #
+          # @see https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-delete-expired-data.html
           #
           def delete_expired_data(arguments = {})
+            headers = arguments.delete(:headers) || {}
+
             arguments = arguments.clone
 
             method = Elasticsearch::API::HTTP_DELETE
@@ -20,7 +23,7 @@ module Elasticsearch
             params = {}
 
             body = nil
-            perform_request(method, path, params, body).body
+            perform_request(method, path, params, body, headers).body
           end
       end
     end

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/machine_learning/delete_filter.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/machine_learning/delete_filter.rb
@@ -7,16 +7,17 @@ module Elasticsearch
     module API
       module MachineLearning
         module Actions
-          # TODO: Description
-
+          # Deletes a filter.
           #
           # @option arguments [String] :filter_id The ID of the filter to delete
-
+          # @option arguments [Hash] :headers Custom HTTP headers
           #
-          # @see [TODO]
+          # @see https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-delete-filter.html
           #
           def delete_filter(arguments = {})
             raise ArgumentError, "Required argument 'filter_id' missing" unless arguments[:filter_id]
+
+            headers = arguments.delete(:headers) || {}
 
             arguments = arguments.clone
 
@@ -27,7 +28,7 @@ module Elasticsearch
             params = {}
 
             body = nil
-            perform_request(method, path, params, body).body
+            perform_request(method, path, params, body, headers).body
           end
       end
     end

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/machine_learning/delete_forecast.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/machine_learning/delete_forecast.rb
@@ -7,19 +7,20 @@ module Elasticsearch
     module API
       module MachineLearning
         module Actions
-          # TODO: Description
-
+          # Deletes forecasts from a machine learning job.
           #
           # @option arguments [String] :job_id The ID of the job from which to delete forecasts
           # @option arguments [String] :forecast_id The ID of the forecast to delete, can be comma delimited list. Leaving blank implies `_all`
           # @option arguments [Boolean] :allow_no_forecasts Whether to ignore if `_all` matches no forecasts
           # @option arguments [Time] :timeout Controls the time to wait until the forecast(s) are deleted. Default to 30 seconds
-
+          # @option arguments [Hash] :headers Custom HTTP headers
           #
           # @see https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-delete-forecast.html
           #
           def delete_forecast(arguments = {})
             raise ArgumentError, "Required argument 'job_id' missing" unless arguments[:job_id]
+
+            headers = arguments.delete(:headers) || {}
 
             arguments = arguments.clone
 
@@ -36,7 +37,7 @@ module Elasticsearch
             params = Elasticsearch::API::Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
 
             body = nil
-            perform_request(method, path, params, body).body
+            perform_request(method, path, params, body, headers).body
           end
 
           # Register this action with its valid params when the module is loaded.

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/machine_learning/delete_job.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/machine_learning/delete_job.rb
@@ -7,18 +7,19 @@ module Elasticsearch
     module API
       module MachineLearning
         module Actions
-          # TODO: Description
-
+          # Deletes an existing anomaly detection job.
           #
           # @option arguments [String] :job_id The ID of the job to delete
           # @option arguments [Boolean] :force True if the job should be forcefully deleted
           # @option arguments [Boolean] :wait_for_completion Should this request wait until the operation has completed before returning
-
+          # @option arguments [Hash] :headers Custom HTTP headers
           #
           # @see https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-delete-job.html
           #
           def delete_job(arguments = {})
             raise ArgumentError, "Required argument 'job_id' missing" unless arguments[:job_id]
+
+            headers = arguments.delete(:headers) || {}
 
             arguments = arguments.clone
 
@@ -29,7 +30,7 @@ module Elasticsearch
             params = Elasticsearch::API::Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
 
             body = nil
-            perform_request(method, path, params, body).body
+            perform_request(method, path, params, body, headers).body
           end
 
           # Register this action with its valid params when the module is loaded.

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/machine_learning/delete_model_snapshot.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/machine_learning/delete_model_snapshot.rb
@@ -7,18 +7,19 @@ module Elasticsearch
     module API
       module MachineLearning
         module Actions
-          # TODO: Description
-
+          # Deletes an existing model snapshot.
           #
           # @option arguments [String] :job_id The ID of the job to fetch
           # @option arguments [String] :snapshot_id The ID of the snapshot to delete
-
+          # @option arguments [Hash] :headers Custom HTTP headers
           #
           # @see https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-delete-snapshot.html
           #
           def delete_model_snapshot(arguments = {})
             raise ArgumentError, "Required argument 'job_id' missing" unless arguments[:job_id]
             raise ArgumentError, "Required argument 'snapshot_id' missing" unless arguments[:snapshot_id]
+
+            headers = arguments.delete(:headers) || {}
 
             arguments = arguments.clone
 
@@ -31,7 +32,7 @@ module Elasticsearch
             params = {}
 
             body = nil
-            perform_request(method, path, params, body).body
+            perform_request(method, path, params, body, headers).body
           end
       end
     end

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/machine_learning/delete_trained_model.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/machine_learning/delete_trained_model.rb
@@ -7,16 +7,17 @@ module Elasticsearch
     module API
       module MachineLearning
         module Actions
-          # TODO: Description
-
+          # Deletes an existing trained inference model that is currently not referenced by an ingest pipeline.
           #
           # @option arguments [String] :model_id The ID of the trained model to delete
-
+          # @option arguments [Hash] :headers Custom HTTP headers
           #
           # @see https://www.elastic.co/guide/en/elasticsearch/reference/current/delete-inference.html
           #
           def delete_trained_model(arguments = {})
             raise ArgumentError, "Required argument 'model_id' missing" unless arguments[:model_id]
+
+            headers = arguments.delete(:headers) || {}
 
             arguments = arguments.clone
 
@@ -27,7 +28,7 @@ module Elasticsearch
             params = {}
 
             body = nil
-            perform_request(method, path, params, body).body
+            perform_request(method, path, params, body, headers).body
           end
       end
     end

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/machine_learning/estimate_model_memory.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/machine_learning/estimate_model_memory.rb
@@ -7,14 +7,17 @@ module Elasticsearch
     module API
       module MachineLearning
         module Actions
-          # TODO: Description
-
+          # Estimates the model memory
+          #
+          # @option arguments [Hash] :headers Custom HTTP headers
           # @option arguments [Hash] :body The analysis config, plus cardinality estimates for fields it references (*Required*)
           #
-          # @see [TODO]
+          # @see https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-apis.html
           #
           def estimate_model_memory(arguments = {})
             raise ArgumentError, "Required argument 'body' missing" unless arguments[:body]
+
+            headers = arguments.delete(:headers) || {}
 
             arguments = arguments.clone
 
@@ -23,7 +26,7 @@ module Elasticsearch
             params = {}
 
             body = arguments[:body]
-            perform_request(method, path, params, body).body
+            perform_request(method, path, params, body, headers).body
           end
       end
     end

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/machine_learning/evaluate_data_frame.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/machine_learning/evaluate_data_frame.rb
@@ -7,14 +7,17 @@ module Elasticsearch
     module API
       module MachineLearning
         module Actions
-          # TODO: Description
-
+          # Evaluates the data frame analytics for an annotated index.
+          #
+          # @option arguments [Hash] :headers Custom HTTP headers
           # @option arguments [Hash] :body The evaluation definition (*Required*)
           #
           # @see https://www.elastic.co/guide/en/elasticsearch/reference/current/evaluate-dfanalytics.html
           #
           def evaluate_data_frame(arguments = {})
             raise ArgumentError, "Required argument 'body' missing" unless arguments[:body]
+
+            headers = arguments.delete(:headers) || {}
 
             arguments = arguments.clone
 
@@ -23,7 +26,7 @@ module Elasticsearch
             params = {}
 
             body = arguments[:body]
-            perform_request(method, path, params, body).body
+            perform_request(method, path, params, body, headers).body
           end
       end
     end

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/machine_learning/explain_data_frame_analytics.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/machine_learning/explain_data_frame_analytics.rb
@@ -7,16 +7,17 @@ module Elasticsearch
     module API
       module MachineLearning
         module Actions
-          # TODO: Description
-
+          # Explains a data frame analytics config.
           #
           # @option arguments [String] :id The ID of the data frame analytics to explain
-
+          # @option arguments [Hash] :headers Custom HTTP headers
           # @option arguments [Hash] :body The data frame analytics config to explain
           #
           # @see http://www.elastic.co/guide/en/elasticsearch/reference/current/explain-dfanalytics.html
           #
           def explain_data_frame_analytics(arguments = {})
+            headers = arguments.delete(:headers) || {}
+
             arguments = arguments.clone
 
             _id = arguments.delete(:id)
@@ -26,11 +27,11 @@ module Elasticsearch
                        "_ml/data_frame/analytics/#{Elasticsearch::API::Utils.__listify(_id)}/_explain"
                      else
                        "_ml/data_frame/analytics/_explain"
-  end
+            end
             params = {}
 
             body = arguments[:body]
-            perform_request(method, path, params, body).body
+            perform_request(method, path, params, body, headers).body
           end
       end
     end

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/machine_learning/find_file_structure.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/machine_learning/find_file_structure.rb
@@ -7,8 +7,7 @@ module Elasticsearch
     module API
       module MachineLearning
         module Actions
-          # TODO: Description
-
+          # Finds the structure of a text file. The text file must contain data that is suitable to be ingested into Elasticsearch.
           #
           # @option arguments [Int] :lines_to_sample How many lines of the file should be included in the analysis
           # @option arguments [Int] :line_merge_size_limit Maximum number of characters permitted in a single message when lines are merged to create messages.
@@ -26,13 +25,15 @@ module Elasticsearch
           # @option arguments [String] :timestamp_field Optional parameter to specify the timestamp field in the file
           # @option arguments [String] :timestamp_format Optional parameter to specify the timestamp format in the file - may be either a Joda or Java time format
           # @option arguments [Boolean] :explain Whether to include a commentary on how the structure was derived
-
+          # @option arguments [Hash] :headers Custom HTTP headers
           # @option arguments [Hash] :body The contents of the file to be analyzed (*Required*)
           #
           # @see https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-find-file-structure.html
           #
           def find_file_structure(arguments = {})
             raise ArgumentError, "Required argument 'body' missing" unless arguments[:body]
+
+            headers = arguments.delete(:headers) || {}
 
             arguments = arguments.clone
 
@@ -41,7 +42,7 @@ module Elasticsearch
             params = Elasticsearch::API::Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
 
             body = Elasticsearch::API::Utils.__bulkify(arguments.delete(:body))
-            perform_request(method, path, params, body).body
+            perform_request(method, path, params, body, headers).body
           end
 
           # Register this action with its valid params when the module is loaded.

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/machine_learning/flush_job.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/machine_learning/flush_job.rb
@@ -7,8 +7,7 @@ module Elasticsearch
     module API
       module MachineLearning
         module Actions
-          # TODO: Description
-
+          # Forces any buffered data to be processed by the job.
           #
           # @option arguments [String] :job_id The name of the job to flush
           # @option arguments [Boolean] :calc_interim Calculates interim results for the most recent bucket or all buckets within the latency period
@@ -16,13 +15,15 @@ module Elasticsearch
           # @option arguments [String] :end When used in conjunction with calc_interim, specifies the range of buckets on which to calculate interim results
           # @option arguments [String] :advance_time Advances time to the given value generating results and updating the model for the advanced interval
           # @option arguments [String] :skip_time Skips time to the given value without generating results or updating the model for the skipped interval
-
+          # @option arguments [Hash] :headers Custom HTTP headers
           # @option arguments [Hash] :body Flush parameters
           #
           # @see https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-flush-job.html
           #
           def flush_job(arguments = {})
             raise ArgumentError, "Required argument 'job_id' missing" unless arguments[:job_id]
+
+            headers = arguments.delete(:headers) || {}
 
             arguments = arguments.clone
 
@@ -33,7 +34,7 @@ module Elasticsearch
             params = Elasticsearch::API::Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
 
             body = arguments[:body]
-            perform_request(method, path, params, body).body
+            perform_request(method, path, params, body, headers).body
           end
 
           # Register this action with its valid params when the module is loaded.

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/machine_learning/forecast.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/machine_learning/forecast.rb
@@ -7,18 +7,19 @@ module Elasticsearch
     module API
       module MachineLearning
         module Actions
-          # TODO: Description
-
+          # Predicts the future behavior of a time series by using its historical behavior.
           #
           # @option arguments [String] :job_id The ID of the job to forecast for
           # @option arguments [Time] :duration The duration of the forecast
           # @option arguments [Time] :expires_in The time interval after which the forecast expires. Expired forecasts will be deleted at the first opportunity.
-
+          # @option arguments [Hash] :headers Custom HTTP headers
           #
-          # @see [TODO]
+          # @see https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-forecast.html
           #
           def forecast(arguments = {})
             raise ArgumentError, "Required argument 'job_id' missing" unless arguments[:job_id]
+
+            headers = arguments.delete(:headers) || {}
 
             arguments = arguments.clone
 
@@ -29,7 +30,7 @@ module Elasticsearch
             params = Elasticsearch::API::Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
 
             body = nil
-            perform_request(method, path, params, body).body
+            perform_request(method, path, params, body, headers).body
           end
 
           # Register this action with its valid params when the module is loaded.

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/machine_learning/get_buckets.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/machine_learning/get_buckets.rb
@@ -7,8 +7,7 @@ module Elasticsearch
     module API
       module MachineLearning
         module Actions
-          # TODO: Description
-
+          # Retrieves anomaly detection job results for one or more buckets.
           #
           # @option arguments [String] :job_id ID of the job to get bucket results from
           # @option arguments [String] :timestamp The timestamp of the desired single bucket result
@@ -21,13 +20,15 @@ module Elasticsearch
           # @option arguments [Double] :anomaly_score Filter for the most anomalous buckets
           # @option arguments [String] :sort Sort buckets by a particular field
           # @option arguments [Boolean] :desc Set the sort direction
-
+          # @option arguments [Hash] :headers Custom HTTP headers
           # @option arguments [Hash] :body Bucket selection details if not provided in URI
           #
           # @see https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-bucket.html
           #
           def get_buckets(arguments = {})
             raise ArgumentError, "Required argument 'job_id' missing" unless arguments[:job_id]
+
+            headers = arguments.delete(:headers) || {}
 
             arguments = arguments.clone
 
@@ -44,7 +45,7 @@ module Elasticsearch
             params = Elasticsearch::API::Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
 
             body = arguments[:body]
-            perform_request(method, path, params, body).body
+            perform_request(method, path, params, body, headers).body
           end
 
           # Register this action with its valid params when the module is loaded.

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/machine_learning/get_calendar_events.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/machine_learning/get_calendar_events.rb
@@ -7,8 +7,7 @@ module Elasticsearch
     module API
       module MachineLearning
         module Actions
-          # TODO: Description
-
+          # Retrieves information about the scheduled events in calendars.
           #
           # @option arguments [String] :calendar_id The ID of the calendar containing the events
           # @option arguments [String] :job_id Get events for the job. When this option is used calendar_id must be '_all'
@@ -16,12 +15,14 @@ module Elasticsearch
           # @option arguments [Date] :end Get events before this time
           # @option arguments [Int] :from Skips a number of events
           # @option arguments [Int] :size Specifies a max number of events to get
-
+          # @option arguments [Hash] :headers Custom HTTP headers
           #
-          # @see [TODO]
+          # @see https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-calendar-event.html
           #
           def get_calendar_events(arguments = {})
             raise ArgumentError, "Required argument 'calendar_id' missing" unless arguments[:calendar_id]
+
+            headers = arguments.delete(:headers) || {}
 
             arguments = arguments.clone
 
@@ -32,7 +33,7 @@ module Elasticsearch
             params = Elasticsearch::API::Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
 
             body = nil
-            perform_request(method, path, params, body).body
+            perform_request(method, path, params, body, headers).body
           end
 
           # Register this action with its valid params when the module is loaded.

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/machine_learning/get_calendars.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/machine_learning/get_calendars.rb
@@ -7,18 +7,19 @@ module Elasticsearch
     module API
       module MachineLearning
         module Actions
-          # TODO: Description
-
+          # Retrieves configuration information for calendars.
           #
           # @option arguments [String] :calendar_id The ID of the calendar to fetch
           # @option arguments [Int] :from skips a number of calendars
           # @option arguments [Int] :size specifies a max number of calendars to get
-
+          # @option arguments [Hash] :headers Custom HTTP headers
           # @option arguments [Hash] :body The from and size parameters optionally sent in the body
           #
-          # @see [TODO]
+          # @see https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-calendar.html
           #
           def get_calendars(arguments = {})
+            headers = arguments.delete(:headers) || {}
+
             arguments = arguments.clone
 
             _calendar_id = arguments.delete(:calendar_id)
@@ -28,11 +29,11 @@ module Elasticsearch
                        "_ml/calendars/#{Elasticsearch::API::Utils.__listify(_calendar_id)}"
                      else
                        "_ml/calendars"
-  end
+            end
             params = Elasticsearch::API::Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
 
             body = arguments[:body]
-            perform_request(method, path, params, body).body
+            perform_request(method, path, params, body, headers).body
           end
 
           # Register this action with its valid params when the module is loaded.

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/machine_learning/get_categories.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/machine_learning/get_categories.rb
@@ -7,20 +7,21 @@ module Elasticsearch
     module API
       module MachineLearning
         module Actions
-          # TODO: Description
-
+          # Retrieves anomaly detection job results for one or more categories.
           #
           # @option arguments [String] :job_id The name of the job
           # @option arguments [Long] :category_id The identifier of the category definition of interest
           # @option arguments [Int] :from skips a number of categories
           # @option arguments [Int] :size specifies a max number of categories to get
-
+          # @option arguments [Hash] :headers Custom HTTP headers
           # @option arguments [Hash] :body Category selection details if not provided in URI
           #
           # @see https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-category.html
           #
           def get_categories(arguments = {})
             raise ArgumentError, "Required argument 'job_id' missing" unless arguments[:job_id]
+
+            headers = arguments.delete(:headers) || {}
 
             arguments = arguments.clone
 
@@ -37,7 +38,7 @@ module Elasticsearch
             params = Elasticsearch::API::Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
 
             body = arguments[:body]
-            perform_request(method, path, params, body).body
+            perform_request(method, path, params, body, headers).body
           end
 
           # Register this action with its valid params when the module is loaded.

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/machine_learning/get_data_frame_analytics.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/machine_learning/get_data_frame_analytics.rb
@@ -7,18 +7,19 @@ module Elasticsearch
     module API
       module MachineLearning
         module Actions
-          # TODO: Description
-
+          # Retrieves configuration information for data frame analytics jobs.
           #
           # @option arguments [String] :id The ID of the data frame analytics to fetch
           # @option arguments [Boolean] :allow_no_match Whether to ignore if a wildcard expression matches no data frame analytics. (This includes `_all` string or when no data frame analytics have been specified)
           # @option arguments [Int] :from skips a number of analytics
           # @option arguments [Int] :size specifies a max number of analytics to get
-
+          # @option arguments [Hash] :headers Custom HTTP headers
           #
           # @see https://www.elastic.co/guide/en/elasticsearch/reference/current/get-dfanalytics.html
           #
           def get_data_frame_analytics(arguments = {})
+            headers = arguments.delete(:headers) || {}
+
             arguments = arguments.clone
 
             _id = arguments.delete(:id)
@@ -28,11 +29,11 @@ module Elasticsearch
                        "_ml/data_frame/analytics/#{Elasticsearch::API::Utils.__listify(_id)}"
                      else
                        "_ml/data_frame/analytics"
-  end
+            end
             params = Elasticsearch::API::Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
 
             body = nil
-            perform_request(method, path, params, body).body
+            perform_request(method, path, params, body, headers).body
           end
 
           # Register this action with its valid params when the module is loaded.

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/machine_learning/get_data_frame_analytics_stats.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/machine_learning/get_data_frame_analytics_stats.rb
@@ -7,18 +7,19 @@ module Elasticsearch
     module API
       module MachineLearning
         module Actions
-          # TODO: Description
-
+          # Retrieves usage information for data frame analytics jobs.
           #
           # @option arguments [String] :id The ID of the data frame analytics stats to fetch
           # @option arguments [Boolean] :allow_no_match Whether to ignore if a wildcard expression matches no data frame analytics. (This includes `_all` string or when no data frame analytics have been specified)
           # @option arguments [Int] :from skips a number of analytics
           # @option arguments [Int] :size specifies a max number of analytics to get
-
+          # @option arguments [Hash] :headers Custom HTTP headers
           #
           # @see https://www.elastic.co/guide/en/elasticsearch/reference/current/get-dfanalytics-stats.html
           #
           def get_data_frame_analytics_stats(arguments = {})
+            headers = arguments.delete(:headers) || {}
+
             arguments = arguments.clone
 
             _id = arguments.delete(:id)
@@ -28,11 +29,11 @@ module Elasticsearch
                        "_ml/data_frame/analytics/#{Elasticsearch::API::Utils.__listify(_id)}/_stats"
                      else
                        "_ml/data_frame/analytics/_stats"
-  end
+            end
             params = Elasticsearch::API::Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
 
             body = nil
-            perform_request(method, path, params, body).body
+            perform_request(method, path, params, body, headers).body
           end
 
           # Register this action with its valid params when the module is loaded.

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/machine_learning/get_datafeed_stats.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/machine_learning/get_datafeed_stats.rb
@@ -7,16 +7,17 @@ module Elasticsearch
     module API
       module MachineLearning
         module Actions
-          # TODO: Description
-
+          # Retrieves usage information for datafeeds.
           #
           # @option arguments [String] :datafeed_id The ID of the datafeeds stats to fetch
           # @option arguments [Boolean] :allow_no_datafeeds Whether to ignore if a wildcard expression matches no datafeeds. (This includes `_all` string or when no datafeeds have been specified)
-
+          # @option arguments [Hash] :headers Custom HTTP headers
           #
           # @see https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-datafeed-stats.html
           #
           def get_datafeed_stats(arguments = {})
+            headers = arguments.delete(:headers) || {}
+
             arguments = arguments.clone
 
             _datafeed_id = arguments.delete(:datafeed_id)
@@ -26,11 +27,11 @@ module Elasticsearch
                        "_ml/datafeeds/#{Elasticsearch::API::Utils.__listify(_datafeed_id)}/_stats"
                      else
                        "_ml/datafeeds/_stats"
-  end
+            end
             params = Elasticsearch::API::Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
 
             body = nil
-            perform_request(method, path, params, body).body
+            perform_request(method, path, params, body, headers).body
           end
 
           # Register this action with its valid params when the module is loaded.

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/machine_learning/get_datafeeds.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/machine_learning/get_datafeeds.rb
@@ -7,16 +7,17 @@ module Elasticsearch
     module API
       module MachineLearning
         module Actions
-          # TODO: Description
-
+          # Retrieves configuration information for datafeeds.
           #
           # @option arguments [String] :datafeed_id The ID of the datafeeds to fetch
           # @option arguments [Boolean] :allow_no_datafeeds Whether to ignore if a wildcard expression matches no datafeeds. (This includes `_all` string or when no datafeeds have been specified)
-
+          # @option arguments [Hash] :headers Custom HTTP headers
           #
           # @see https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-datafeed.html
           #
           def get_datafeeds(arguments = {})
+            headers = arguments.delete(:headers) || {}
+
             arguments = arguments.clone
 
             _datafeed_id = arguments.delete(:datafeed_id)
@@ -26,11 +27,11 @@ module Elasticsearch
                        "_ml/datafeeds/#{Elasticsearch::API::Utils.__listify(_datafeed_id)}"
                      else
                        "_ml/datafeeds"
-  end
+            end
             params = Elasticsearch::API::Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
 
             body = nil
-            perform_request(method, path, params, body).body
+            perform_request(method, path, params, body, headers).body
           end
 
           # Register this action with its valid params when the module is loaded.

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/machine_learning/get_filters.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/machine_learning/get_filters.rb
@@ -7,17 +7,18 @@ module Elasticsearch
     module API
       module MachineLearning
         module Actions
-          # TODO: Description
-
+          # Retrieves filters.
           #
           # @option arguments [String] :filter_id The ID of the filter to fetch
           # @option arguments [Int] :from skips a number of filters
           # @option arguments [Int] :size specifies a max number of filters to get
-
+          # @option arguments [Hash] :headers Custom HTTP headers
           #
-          # @see [TODO]
+          # @see https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-filter.html
           #
           def get_filters(arguments = {})
+            headers = arguments.delete(:headers) || {}
+
             arguments = arguments.clone
 
             _filter_id = arguments.delete(:filter_id)
@@ -27,11 +28,11 @@ module Elasticsearch
                        "_ml/filters/#{Elasticsearch::API::Utils.__listify(_filter_id)}"
                      else
                        "_ml/filters"
-  end
+            end
             params = Elasticsearch::API::Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
 
             body = nil
-            perform_request(method, path, params, body).body
+            perform_request(method, path, params, body, headers).body
           end
 
           # Register this action with its valid params when the module is loaded.

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/machine_learning/get_influencers.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/machine_learning/get_influencers.rb
@@ -7,10 +7,9 @@ module Elasticsearch
     module API
       module MachineLearning
         module Actions
-          # TODO: Description
-
+          # Retrieves anomaly detection job results for one or more influencers.
           #
-          # @option arguments [String] :job_id [TODO]
+          # @option arguments [String] :job_id Identifier for the anomaly detection job
           # @option arguments [Boolean] :exclude_interim Exclude interim results
           # @option arguments [Int] :from skips a number of influencers
           # @option arguments [Int] :size specifies a max number of influencers to get
@@ -19,13 +18,15 @@ module Elasticsearch
           # @option arguments [Double] :influencer_score influencer score threshold for the requested influencers
           # @option arguments [String] :sort sort field for the requested influencers
           # @option arguments [Boolean] :desc whether the results should be sorted in decending order
-
+          # @option arguments [Hash] :headers Custom HTTP headers
           # @option arguments [Hash] :body Influencer selection criteria
           #
           # @see https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-influencer.html
           #
           def get_influencers(arguments = {})
             raise ArgumentError, "Required argument 'job_id' missing" unless arguments[:job_id]
+
+            headers = arguments.delete(:headers) || {}
 
             arguments = arguments.clone
 
@@ -36,7 +37,7 @@ module Elasticsearch
             params = Elasticsearch::API::Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
 
             body = arguments[:body]
-            perform_request(method, path, params, body).body
+            perform_request(method, path, params, body, headers).body
           end
 
           # Register this action with its valid params when the module is loaded.

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/machine_learning/get_job_stats.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/machine_learning/get_job_stats.rb
@@ -7,16 +7,17 @@ module Elasticsearch
     module API
       module MachineLearning
         module Actions
-          # TODO: Description
-
+          # Retrieves usage information for anomaly detection jobs.
           #
           # @option arguments [String] :job_id The ID of the jobs stats to fetch
           # @option arguments [Boolean] :allow_no_jobs Whether to ignore if a wildcard expression matches no jobs. (This includes `_all` string or when no jobs have been specified)
-
+          # @option arguments [Hash] :headers Custom HTTP headers
           #
           # @see https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-job-stats.html
           #
           def get_job_stats(arguments = {})
+            headers = arguments.delete(:headers) || {}
+
             arguments = arguments.clone
 
             _job_id = arguments.delete(:job_id)
@@ -26,11 +27,11 @@ module Elasticsearch
                        "_ml/anomaly_detectors/#{Elasticsearch::API::Utils.__listify(_job_id)}/_stats"
                      else
                        "_ml/anomaly_detectors/_stats"
-  end
+            end
             params = Elasticsearch::API::Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
 
             body = nil
-            perform_request(method, path, params, body).body
+            perform_request(method, path, params, body, headers).body
           end
 
           # Register this action with its valid params when the module is loaded.

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/machine_learning/get_jobs.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/machine_learning/get_jobs.rb
@@ -7,16 +7,17 @@ module Elasticsearch
     module API
       module MachineLearning
         module Actions
-          # TODO: Description
-
+          # Retrieves configuration information for anomaly detection jobs.
           #
           # @option arguments [String] :job_id The ID of the jobs to fetch
           # @option arguments [Boolean] :allow_no_jobs Whether to ignore if a wildcard expression matches no jobs. (This includes `_all` string or when no jobs have been specified)
-
+          # @option arguments [Hash] :headers Custom HTTP headers
           #
           # @see https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-job.html
           #
           def get_jobs(arguments = {})
+            headers = arguments.delete(:headers) || {}
+
             arguments = arguments.clone
 
             _job_id = arguments.delete(:job_id)
@@ -26,11 +27,11 @@ module Elasticsearch
                        "_ml/anomaly_detectors/#{Elasticsearch::API::Utils.__listify(_job_id)}"
                      else
                        "_ml/anomaly_detectors"
-  end
+            end
             params = Elasticsearch::API::Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
 
             body = nil
-            perform_request(method, path, params, body).body
+            perform_request(method, path, params, body, headers).body
           end
 
           # Register this action with its valid params when the module is loaded.

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/machine_learning/get_model_snapshots.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/machine_learning/get_model_snapshots.rb
@@ -7,8 +7,7 @@ module Elasticsearch
     module API
       module MachineLearning
         module Actions
-          # TODO: Description
-
+          # Retrieves information about model snapshots.
           #
           # @option arguments [String] :job_id The ID of the job to fetch
           # @option arguments [String] :snapshot_id The ID of the snapshot to fetch
@@ -18,13 +17,15 @@ module Elasticsearch
           # @option arguments [Date] :end The filter 'end' query parameter
           # @option arguments [String] :sort Name of the field to sort on
           # @option arguments [Boolean] :desc True if the results should be sorted in descending order
-
+          # @option arguments [Hash] :headers Custom HTTP headers
           # @option arguments [Hash] :body Model snapshot selection criteria
           #
           # @see https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-snapshot.html
           #
           def get_model_snapshots(arguments = {})
             raise ArgumentError, "Required argument 'job_id' missing" unless arguments[:job_id]
+
+            headers = arguments.delete(:headers) || {}
 
             arguments = arguments.clone
 
@@ -41,7 +42,7 @@ module Elasticsearch
             params = Elasticsearch::API::Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
 
             body = arguments[:body]
-            perform_request(method, path, params, body).body
+            perform_request(method, path, params, body, headers).body
           end
 
           # Register this action with its valid params when the module is loaded.

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/machine_learning/get_overall_buckets.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/machine_learning/get_overall_buckets.rb
@@ -7,8 +7,7 @@ module Elasticsearch
     module API
       module MachineLearning
         module Actions
-          # TODO: Description
-
+          # Retrieves overall bucket results that summarize the bucket results of multiple anomaly detection jobs.
           #
           # @option arguments [String] :job_id The job IDs for which to calculate overall bucket results
           # @option arguments [Int] :top_n The number of top job bucket scores to be used in the overall_score calculation
@@ -18,13 +17,15 @@ module Elasticsearch
           # @option arguments [String] :start Returns overall buckets with timestamps after this time
           # @option arguments [String] :end Returns overall buckets with timestamps earlier than this time
           # @option arguments [Boolean] :allow_no_jobs Whether to ignore if a wildcard expression matches no jobs. (This includes `_all` string or when no jobs have been specified)
-
+          # @option arguments [Hash] :headers Custom HTTP headers
           # @option arguments [Hash] :body Overall bucket selection details if not provided in URI
           #
           # @see https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-overall-buckets.html
           #
           def get_overall_buckets(arguments = {})
             raise ArgumentError, "Required argument 'job_id' missing" unless arguments[:job_id]
+
+            headers = arguments.delete(:headers) || {}
 
             arguments = arguments.clone
 
@@ -35,7 +36,7 @@ module Elasticsearch
             params = Elasticsearch::API::Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
 
             body = arguments[:body]
-            perform_request(method, path, params, body).body
+            perform_request(method, path, params, body, headers).body
           end
 
           # Register this action with its valid params when the module is loaded.

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/machine_learning/get_records.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/machine_learning/get_records.rb
@@ -7,25 +7,26 @@ module Elasticsearch
     module API
       module MachineLearning
         module Actions
-          # TODO: Description
-
+          # Retrieves anomaly records for an anomaly detection job.
           #
-          # @option arguments [String] :job_id [TODO]
+          # @option arguments [String] :job_id The ID of the job
           # @option arguments [Boolean] :exclude_interim Exclude interim results
           # @option arguments [Int] :from skips a number of records
           # @option arguments [Int] :size specifies a max number of records to get
           # @option arguments [String] :start Start time filter for records
           # @option arguments [String] :end End time filter for records
-          # @option arguments [Double] :record_score [TODO]
+          # @option arguments [Double] :record_score Returns records with anomaly scores greater or equal than this value
           # @option arguments [String] :sort Sort records by a particular field
           # @option arguments [Boolean] :desc Set the sort direction
-
+          # @option arguments [Hash] :headers Custom HTTP headers
           # @option arguments [Hash] :body Record selection criteria
           #
           # @see https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-record.html
           #
           def get_records(arguments = {})
             raise ArgumentError, "Required argument 'job_id' missing" unless arguments[:job_id]
+
+            headers = arguments.delete(:headers) || {}
 
             arguments = arguments.clone
 
@@ -36,7 +37,7 @@ module Elasticsearch
             params = Elasticsearch::API::Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
 
             body = arguments[:body]
-            perform_request(method, path, params, body).body
+            perform_request(method, path, params, body, headers).body
           end
 
           # Register this action with its valid params when the module is loaded.

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/machine_learning/get_trained_models.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/machine_learning/get_trained_models.rb
@@ -7,8 +7,7 @@ module Elasticsearch
     module API
       module MachineLearning
         module Actions
-          # TODO: Description
-
+          # Retrieves configuration information for a trained inference model.
           #
           # @option arguments [String] :model_id The ID of the trained models to fetch
           # @option arguments [Boolean] :allow_no_match Whether to ignore if a wildcard expression matches no trained models. (This includes `_all` string or when no trained models have been specified)
@@ -17,11 +16,13 @@ module Elasticsearch
           # @option arguments [Int] :from skips a number of trained models
           # @option arguments [Int] :size specifies a max number of trained models to get
           # @option arguments [List] :tags A comma-separated list of tags that the model must have.
-
+          # @option arguments [Hash] :headers Custom HTTP headers
           #
           # @see https://www.elastic.co/guide/en/elasticsearch/reference/current/get-inference.html
           #
           def get_trained_models(arguments = {})
+            headers = arguments.delete(:headers) || {}
+
             arguments = arguments.clone
 
             _model_id = arguments.delete(:model_id)
@@ -31,11 +32,11 @@ module Elasticsearch
                        "_ml/inference/#{Elasticsearch::API::Utils.__listify(_model_id)}"
                      else
                        "_ml/inference"
-  end
+            end
             params = Elasticsearch::API::Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
 
             body = nil
-            perform_request(method, path, params, body).body
+            perform_request(method, path, params, body, headers).body
           end
 
           # Register this action with its valid params when the module is loaded.

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/machine_learning/get_trained_models_stats.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/machine_learning/get_trained_models_stats.rb
@@ -7,18 +7,19 @@ module Elasticsearch
     module API
       module MachineLearning
         module Actions
-          # TODO: Description
-
+          # Retrieves usage information for trained inference models.
           #
           # @option arguments [String] :model_id The ID of the trained models stats to fetch
           # @option arguments [Boolean] :allow_no_match Whether to ignore if a wildcard expression matches no trained models. (This includes `_all` string or when no trained models have been specified)
           # @option arguments [Int] :from skips a number of trained models
           # @option arguments [Int] :size specifies a max number of trained models to get
-
+          # @option arguments [Hash] :headers Custom HTTP headers
           #
           # @see https://www.elastic.co/guide/en/elasticsearch/reference/current/get-inference-stats.html
           #
           def get_trained_models_stats(arguments = {})
+            headers = arguments.delete(:headers) || {}
+
             arguments = arguments.clone
 
             _model_id = arguments.delete(:model_id)
@@ -28,11 +29,11 @@ module Elasticsearch
                        "_ml/inference/#{Elasticsearch::API::Utils.__listify(_model_id)}/_stats"
                      else
                        "_ml/inference/_stats"
-  end
+            end
             params = Elasticsearch::API::Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
 
             body = nil
-            perform_request(method, path, params, body).body
+            perform_request(method, path, params, body, headers).body
           end
 
           # Register this action with its valid params when the module is loaded.

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/machine_learning/info.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/machine_learning/info.rb
@@ -7,12 +7,15 @@ module Elasticsearch
     module API
       module MachineLearning
         module Actions
-          # TODO: Description
-
+          # Returns defaults and limits used by machine learning.
           #
-          # @see [TODO]
+          # @option arguments [Hash] :headers Custom HTTP headers
+          #
+          # @see https://www.elastic.co/guide/en/elasticsearch/reference/current/get-ml-info.html
           #
           def info(arguments = {})
+            headers = arguments.delete(:headers) || {}
+
             arguments = arguments.clone
 
             method = Elasticsearch::API::HTTP_GET
@@ -20,7 +23,7 @@ module Elasticsearch
             params = {}
 
             body = nil
-            perform_request(method, path, params, body).body
+            perform_request(method, path, params, body, headers).body
           end
       end
     end

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/machine_learning/open_job.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/machine_learning/open_job.rb
@@ -7,16 +7,17 @@ module Elasticsearch
     module API
       module MachineLearning
         module Actions
-          # TODO: Description
-
+          # Opens one or more anomaly detection jobs.
           #
           # @option arguments [String] :job_id The ID of the job to open
-
+          # @option arguments [Hash] :headers Custom HTTP headers
           #
           # @see https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-open-job.html
           #
           def open_job(arguments = {})
             raise ArgumentError, "Required argument 'job_id' missing" unless arguments[:job_id]
+
+            headers = arguments.delete(:headers) || {}
 
             arguments = arguments.clone
 
@@ -27,7 +28,7 @@ module Elasticsearch
             params = {}
 
             body = nil
-            perform_request(method, path, params, body).body
+            perform_request(method, path, params, body, headers).body
           end
       end
     end

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/machine_learning/post_calendar_events.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/machine_learning/post_calendar_events.rb
@@ -7,18 +7,19 @@ module Elasticsearch
     module API
       module MachineLearning
         module Actions
-          # TODO: Description
-
+          # Posts scheduled events in a calendar.
           #
           # @option arguments [String] :calendar_id The ID of the calendar to modify
-
+          # @option arguments [Hash] :headers Custom HTTP headers
           # @option arguments [Hash] :body A list of events (*Required*)
           #
-          # @see [TODO]
+          # @see https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-post-calendar-event.html
           #
           def post_calendar_events(arguments = {})
             raise ArgumentError, "Required argument 'body' missing" unless arguments[:body]
             raise ArgumentError, "Required argument 'calendar_id' missing" unless arguments[:calendar_id]
+
+            headers = arguments.delete(:headers) || {}
 
             arguments = arguments.clone
 
@@ -29,7 +30,7 @@ module Elasticsearch
             params = {}
 
             body = arguments[:body]
-            perform_request(method, path, params, body).body
+            perform_request(method, path, params, body, headers).body
           end
       end
     end

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/machine_learning/post_data.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/machine_learning/post_data.rb
@@ -7,13 +7,12 @@ module Elasticsearch
     module API
       module MachineLearning
         module Actions
-          # TODO: Description
-
+          # Sends data to an anomaly detection job for analysis.
           #
           # @option arguments [String] :job_id The name of the job receiving the data
           # @option arguments [String] :reset_start Optional parameter to specify the start of the bucket resetting range
           # @option arguments [String] :reset_end Optional parameter to specify the end of the bucket resetting range
-
+          # @option arguments [Hash] :headers Custom HTTP headers
           # @option arguments [Hash] :body The data to process (*Required*)
           #
           # @see https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-post-data.html
@@ -21,6 +20,8 @@ module Elasticsearch
           def post_data(arguments = {})
             raise ArgumentError, "Required argument 'body' missing" unless arguments[:body]
             raise ArgumentError, "Required argument 'job_id' missing" unless arguments[:job_id]
+
+            headers = arguments.delete(:headers) || {}
 
             arguments = arguments.clone
 
@@ -31,7 +32,7 @@ module Elasticsearch
             params = Elasticsearch::API::Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
 
             body = arguments[:body]
-            perform_request(method, path, params, body).body
+            perform_request(method, path, params, body, headers).body
           end
 
           # Register this action with its valid params when the module is loaded.

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/machine_learning/preview_datafeed.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/machine_learning/preview_datafeed.rb
@@ -7,16 +7,17 @@ module Elasticsearch
     module API
       module MachineLearning
         module Actions
-          # TODO: Description
-
+          # Previews a datafeed.
           #
           # @option arguments [String] :datafeed_id The ID of the datafeed to preview
-
+          # @option arguments [Hash] :headers Custom HTTP headers
           #
           # @see https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-preview-datafeed.html
           #
           def preview_datafeed(arguments = {})
             raise ArgumentError, "Required argument 'datafeed_id' missing" unless arguments[:datafeed_id]
+
+            headers = arguments.delete(:headers) || {}
 
             arguments = arguments.clone
 
@@ -27,7 +28,7 @@ module Elasticsearch
             params = {}
 
             body = nil
-            perform_request(method, path, params, body).body
+            perform_request(method, path, params, body, headers).body
           end
       end
     end

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/machine_learning/put_calendar.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/machine_learning/put_calendar.rb
@@ -7,17 +7,18 @@ module Elasticsearch
     module API
       module MachineLearning
         module Actions
-          # TODO: Description
-
+          # Instantiates a calendar.
           #
           # @option arguments [String] :calendar_id The ID of the calendar to create
-
+          # @option arguments [Hash] :headers Custom HTTP headers
           # @option arguments [Hash] :body The calendar details
           #
-          # @see [TODO]
+          # @see https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-put-calendar.html
           #
           def put_calendar(arguments = {})
             raise ArgumentError, "Required argument 'calendar_id' missing" unless arguments[:calendar_id]
+
+            headers = arguments.delete(:headers) || {}
 
             arguments = arguments.clone
 
@@ -28,7 +29,7 @@ module Elasticsearch
             params = {}
 
             body = arguments[:body]
-            perform_request(method, path, params, body).body
+            perform_request(method, path, params, body, headers).body
           end
       end
     end

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/machine_learning/put_calendar_job.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/machine_learning/put_calendar_job.rb
@@ -7,18 +7,19 @@ module Elasticsearch
     module API
       module MachineLearning
         module Actions
-          # TODO: Description
-
+          # Adds an anomaly detection job to a calendar.
           #
           # @option arguments [String] :calendar_id The ID of the calendar to modify
           # @option arguments [String] :job_id The ID of the job to add to the calendar
-
+          # @option arguments [Hash] :headers Custom HTTP headers
           #
-          # @see [TODO]
+          # @see https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-put-calendar-job.html
           #
           def put_calendar_job(arguments = {})
             raise ArgumentError, "Required argument 'calendar_id' missing" unless arguments[:calendar_id]
             raise ArgumentError, "Required argument 'job_id' missing" unless arguments[:job_id]
+
+            headers = arguments.delete(:headers) || {}
 
             arguments = arguments.clone
 
@@ -31,7 +32,7 @@ module Elasticsearch
             params = {}
 
             body = nil
-            perform_request(method, path, params, body).body
+            perform_request(method, path, params, body, headers).body
           end
       end
     end

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/machine_learning/put_data_frame_analytics.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/machine_learning/put_data_frame_analytics.rb
@@ -7,11 +7,10 @@ module Elasticsearch
     module API
       module MachineLearning
         module Actions
-          # TODO: Description
-
+          # Instantiates a data frame analytics job.
           #
           # @option arguments [String] :id The ID of the data frame analytics to create
-
+          # @option arguments [Hash] :headers Custom HTTP headers
           # @option arguments [Hash] :body The data frame analytics configuration (*Required*)
           #
           # @see https://www.elastic.co/guide/en/elasticsearch/reference/current/put-dfanalytics.html
@@ -19,6 +18,8 @@ module Elasticsearch
           def put_data_frame_analytics(arguments = {})
             raise ArgumentError, "Required argument 'body' missing" unless arguments[:body]
             raise ArgumentError, "Required argument 'id' missing" unless arguments[:id]
+
+            headers = arguments.delete(:headers) || {}
 
             arguments = arguments.clone
 
@@ -29,7 +30,7 @@ module Elasticsearch
             params = {}
 
             body = arguments[:body]
-            perform_request(method, path, params, body).body
+            perform_request(method, path, params, body, headers).body
           end
       end
     end

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/machine_learning/put_datafeed.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/machine_learning/put_datafeed.rb
@@ -7,8 +7,7 @@ module Elasticsearch
     module API
       module MachineLearning
         module Actions
-          # TODO: Description
-
+          # Instantiates a datafeed.
           #
           # @option arguments [String] :datafeed_id The ID of the datafeed to create
           # @option arguments [Boolean] :ignore_unavailable Ignore unavailable indexes (default: false)
@@ -17,6 +16,7 @@ module Elasticsearch
           # @option arguments [String] :expand_wildcards Whether source index expressions should get expanded to open or closed indices (default: open)
           #   (options: open,closed,hidden,none,all)
 
+          # @option arguments [Hash] :headers Custom HTTP headers
           # @option arguments [Hash] :body The datafeed config (*Required*)
           #
           # @see https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-put-datafeed.html
@@ -24,6 +24,8 @@ module Elasticsearch
           def put_datafeed(arguments = {})
             raise ArgumentError, "Required argument 'body' missing" unless arguments[:body]
             raise ArgumentError, "Required argument 'datafeed_id' missing" unless arguments[:datafeed_id]
+
+            headers = arguments.delete(:headers) || {}
 
             arguments = arguments.clone
 
@@ -34,7 +36,7 @@ module Elasticsearch
             params = Elasticsearch::API::Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
 
             body = arguments[:body]
-            perform_request(method, path, params, body).body
+            perform_request(method, path, params, body, headers).body
           end
 
           # Register this action with its valid params when the module is loaded.

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/machine_learning/put_filter.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/machine_learning/put_filter.rb
@@ -7,18 +7,19 @@ module Elasticsearch
     module API
       module MachineLearning
         module Actions
-          # TODO: Description
-
+          # Instantiates a filter.
           #
           # @option arguments [String] :filter_id The ID of the filter to create
-
+          # @option arguments [Hash] :headers Custom HTTP headers
           # @option arguments [Hash] :body The filter details (*Required*)
           #
-          # @see [TODO]
+          # @see https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-put-filter.html
           #
           def put_filter(arguments = {})
             raise ArgumentError, "Required argument 'body' missing" unless arguments[:body]
             raise ArgumentError, "Required argument 'filter_id' missing" unless arguments[:filter_id]
+
+            headers = arguments.delete(:headers) || {}
 
             arguments = arguments.clone
 
@@ -29,7 +30,7 @@ module Elasticsearch
             params = {}
 
             body = arguments[:body]
-            perform_request(method, path, params, body).body
+            perform_request(method, path, params, body, headers).body
           end
       end
     end

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/machine_learning/put_job.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/machine_learning/put_job.rb
@@ -7,11 +7,10 @@ module Elasticsearch
     module API
       module MachineLearning
         module Actions
-          # TODO: Description
-
+          # Instantiates an anomaly detection job.
           #
           # @option arguments [String] :job_id The ID of the job to create
-
+          # @option arguments [Hash] :headers Custom HTTP headers
           # @option arguments [Hash] :body The job (*Required*)
           #
           # @see https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-put-job.html
@@ -19,6 +18,8 @@ module Elasticsearch
           def put_job(arguments = {})
             raise ArgumentError, "Required argument 'body' missing" unless arguments[:body]
             raise ArgumentError, "Required argument 'job_id' missing" unless arguments[:job_id]
+
+            headers = arguments.delete(:headers) || {}
 
             arguments = arguments.clone
 
@@ -29,7 +30,7 @@ module Elasticsearch
             params = {}
 
             body = arguments[:body]
-            perform_request(method, path, params, body).body
+            perform_request(method, path, params, body, headers).body
           end
       end
     end

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/machine_learning/put_trained_model.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/machine_learning/put_trained_model.rb
@@ -7,18 +7,19 @@ module Elasticsearch
     module API
       module MachineLearning
         module Actions
-          # TODO: Description
-
+          # Creates an inference trained model.
           #
           # @option arguments [String] :model_id The ID of the trained models to store
-
+          # @option arguments [Hash] :headers Custom HTTP headers
           # @option arguments [Hash] :body The trained model configuration (*Required*)
           #
-          # @see TODO
+          # @see https://www.elastic.co/guide/en/elasticsearch/reference/current/put-inference.html
           #
           def put_trained_model(arguments = {})
             raise ArgumentError, "Required argument 'body' missing" unless arguments[:body]
             raise ArgumentError, "Required argument 'model_id' missing" unless arguments[:model_id]
+
+            headers = arguments.delete(:headers) || {}
 
             arguments = arguments.clone
 
@@ -29,7 +30,7 @@ module Elasticsearch
             params = {}
 
             body = arguments[:body]
-            perform_request(method, path, params, body).body
+            perform_request(method, path, params, body, headers).body
           end
       end
     end

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/machine_learning/revert_model_snapshot.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/machine_learning/revert_model_snapshot.rb
@@ -7,13 +7,12 @@ module Elasticsearch
     module API
       module MachineLearning
         module Actions
-          # TODO: Description
-
+          # Reverts to a specific snapshot.
           #
           # @option arguments [String] :job_id The ID of the job to fetch
           # @option arguments [String] :snapshot_id The ID of the snapshot to revert to
           # @option arguments [Boolean] :delete_intervening_results Should we reset the results back to the time of the snapshot?
-
+          # @option arguments [Hash] :headers Custom HTTP headers
           # @option arguments [Hash] :body Reversion options
           #
           # @see https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-revert-snapshot.html
@@ -21,6 +20,8 @@ module Elasticsearch
           def revert_model_snapshot(arguments = {})
             raise ArgumentError, "Required argument 'job_id' missing" unless arguments[:job_id]
             raise ArgumentError, "Required argument 'snapshot_id' missing" unless arguments[:snapshot_id]
+
+            headers = arguments.delete(:headers) || {}
 
             arguments = arguments.clone
 
@@ -33,7 +34,7 @@ module Elasticsearch
             params = Elasticsearch::API::Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
 
             body = arguments[:body]
-            perform_request(method, path, params, body).body
+            perform_request(method, path, params, body, headers).body
           end
 
           # Register this action with its valid params when the module is loaded.

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/machine_learning/set_upgrade_mode.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/machine_learning/set_upgrade_mode.rb
@@ -7,16 +7,17 @@ module Elasticsearch
     module API
       module MachineLearning
         module Actions
-          # TODO: Description
-
+          # Sets a cluster wide upgrade_mode setting that prepares machine learning indices for an upgrade.
           #
           # @option arguments [Boolean] :enabled Whether to enable upgrade_mode ML setting or not. Defaults to false.
           # @option arguments [Time] :timeout Controls the time to wait before action times out. Defaults to 30 seconds
-
+          # @option arguments [Hash] :headers Custom HTTP headers
           #
           # @see https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-set-upgrade-mode.html
           #
           def set_upgrade_mode(arguments = {})
+            headers = arguments.delete(:headers) || {}
+
             arguments = arguments.clone
 
             method = Elasticsearch::API::HTTP_POST
@@ -24,7 +25,7 @@ module Elasticsearch
             params = Elasticsearch::API::Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
 
             body = nil
-            perform_request(method, path, params, body).body
+            perform_request(method, path, params, body, headers).body
           end
 
           # Register this action with its valid params when the module is loaded.

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/machine_learning/start_data_frame_analytics.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/machine_learning/start_data_frame_analytics.rb
@@ -7,18 +7,19 @@ module Elasticsearch
     module API
       module MachineLearning
         module Actions
-          # TODO: Description
-
+          # Starts a data frame analytics job.
           #
           # @option arguments [String] :id The ID of the data frame analytics to start
           # @option arguments [Time] :timeout Controls the time to wait until the task has started. Defaults to 20 seconds
-
+          # @option arguments [Hash] :headers Custom HTTP headers
           # @option arguments [Hash] :body The start data frame analytics parameters
           #
           # @see https://www.elastic.co/guide/en/elasticsearch/reference/current/start-dfanalytics.html
           #
           def start_data_frame_analytics(arguments = {})
             raise ArgumentError, "Required argument 'id' missing" unless arguments[:id]
+
+            headers = arguments.delete(:headers) || {}
 
             arguments = arguments.clone
 
@@ -29,7 +30,7 @@ module Elasticsearch
             params = Elasticsearch::API::Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
 
             body = arguments[:body]
-            perform_request(method, path, params, body).body
+            perform_request(method, path, params, body, headers).body
           end
 
           # Register this action with its valid params when the module is loaded.

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/machine_learning/start_datafeed.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/machine_learning/start_datafeed.rb
@@ -7,20 +7,21 @@ module Elasticsearch
     module API
       module MachineLearning
         module Actions
-          # TODO: Description
-
+          # Starts one or more datafeeds.
           #
           # @option arguments [String] :datafeed_id The ID of the datafeed to start
           # @option arguments [String] :start The start time from where the datafeed should begin
           # @option arguments [String] :end The end time when the datafeed should stop. When not set, the datafeed continues in real time
           # @option arguments [Time] :timeout Controls the time to wait until a datafeed has started. Default to 20 seconds
-
+          # @option arguments [Hash] :headers Custom HTTP headers
           # @option arguments [Hash] :body The start datafeed parameters
           #
           # @see https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-start-datafeed.html
           #
           def start_datafeed(arguments = {})
             raise ArgumentError, "Required argument 'datafeed_id' missing" unless arguments[:datafeed_id]
+
+            headers = arguments.delete(:headers) || {}
 
             arguments = arguments.clone
 
@@ -31,7 +32,7 @@ module Elasticsearch
             params = Elasticsearch::API::Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
 
             body = arguments[:body]
-            perform_request(method, path, params, body).body
+            perform_request(method, path, params, body, headers).body
           end
 
           # Register this action with its valid params when the module is loaded.

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/machine_learning/stop_data_frame_analytics.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/machine_learning/stop_data_frame_analytics.rb
@@ -7,20 +7,21 @@ module Elasticsearch
     module API
       module MachineLearning
         module Actions
-          # TODO: Description
-
+          # Stops one or more data frame analytics jobs.
           #
           # @option arguments [String] :id The ID of the data frame analytics to stop
           # @option arguments [Boolean] :allow_no_match Whether to ignore if a wildcard expression matches no data frame analytics. (This includes `_all` string or when no data frame analytics have been specified)
           # @option arguments [Boolean] :force True if the data frame analytics should be forcefully stopped
           # @option arguments [Time] :timeout Controls the time to wait until the task has stopped. Defaults to 20 seconds
-
+          # @option arguments [Hash] :headers Custom HTTP headers
           # @option arguments [Hash] :body The stop data frame analytics parameters
           #
           # @see https://www.elastic.co/guide/en/elasticsearch/reference/current/stop-dfanalytics.html
           #
           def stop_data_frame_analytics(arguments = {})
             raise ArgumentError, "Required argument 'id' missing" unless arguments[:id]
+
+            headers = arguments.delete(:headers) || {}
 
             arguments = arguments.clone
 
@@ -31,7 +32,7 @@ module Elasticsearch
             params = Elasticsearch::API::Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
 
             body = arguments[:body]
-            perform_request(method, path, params, body).body
+            perform_request(method, path, params, body, headers).body
           end
 
           # Register this action with its valid params when the module is loaded.

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/machine_learning/stop_datafeed.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/machine_learning/stop_datafeed.rb
@@ -7,19 +7,20 @@ module Elasticsearch
     module API
       module MachineLearning
         module Actions
-          # TODO: Description
-
+          # Stops one or more datafeeds.
           #
           # @option arguments [String] :datafeed_id The ID of the datafeed to stop
           # @option arguments [Boolean] :allow_no_datafeeds Whether to ignore if a wildcard expression matches no datafeeds. (This includes `_all` string or when no datafeeds have been specified)
           # @option arguments [Boolean] :force True if the datafeed should be forcefully stopped.
           # @option arguments [Time] :timeout Controls the time to wait until a datafeed has stopped. Default to 20 seconds
-
+          # @option arguments [Hash] :headers Custom HTTP headers
           #
           # @see https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-stop-datafeed.html
           #
           def stop_datafeed(arguments = {})
             raise ArgumentError, "Required argument 'datafeed_id' missing" unless arguments[:datafeed_id]
+
+            headers = arguments.delete(:headers) || {}
 
             arguments = arguments.clone
 
@@ -30,7 +31,7 @@ module Elasticsearch
             params = Elasticsearch::API::Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
 
             body = nil
-            perform_request(method, path, params, body).body
+            perform_request(method, path, params, body, headers).body
           end
 
           # Register this action with its valid params when the module is loaded.

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/machine_learning/update_datafeed.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/machine_learning/update_datafeed.rb
@@ -7,8 +7,7 @@ module Elasticsearch
     module API
       module MachineLearning
         module Actions
-          # TODO: Description
-
+          # Updates certain properties of a datafeed.
           #
           # @option arguments [String] :datafeed_id The ID of the datafeed to update
           # @option arguments [Boolean] :ignore_unavailable Ignore unavailable indexes (default: false)
@@ -17,6 +16,7 @@ module Elasticsearch
           # @option arguments [String] :expand_wildcards Whether source index expressions should get expanded to open or closed indices (default: open)
           #   (options: open,closed,hidden,none,all)
 
+          # @option arguments [Hash] :headers Custom HTTP headers
           # @option arguments [Hash] :body The datafeed update settings (*Required*)
           #
           # @see https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-update-datafeed.html
@@ -24,6 +24,8 @@ module Elasticsearch
           def update_datafeed(arguments = {})
             raise ArgumentError, "Required argument 'body' missing" unless arguments[:body]
             raise ArgumentError, "Required argument 'datafeed_id' missing" unless arguments[:datafeed_id]
+
+            headers = arguments.delete(:headers) || {}
 
             arguments = arguments.clone
 
@@ -34,7 +36,7 @@ module Elasticsearch
             params = Elasticsearch::API::Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
 
             body = arguments[:body]
-            perform_request(method, path, params, body).body
+            perform_request(method, path, params, body, headers).body
           end
 
           # Register this action with its valid params when the module is loaded.

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/machine_learning/update_filter.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/machine_learning/update_filter.rb
@@ -7,18 +7,19 @@ module Elasticsearch
     module API
       module MachineLearning
         module Actions
-          # TODO: Description
-
+          # Updates the description of a filter, adds items, or removes items.
           #
           # @option arguments [String] :filter_id The ID of the filter to update
-
+          # @option arguments [Hash] :headers Custom HTTP headers
           # @option arguments [Hash] :body The filter update (*Required*)
           #
-          # @see [TODO]
+          # @see https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-update-filter.html
           #
           def update_filter(arguments = {})
             raise ArgumentError, "Required argument 'body' missing" unless arguments[:body]
             raise ArgumentError, "Required argument 'filter_id' missing" unless arguments[:filter_id]
+
+            headers = arguments.delete(:headers) || {}
 
             arguments = arguments.clone
 
@@ -29,7 +30,7 @@ module Elasticsearch
             params = {}
 
             body = arguments[:body]
-            perform_request(method, path, params, body).body
+            perform_request(method, path, params, body, headers).body
           end
       end
     end

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/machine_learning/update_job.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/machine_learning/update_job.rb
@@ -7,11 +7,10 @@ module Elasticsearch
     module API
       module MachineLearning
         module Actions
-          # TODO: Description
-
+          # Updates certain properties of an anomaly detection job.
           #
           # @option arguments [String] :job_id The ID of the job to create
-
+          # @option arguments [Hash] :headers Custom HTTP headers
           # @option arguments [Hash] :body The job update settings (*Required*)
           #
           # @see https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-update-job.html
@@ -19,6 +18,8 @@ module Elasticsearch
           def update_job(arguments = {})
             raise ArgumentError, "Required argument 'body' missing" unless arguments[:body]
             raise ArgumentError, "Required argument 'job_id' missing" unless arguments[:job_id]
+
+            headers = arguments.delete(:headers) || {}
 
             arguments = arguments.clone
 
@@ -29,7 +30,7 @@ module Elasticsearch
             params = {}
 
             body = arguments[:body]
-            perform_request(method, path, params, body).body
+            perform_request(method, path, params, body, headers).body
           end
       end
     end

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/machine_learning/update_model_snapshot.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/machine_learning/update_model_snapshot.rb
@@ -7,12 +7,11 @@ module Elasticsearch
     module API
       module MachineLearning
         module Actions
-          # TODO: Description
-
+          # Updates certain properties of a snapshot.
           #
           # @option arguments [String] :job_id The ID of the job to fetch
           # @option arguments [String] :snapshot_id The ID of the snapshot to update
-
+          # @option arguments [Hash] :headers Custom HTTP headers
           # @option arguments [Hash] :body The model snapshot properties to update (*Required*)
           #
           # @see https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-update-snapshot.html
@@ -21,6 +20,8 @@ module Elasticsearch
             raise ArgumentError, "Required argument 'body' missing" unless arguments[:body]
             raise ArgumentError, "Required argument 'job_id' missing" unless arguments[:job_id]
             raise ArgumentError, "Required argument 'snapshot_id' missing" unless arguments[:snapshot_id]
+
+            headers = arguments.delete(:headers) || {}
 
             arguments = arguments.clone
 
@@ -33,7 +34,7 @@ module Elasticsearch
             params = {}
 
             body = arguments[:body]
-            perform_request(method, path, params, body).body
+            perform_request(method, path, params, body, headers).body
           end
       end
     end

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/machine_learning/validate.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/machine_learning/validate.rb
@@ -7,14 +7,17 @@ module Elasticsearch
     module API
       module MachineLearning
         module Actions
-          # TODO: Description
-
+          # Validates an anomaly detection job.
+          #
+          # @option arguments [Hash] :headers Custom HTTP headers
           # @option arguments [Hash] :body The job config (*Required*)
           #
           # @see [TODO]
           #
           def validate(arguments = {})
             raise ArgumentError, "Required argument 'body' missing" unless arguments[:body]
+
+            headers = arguments.delete(:headers) || {}
 
             arguments = arguments.clone
 
@@ -23,7 +26,7 @@ module Elasticsearch
             params = {}
 
             body = arguments[:body]
-            perform_request(method, path, params, body).body
+            perform_request(method, path, params, body, headers).body
           end
       end
     end

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/machine_learning/validate_detector.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/machine_learning/validate_detector.rb
@@ -7,14 +7,17 @@ module Elasticsearch
     module API
       module MachineLearning
         module Actions
-          # TODO: Description
-
+          # Validates an anomaly detection detector.
+          #
+          # @option arguments [Hash] :headers Custom HTTP headers
           # @option arguments [Hash] :body The detector (*Required*)
           #
           # @see [TODO]
           #
           def validate_detector(arguments = {})
             raise ArgumentError, "Required argument 'body' missing" unless arguments[:body]
+
+            headers = arguments.delete(:headers) || {}
 
             arguments = arguments.clone
 
@@ -23,7 +26,7 @@ module Elasticsearch
             params = {}
 
             body = arguments[:body]
-            perform_request(method, path, params, body).body
+            perform_request(method, path, params, body, headers).body
           end
       end
     end

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/migration/deprecations.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/migration/deprecations.rb
@@ -7,15 +7,16 @@ module Elasticsearch
     module API
       module Migration
         module Actions
-          # TODO: Description
-
+          # Retrieves information about different cluster, node, and index level settings that use deprecated features that will be removed or changed in the next major version.
           #
           # @option arguments [String] :index Index pattern
-
+          # @option arguments [Hash] :headers Custom HTTP headers
           #
           # @see https://www.elastic.co/guide/en/elasticsearch/reference/current/migration-api-deprecation.html
           #
           def deprecations(arguments = {})
+            headers = arguments.delete(:headers) || {}
+
             arguments = arguments.clone
 
             _index = arguments.delete(:index)
@@ -25,11 +26,11 @@ module Elasticsearch
                        "#{Elasticsearch::API::Utils.__listify(_index)}/_migration/deprecations"
                      else
                        "_migration/deprecations"
-  end
+            end
             params = {}
 
             body = nil
-            perform_request(method, path, params, body).body
+            perform_request(method, path, params, body, headers).body
           end
       end
     end

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/monitoring/bulk.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/monitoring/bulk.rb
@@ -7,14 +7,13 @@ module Elasticsearch
     module API
       module Monitoring
         module Actions
-          # TODO: Description
-
+          # Used by the monitoring features to send monitoring data.
           #
           # @option arguments [String] :type Default document type for items which don't provide one   *Deprecated*
           # @option arguments [String] :system_id Identifier of the monitored system
           # @option arguments [String] :system_api_version API Version of the monitored system
           # @option arguments [String] :interval Collection interval (e.g., '10s' or '10000ms') of the payload
-
+          # @option arguments [Hash] :headers Custom HTTP headers
           # @option arguments [Hash] :body The operation definition and data (action-data pairs), separated by newlines (*Required*)
           #
           # *Deprecation notice*:
@@ -26,6 +25,8 @@ module Elasticsearch
           #
           def bulk(arguments = {})
             raise ArgumentError, "Required argument 'body' missing" unless arguments[:body]
+
+            headers = arguments.delete(:headers) || {}
 
             arguments = arguments.clone
 
@@ -46,7 +47,8 @@ module Elasticsearch
               payload = body
           end
 
-            perform_request(method, path, params, payload, { "Content-Type" => "application/x-ndjson" }).body
+            headers.merge!("Content-Type" => "application/x-ndjson")
+            perform_request(method, path, params, payload, headers).body
           end
 
           # Register this action with its valid params when the module is loaded.

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/rollup/delete_job.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/rollup/delete_job.rb
@@ -7,16 +7,17 @@ module Elasticsearch
     module API
       module Rollup
         module Actions
-          # TODO: Description
-
+          # Deletes an existing rollup job.
           #
           # @option arguments [String] :id The ID of the job to delete
-
+          # @option arguments [Hash] :headers Custom HTTP headers
           #
-          # @see
+          # @see https://www.elastic.co/guide/en/elasticsearch/reference/master/rollup-delete-job.html
           #
           def delete_job(arguments = {})
             raise ArgumentError, "Required argument 'id' missing" unless arguments[:id]
+
+            headers = arguments.delete(:headers) || {}
 
             arguments = arguments.clone
 
@@ -27,7 +28,7 @@ module Elasticsearch
             params = {}
 
             body = nil
-            perform_request(method, path, params, body).body
+            perform_request(method, path, params, body, headers).body
           end
       end
     end

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/rollup/get_jobs.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/rollup/get_jobs.rb
@@ -7,15 +7,16 @@ module Elasticsearch
     module API
       module Rollup
         module Actions
-          # TODO: Description
-
+          # Retrieves the configuration, stats, and status of rollup jobs.
           #
           # @option arguments [String] :id The ID of the job(s) to fetch. Accepts glob patterns, or left blank for all jobs
-
+          # @option arguments [Hash] :headers Custom HTTP headers
           #
-          # @see
+          # @see https://www.elastic.co/guide/en/elasticsearch/reference/master/rollup-get-job.html
           #
           def get_jobs(arguments = {})
+            headers = arguments.delete(:headers) || {}
+
             arguments = arguments.clone
 
             _id = arguments.delete(:id)
@@ -25,11 +26,11 @@ module Elasticsearch
                        "_rollup/job/#{Elasticsearch::API::Utils.__listify(_id)}"
                      else
                        "_rollup/job"
-  end
+            end
             params = {}
 
             body = nil
-            perform_request(method, path, params, body).body
+            perform_request(method, path, params, body, headers).body
           end
       end
     end

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/rollup/get_rollup_caps.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/rollup/get_rollup_caps.rb
@@ -7,15 +7,16 @@ module Elasticsearch
     module API
       module Rollup
         module Actions
-          # TODO: Description
-
+          # Returns the capabilities of any rollup jobs that have been configured for a specific index or index pattern.
           #
           # @option arguments [String] :id The ID of the index to check rollup capabilities on, or left blank for all jobs
-
+          # @option arguments [Hash] :headers Custom HTTP headers
           #
-          # @see
+          # @see https://www.elastic.co/guide/en/elasticsearch/reference/master/rollup-get-rollup-caps.html
           #
           def get_rollup_caps(arguments = {})
+            headers = arguments.delete(:headers) || {}
+
             arguments = arguments.clone
 
             _id = arguments.delete(:id)
@@ -25,11 +26,11 @@ module Elasticsearch
                        "_rollup/data/#{Elasticsearch::API::Utils.__listify(_id)}"
                      else
                        "_rollup/data"
-  end
+            end
             params = {}
 
             body = nil
-            perform_request(method, path, params, body).body
+            perform_request(method, path, params, body, headers).body
           end
       end
     end

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/rollup/get_rollup_index_caps.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/rollup/get_rollup_index_caps.rb
@@ -7,16 +7,17 @@ module Elasticsearch
     module API
       module Rollup
         module Actions
-          # TODO: Description
-
+          # Returns the rollup capabilities of all jobs inside of a rollup index (e.g. the index where rollup data is stored).
           #
           # @option arguments [String] :index The rollup index or index pattern to obtain rollup capabilities from.
-
+          # @option arguments [Hash] :headers Custom HTTP headers
           #
-          # @see
+          # @see https://www.elastic.co/guide/en/elasticsearch/reference/master/rollup-get-rollup-index-caps.html
           #
           def get_rollup_index_caps(arguments = {})
             raise ArgumentError, "Required argument 'index' missing" unless arguments[:index]
+
+            headers = arguments.delete(:headers) || {}
 
             arguments = arguments.clone
 
@@ -27,7 +28,7 @@ module Elasticsearch
             params = {}
 
             body = nil
-            perform_request(method, path, params, body).body
+            perform_request(method, path, params, body, headers).body
           end
       end
     end

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/rollup/put_job.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/rollup/put_job.rb
@@ -7,18 +7,19 @@ module Elasticsearch
     module API
       module Rollup
         module Actions
-          # TODO: Description
-
+          # Creates a rollup job.
           #
           # @option arguments [String] :id The ID of the job to create
-
+          # @option arguments [Hash] :headers Custom HTTP headers
           # @option arguments [Hash] :body The job configuration (*Required*)
           #
-          # @see
+          # @see https://www.elastic.co/guide/en/elasticsearch/reference/master/rollup-put-job.html
           #
           def put_job(arguments = {})
             raise ArgumentError, "Required argument 'body' missing" unless arguments[:body]
             raise ArgumentError, "Required argument 'id' missing" unless arguments[:id]
+
+            headers = arguments.delete(:headers) || {}
 
             arguments = arguments.clone
 
@@ -29,7 +30,7 @@ module Elasticsearch
             params = {}
 
             body = arguments[:body]
-            perform_request(method, path, params, body).body
+            perform_request(method, path, params, body, headers).body
           end
       end
     end

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/rollup/rollup_search.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/rollup/rollup_search.rb
@@ -7,14 +7,13 @@ module Elasticsearch
     module API
       module Rollup
         module Actions
-          # TODO: Description
-
+          # Enables searching rolled-up data using the standard query DSL.
           #
           # @option arguments [List] :index The indices or index-pattern(s) (containing rollup or regular data) that should be searched
           # @option arguments [String] :type The doc type inside the index   *Deprecated*
           # @option arguments [Boolean] :typed_keys Specify whether aggregation and suggester names should be prefixed by their respective types in the response
           # @option arguments [Boolean] :rest_total_hits_as_int Indicates whether hits.total should be rendered as an integer or an object in the rest search response
-
+          # @option arguments [Hash] :headers Custom HTTP headers
           # @option arguments [Hash] :body The search request body (*Required*)
           #
           # *Deprecation notice*:
@@ -22,11 +21,13 @@ module Elasticsearch
           # Deprecated since version 7.0.0
           #
           #
-          # @see
+          # @see https://www.elastic.co/guide/en/elasticsearch/reference/master/rollup-search.html
           #
           def rollup_search(arguments = {})
             raise ArgumentError, "Required argument 'body' missing" unless arguments[:body]
             raise ArgumentError, "Required argument 'index' missing" unless arguments[:index]
+
+            headers = arguments.delete(:headers) || {}
 
             arguments = arguments.clone
 
@@ -43,7 +44,7 @@ module Elasticsearch
             params = Elasticsearch::API::Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
 
             body = arguments[:body]
-            perform_request(method, path, params, body).body
+            perform_request(method, path, params, body, headers).body
           end
 
           # Register this action with its valid params when the module is loaded.

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/rollup/start_job.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/rollup/start_job.rb
@@ -7,16 +7,17 @@ module Elasticsearch
     module API
       module Rollup
         module Actions
-          # TODO: Description
-
+          # Starts an existing, stopped rollup job.
           #
           # @option arguments [String] :id The ID of the job to start
-
+          # @option arguments [Hash] :headers Custom HTTP headers
           #
-          # @see
+          # @see https://www.elastic.co/guide/en/elasticsearch/reference/master/rollup-start-job.html
           #
           def start_job(arguments = {})
             raise ArgumentError, "Required argument 'id' missing" unless arguments[:id]
+
+            headers = arguments.delete(:headers) || {}
 
             arguments = arguments.clone
 
@@ -27,7 +28,7 @@ module Elasticsearch
             params = {}
 
             body = nil
-            perform_request(method, path, params, body).body
+            perform_request(method, path, params, body, headers).body
           end
       end
     end

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/rollup/stop_job.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/rollup/stop_job.rb
@@ -7,18 +7,19 @@ module Elasticsearch
     module API
       module Rollup
         module Actions
-          # TODO: Description
-
+          # Stops an existing, started rollup job.
           #
           # @option arguments [String] :id The ID of the job to stop
           # @option arguments [Boolean] :wait_for_completion True if the API should block until the job has fully stopped, false if should be executed async. Defaults to false.
           # @option arguments [Time] :timeout Block for (at maximum) the specified duration while waiting for the job to stop.  Defaults to 30s.
-
+          # @option arguments [Hash] :headers Custom HTTP headers
           #
-          # @see
+          # @see https://www.elastic.co/guide/en/elasticsearch/reference/master/rollup-stop-job.html
           #
           def stop_job(arguments = {})
             raise ArgumentError, "Required argument 'id' missing" unless arguments[:id]
+
+            headers = arguments.delete(:headers) || {}
 
             arguments = arguments.clone
 
@@ -29,7 +30,7 @@ module Elasticsearch
             params = Elasticsearch::API::Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
 
             body = nil
-            perform_request(method, path, params, body).body
+            perform_request(method, path, params, body, headers).body
           end
 
           # Register this action with its valid params when the module is loaded.

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/security/authenticate.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/security/authenticate.rb
@@ -7,12 +7,15 @@ module Elasticsearch
     module API
       module Security
         module Actions
-          # TODO: Description
-
+          # Enables authentication as a user and retrieve information about the authenticated user.
+          #
+          # @option arguments [Hash] :headers Custom HTTP headers
           #
           # @see https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-authenticate.html
           #
           def authenticate(arguments = {})
+            headers = arguments.delete(:headers) || {}
+
             arguments = arguments.clone
 
             method = Elasticsearch::API::HTTP_GET
@@ -20,7 +23,7 @@ module Elasticsearch
             params = {}
 
             body = nil
-            perform_request(method, path, params, body).body
+            perform_request(method, path, params, body, headers).body
           end
       end
     end

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/security/change_password.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/security/change_password.rb
@@ -7,19 +7,21 @@ module Elasticsearch
     module API
       module Security
         module Actions
-          # TODO: Description
-
+          # Changes the passwords of users in the native realm and built-in users.
           #
           # @option arguments [String] :username The username of the user to change the password for
           # @option arguments [String] :refresh If `true` (the default) then refresh the affected shards to make this operation visible to search, if `wait_for` then wait for a refresh to make this operation visible to search, if `false` then do nothing with refreshes.
           #   (options: true,false,wait_for)
 
+          # @option arguments [Hash] :headers Custom HTTP headers
           # @option arguments [Hash] :body the new password for the user (*Required*)
           #
           # @see https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-change-password.html
           #
           def change_password(arguments = {})
             raise ArgumentError, "Required argument 'body' missing" unless arguments[:body]
+
+            headers = arguments.delete(:headers) || {}
 
             arguments = arguments.clone
 
@@ -34,7 +36,7 @@ module Elasticsearch
             params = Elasticsearch::API::Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
 
             body = arguments[:body]
-            perform_request(method, path, params, body).body
+            perform_request(method, path, params, body, headers).body
           end
 
           # Register this action with its valid params when the module is loaded.

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/security/clear_cached_realms.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/security/clear_cached_realms.rb
@@ -7,17 +7,18 @@ module Elasticsearch
     module API
       module Security
         module Actions
-          # TODO: Description
-
+          # Evicts users from the user cache. Can completely clear the cache or evict specific users.
           #
           # @option arguments [List] :realms Comma-separated list of realms to clear
           # @option arguments [List] :usernames Comma-separated list of usernames to clear from the cache
-
+          # @option arguments [Hash] :headers Custom HTTP headers
           #
           # @see https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-clear-cache.html
           #
           def clear_cached_realms(arguments = {})
             raise ArgumentError, "Required argument 'realms' missing" unless arguments[:realms]
+
+            headers = arguments.delete(:headers) || {}
 
             arguments = arguments.clone
 
@@ -28,7 +29,7 @@ module Elasticsearch
             params = Elasticsearch::API::Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
 
             body = nil
-            perform_request(method, path, params, body).body
+            perform_request(method, path, params, body, headers).body
           end
 
           # Register this action with its valid params when the module is loaded.

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/security/clear_cached_roles.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/security/clear_cached_roles.rb
@@ -7,16 +7,17 @@ module Elasticsearch
     module API
       module Security
         module Actions
-          # TODO: Description
-
+          # Evicts roles from the native role cache.
           #
           # @option arguments [List] :name Role name
-
+          # @option arguments [Hash] :headers Custom HTTP headers
           #
           # @see https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-clear-role-cache.html
           #
           def clear_cached_roles(arguments = {})
             raise ArgumentError, "Required argument 'name' missing" unless arguments[:name]
+
+            headers = arguments.delete(:headers) || {}
 
             arguments = arguments.clone
 
@@ -27,7 +28,7 @@ module Elasticsearch
             params = {}
 
             body = nil
-            perform_request(method, path, params, body).body
+            perform_request(method, path, params, body, headers).body
           end
       end
     end

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/security/create_api_key.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/security/create_api_key.rb
@@ -7,18 +7,20 @@ module Elasticsearch
     module API
       module Security
         module Actions
-          # TODO: Description
-
+          # Creates an API key for access without requiring basic authentication.
           #
           # @option arguments [String] :refresh If `true` (the default) then refresh the affected shards to make this operation visible to search, if `wait_for` then wait for a refresh to make this operation visible to search, if `false` then do nothing with refreshes.
           #   (options: true,false,wait_for)
 
+          # @option arguments [Hash] :headers Custom HTTP headers
           # @option arguments [Hash] :body The api key request to create an API key (*Required*)
           #
           # @see https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-create-api-key.html
           #
           def create_api_key(arguments = {})
             raise ArgumentError, "Required argument 'body' missing" unless arguments[:body]
+
+            headers = arguments.delete(:headers) || {}
 
             arguments = arguments.clone
 
@@ -27,7 +29,7 @@ module Elasticsearch
             params = Elasticsearch::API::Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
 
             body = arguments[:body]
-            perform_request(method, path, params, body).body
+            perform_request(method, path, params, body, headers).body
           end
 
           # Register this action with its valid params when the module is loaded.

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/security/delete_privileges.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/security/delete_privileges.rb
@@ -7,20 +7,22 @@ module Elasticsearch
     module API
       module Security
         module Actions
-          # TODO: Description
-
+          # Removes application privileges.
           #
           # @option arguments [String] :application Application name
           # @option arguments [String] :name Privilege name
           # @option arguments [String] :refresh If `true` (the default) then refresh the affected shards to make this operation visible to search, if `wait_for` then wait for a refresh to make this operation visible to search, if `false` then do nothing with refreshes.
           #   (options: true,false,wait_for)
 
+          # @option arguments [Hash] :headers Custom HTTP headers
           #
           # @see https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-delete-privilege.html
           #
           def delete_privileges(arguments = {})
             raise ArgumentError, "Required argument 'application' missing" unless arguments[:application]
             raise ArgumentError, "Required argument 'name' missing" unless arguments[:name]
+
+            headers = arguments.delete(:headers) || {}
 
             arguments = arguments.clone
 
@@ -33,7 +35,7 @@ module Elasticsearch
             params = Elasticsearch::API::Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
 
             body = nil
-            perform_request(method, path, params, body).body
+            perform_request(method, path, params, body, headers).body
           end
 
           # Register this action with its valid params when the module is loaded.

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/security/delete_role.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/security/delete_role.rb
@@ -7,18 +7,20 @@ module Elasticsearch
     module API
       module Security
         module Actions
-          # TODO: Description
-
+          # Removes roles in the native realm.
           #
           # @option arguments [String] :name Role name
           # @option arguments [String] :refresh If `true` (the default) then refresh the affected shards to make this operation visible to search, if `wait_for` then wait for a refresh to make this operation visible to search, if `false` then do nothing with refreshes.
           #   (options: true,false,wait_for)
 
+          # @option arguments [Hash] :headers Custom HTTP headers
           #
           # @see https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-delete-role.html
           #
           def delete_role(arguments = {})
             raise ArgumentError, "Required argument 'name' missing" unless arguments[:name]
+
+            headers = arguments.delete(:headers) || {}
 
             arguments = arguments.clone
 
@@ -29,7 +31,7 @@ module Elasticsearch
             params = Elasticsearch::API::Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
 
             body = nil
-            perform_request(method, path, params, body).body
+            perform_request(method, path, params, body, headers).body
           end
 
           # Register this action with its valid params when the module is loaded.

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/security/delete_role_mapping.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/security/delete_role_mapping.rb
@@ -7,18 +7,20 @@ module Elasticsearch
     module API
       module Security
         module Actions
-          # TODO: Description
-
+          # Removes role mappings.
           #
           # @option arguments [String] :name Role-mapping name
           # @option arguments [String] :refresh If `true` (the default) then refresh the affected shards to make this operation visible to search, if `wait_for` then wait for a refresh to make this operation visible to search, if `false` then do nothing with refreshes.
           #   (options: true,false,wait_for)
 
+          # @option arguments [Hash] :headers Custom HTTP headers
           #
           # @see https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-delete-role-mapping.html
           #
           def delete_role_mapping(arguments = {})
             raise ArgumentError, "Required argument 'name' missing" unless arguments[:name]
+
+            headers = arguments.delete(:headers) || {}
 
             arguments = arguments.clone
 
@@ -29,7 +31,7 @@ module Elasticsearch
             params = Elasticsearch::API::Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
 
             body = nil
-            perform_request(method, path, params, body).body
+            perform_request(method, path, params, body, headers).body
           end
 
           # Register this action with its valid params when the module is loaded.

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/security/delete_user.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/security/delete_user.rb
@@ -7,18 +7,20 @@ module Elasticsearch
     module API
       module Security
         module Actions
-          # TODO: Description
-
+          # Deletes users from the native realm.
           #
           # @option arguments [String] :username username
           # @option arguments [String] :refresh If `true` (the default) then refresh the affected shards to make this operation visible to search, if `wait_for` then wait for a refresh to make this operation visible to search, if `false` then do nothing with refreshes.
           #   (options: true,false,wait_for)
 
+          # @option arguments [Hash] :headers Custom HTTP headers
           #
           # @see https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-delete-user.html
           #
           def delete_user(arguments = {})
             raise ArgumentError, "Required argument 'username' missing" unless arguments[:username]
+
+            headers = arguments.delete(:headers) || {}
 
             arguments = arguments.clone
 
@@ -29,7 +31,7 @@ module Elasticsearch
             params = Elasticsearch::API::Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
 
             body = nil
-            perform_request(method, path, params, body).body
+            perform_request(method, path, params, body, headers).body
           end
 
           # Register this action with its valid params when the module is loaded.

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/security/disable_user.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/security/disable_user.rb
@@ -7,18 +7,20 @@ module Elasticsearch
     module API
       module Security
         module Actions
-          # TODO: Description
-
+          # Disables users in the native realm.
           #
           # @option arguments [String] :username The username of the user to disable
           # @option arguments [String] :refresh If `true` (the default) then refresh the affected shards to make this operation visible to search, if `wait_for` then wait for a refresh to make this operation visible to search, if `false` then do nothing with refreshes.
           #   (options: true,false,wait_for)
 
+          # @option arguments [Hash] :headers Custom HTTP headers
           #
           # @see https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-disable-user.html
           #
           def disable_user(arguments = {})
             raise ArgumentError, "Required argument 'username' missing" unless arguments[:username]
+
+            headers = arguments.delete(:headers) || {}
 
             arguments = arguments.clone
 
@@ -29,7 +31,7 @@ module Elasticsearch
             params = Elasticsearch::API::Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
 
             body = nil
-            perform_request(method, path, params, body).body
+            perform_request(method, path, params, body, headers).body
           end
 
           # Register this action with its valid params when the module is loaded.

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/security/enable_user.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/security/enable_user.rb
@@ -7,18 +7,20 @@ module Elasticsearch
     module API
       module Security
         module Actions
-          # TODO: Description
-
+          # Enables users in the native realm.
           #
           # @option arguments [String] :username The username of the user to enable
           # @option arguments [String] :refresh If `true` (the default) then refresh the affected shards to make this operation visible to search, if `wait_for` then wait for a refresh to make this operation visible to search, if `false` then do nothing with refreshes.
           #   (options: true,false,wait_for)
 
+          # @option arguments [Hash] :headers Custom HTTP headers
           #
           # @see https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-enable-user.html
           #
           def enable_user(arguments = {})
             raise ArgumentError, "Required argument 'username' missing" unless arguments[:username]
+
+            headers = arguments.delete(:headers) || {}
 
             arguments = arguments.clone
 
@@ -29,7 +31,7 @@ module Elasticsearch
             params = Elasticsearch::API::Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
 
             body = nil
-            perform_request(method, path, params, body).body
+            perform_request(method, path, params, body, headers).body
           end
 
           # Register this action with its valid params when the module is loaded.

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/security/get_api_key.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/security/get_api_key.rb
@@ -7,19 +7,20 @@ module Elasticsearch
     module API
       module Security
         module Actions
-          # TODO: Description
-
+          # Retrieves information for one or more API keys.
           #
           # @option arguments [String] :id API key id of the API key to be retrieved
           # @option arguments [String] :name API key name of the API key to be retrieved
           # @option arguments [String] :username user name of the user who created this API key to be retrieved
           # @option arguments [String] :realm_name realm name of the user who created this API key to be retrieved
           # @option arguments [Boolean] :owner flag to query API keys owned by the currently authenticated user
-
+          # @option arguments [Hash] :headers Custom HTTP headers
           #
           # @see https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-get-api-key.html
           #
           def get_api_key(arguments = {})
+            headers = arguments.delete(:headers) || {}
+
             arguments = arguments.clone
 
             method = Elasticsearch::API::HTTP_GET
@@ -27,7 +28,7 @@ module Elasticsearch
             params = Elasticsearch::API::Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
 
             body = nil
-            perform_request(method, path, params, body).body
+            perform_request(method, path, params, body, headers).body
           end
 
           # Register this action with its valid params when the module is loaded.

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/security/get_builtin_privileges.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/security/get_builtin_privileges.rb
@@ -7,12 +7,15 @@ module Elasticsearch
     module API
       module Security
         module Actions
-          # TODO: Description
-
+          # Retrieves the list of cluster privileges and index privileges that are available in this version of Elasticsearch.
+          #
+          # @option arguments [Hash] :headers Custom HTTP headers
           #
           # @see https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-get-builtin-privileges.html
           #
           def get_builtin_privileges(arguments = {})
+            headers = arguments.delete(:headers) || {}
+
             arguments = arguments.clone
 
             method = Elasticsearch::API::HTTP_GET
@@ -20,7 +23,7 @@ module Elasticsearch
             params = {}
 
             body = nil
-            perform_request(method, path, params, body).body
+            perform_request(method, path, params, body, headers).body
           end
       end
     end

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/security/get_privileges.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/security/get_privileges.rb
@@ -7,16 +7,17 @@ module Elasticsearch
     module API
       module Security
         module Actions
-          # TODO: Description
-
+          # Retrieves application privileges.
           #
           # @option arguments [String] :application Application name
           # @option arguments [String] :name Privilege name
-
+          # @option arguments [Hash] :headers Custom HTTP headers
           #
           # @see https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-get-privileges.html
           #
           def get_privileges(arguments = {})
+            headers = arguments.delete(:headers) || {}
+
             arguments = arguments.clone
 
             _application = arguments.delete(:application)
@@ -30,11 +31,11 @@ module Elasticsearch
                        "_security/privilege/#{Elasticsearch::API::Utils.__listify(_application)}"
                      else
                        "_security/privilege"
-  end
+            end
             params = {}
 
             body = nil
-            perform_request(method, path, params, body).body
+            perform_request(method, path, params, body, headers).body
           end
       end
     end

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/security/get_role.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/security/get_role.rb
@@ -7,15 +7,16 @@ module Elasticsearch
     module API
       module Security
         module Actions
-          # TODO: Description
-
+          # Retrieves roles in the native realm.
           #
           # @option arguments [String] :name Role name
-
+          # @option arguments [Hash] :headers Custom HTTP headers
           #
           # @see https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-get-role.html
           #
           def get_role(arguments = {})
+            headers = arguments.delete(:headers) || {}
+
             arguments = arguments.clone
 
             _name = arguments.delete(:name)
@@ -25,14 +26,14 @@ module Elasticsearch
                        "_security/role/#{Elasticsearch::API::Utils.__listify(_name)}"
                      else
                        "_security/role"
-  end
+            end
             params = {}
 
             body = nil
             if Array(arguments[:ignore]).include?(404)
-              Elasticsearch::API::Utils.__rescue_from_not_found { perform_request(method, path, params, body).body }
+              Elasticsearch::API::Utils.__rescue_from_not_found { perform_request(method, path, params, body, headers).body }
             else
-              perform_request(method, path, params, body).body
+              perform_request(method, path, params, body, headers).body
             end
           end
       end

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/security/get_role_mapping.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/security/get_role_mapping.rb
@@ -7,15 +7,16 @@ module Elasticsearch
     module API
       module Security
         module Actions
-          # TODO: Description
-
+          # Retrieves role mappings.
           #
           # @option arguments [String] :name Role-Mapping name
-
+          # @option arguments [Hash] :headers Custom HTTP headers
           #
           # @see https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-get-role-mapping.html
           #
           def get_role_mapping(arguments = {})
+            headers = arguments.delete(:headers) || {}
+
             arguments = arguments.clone
 
             _name = arguments.delete(:name)
@@ -25,11 +26,11 @@ module Elasticsearch
                        "_security/role_mapping/#{Elasticsearch::API::Utils.__listify(_name)}"
                      else
                        "_security/role_mapping"
-  end
+            end
             params = {}
 
             body = nil
-            perform_request(method, path, params, body).body
+            perform_request(method, path, params, body, headers).body
           end
       end
     end

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/security/get_token.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/security/get_token.rb
@@ -7,14 +7,17 @@ module Elasticsearch
     module API
       module Security
         module Actions
-          # TODO: Description
-
+          # Creates a bearer token for access without requiring basic authentication.
+          #
+          # @option arguments [Hash] :headers Custom HTTP headers
           # @option arguments [Hash] :body The token request to get (*Required*)
           #
           # @see https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-get-token.html
           #
           def get_token(arguments = {})
             raise ArgumentError, "Required argument 'body' missing" unless arguments[:body]
+
+            headers = arguments.delete(:headers) || {}
 
             arguments = arguments.clone
 
@@ -23,7 +26,7 @@ module Elasticsearch
             params = {}
 
             body = arguments[:body]
-            perform_request(method, path, params, body).body
+            perform_request(method, path, params, body, headers).body
           end
       end
     end

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/security/get_user.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/security/get_user.rb
@@ -7,15 +7,16 @@ module Elasticsearch
     module API
       module Security
         module Actions
-          # TODO: Description
-
+          # Retrieves information about users in the native realm and built-in users.
           #
           # @option arguments [List] :username A comma-separated list of usernames
-
+          # @option arguments [Hash] :headers Custom HTTP headers
           #
           # @see https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-get-user.html
           #
           def get_user(arguments = {})
+            headers = arguments.delete(:headers) || {}
+
             arguments = arguments.clone
 
             _username = arguments.delete(:username)
@@ -25,14 +26,14 @@ module Elasticsearch
                        "_security/user/#{Elasticsearch::API::Utils.__listify(_username)}"
                      else
                        "_security/user"
-  end
+            end
             params = {}
 
             body = nil
             if Array(arguments[:ignore]).include?(404)
-              Elasticsearch::API::Utils.__rescue_from_not_found { perform_request(method, path, params, body).body }
+              Elasticsearch::API::Utils.__rescue_from_not_found { perform_request(method, path, params, body, headers).body }
             else
-              perform_request(method, path, params, body).body
+              perform_request(method, path, params, body, headers).body
             end
           end
       end

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/security/get_user_privileges.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/security/get_user_privileges.rb
@@ -7,12 +7,15 @@ module Elasticsearch
     module API
       module Security
         module Actions
-          # TODO: Description
-
+          # Retrieves application privileges.
+          #
+          # @option arguments [Hash] :headers Custom HTTP headers
           #
           # @see https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-get-privileges.html
           #
           def get_user_privileges(arguments = {})
+            headers = arguments.delete(:headers) || {}
+
             arguments = arguments.clone
 
             method = Elasticsearch::API::HTTP_GET
@@ -20,7 +23,7 @@ module Elasticsearch
             params = {}
 
             body = nil
-            perform_request(method, path, params, body).body
+            perform_request(method, path, params, body, headers).body
           end
       end
     end

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/security/has_privileges.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/security/has_privileges.rb
@@ -7,17 +7,18 @@ module Elasticsearch
     module API
       module Security
         module Actions
-          # TODO: Description
-
+          # Determines whether the specified user has a specified list of privileges.
           #
           # @option arguments [String] :user Username
-
+          # @option arguments [Hash] :headers Custom HTTP headers
           # @option arguments [Hash] :body The privileges to test (*Required*)
           #
           # @see https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-has-privileges.html
           #
           def has_privileges(arguments = {})
             raise ArgumentError, "Required argument 'body' missing" unless arguments[:body]
+
+            headers = arguments.delete(:headers) || {}
 
             arguments = arguments.clone
 
@@ -32,7 +33,7 @@ module Elasticsearch
             params = {}
 
             body = arguments[:body]
-            perform_request(method, path, params, body).body
+            perform_request(method, path, params, body, headers).body
           end
       end
     end

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/security/invalidate_api_key.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/security/invalidate_api_key.rb
@@ -7,14 +7,17 @@ module Elasticsearch
     module API
       module Security
         module Actions
-          # TODO: Description
-
+          # Invalidates one or more API keys.
+          #
+          # @option arguments [Hash] :headers Custom HTTP headers
           # @option arguments [Hash] :body The api key request to invalidate API key(s) (*Required*)
           #
           # @see https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-invalidate-api-key.html
           #
           def invalidate_api_key(arguments = {})
             raise ArgumentError, "Required argument 'body' missing" unless arguments[:body]
+
+            headers = arguments.delete(:headers) || {}
 
             arguments = arguments.clone
 
@@ -23,7 +26,7 @@ module Elasticsearch
             params = {}
 
             body = arguments[:body]
-            perform_request(method, path, params, body).body
+            perform_request(method, path, params, body, headers).body
           end
       end
     end

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/security/invalidate_token.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/security/invalidate_token.rb
@@ -7,14 +7,17 @@ module Elasticsearch
     module API
       module Security
         module Actions
-          # TODO: Description
-
+          # Invalidates one or more access tokens or refresh tokens.
+          #
+          # @option arguments [Hash] :headers Custom HTTP headers
           # @option arguments [Hash] :body The token to invalidate (*Required*)
           #
           # @see https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-invalidate-token.html
           #
           def invalidate_token(arguments = {})
             raise ArgumentError, "Required argument 'body' missing" unless arguments[:body]
+
+            headers = arguments.delete(:headers) || {}
 
             arguments = arguments.clone
 
@@ -23,7 +26,7 @@ module Elasticsearch
             params = {}
 
             body = arguments[:body]
-            perform_request(method, path, params, body).body
+            perform_request(method, path, params, body, headers).body
           end
       end
     end

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/security/put_privileges.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/security/put_privileges.rb
@@ -7,18 +7,20 @@ module Elasticsearch
     module API
       module Security
         module Actions
-          # TODO: Description
-
+          # Adds or updates application privileges.
           #
           # @option arguments [String] :refresh If `true` (the default) then refresh the affected shards to make this operation visible to search, if `wait_for` then wait for a refresh to make this operation visible to search, if `false` then do nothing with refreshes.
           #   (options: true,false,wait_for)
 
+          # @option arguments [Hash] :headers Custom HTTP headers
           # @option arguments [Hash] :body The privilege(s) to add (*Required*)
           #
           # @see https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-put-privileges.html
           #
           def put_privileges(arguments = {})
             raise ArgumentError, "Required argument 'body' missing" unless arguments[:body]
+
+            headers = arguments.delete(:headers) || {}
 
             arguments = arguments.clone
 
@@ -27,7 +29,7 @@ module Elasticsearch
             params = Elasticsearch::API::Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
 
             body = arguments[:body]
-            perform_request(method, path, params, body).body
+            perform_request(method, path, params, body, headers).body
           end
 
           # Register this action with its valid params when the module is loaded.

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/security/put_role.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/security/put_role.rb
@@ -7,13 +7,13 @@ module Elasticsearch
     module API
       module Security
         module Actions
-          # TODO: Description
-
+          # Adds and updates roles in the native realm.
           #
           # @option arguments [String] :name Role name
           # @option arguments [String] :refresh If `true` (the default) then refresh the affected shards to make this operation visible to search, if `wait_for` then wait for a refresh to make this operation visible to search, if `false` then do nothing with refreshes.
           #   (options: true,false,wait_for)
 
+          # @option arguments [Hash] :headers Custom HTTP headers
           # @option arguments [Hash] :body The role to add (*Required*)
           #
           # @see https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-put-role.html
@@ -21,6 +21,8 @@ module Elasticsearch
           def put_role(arguments = {})
             raise ArgumentError, "Required argument 'body' missing" unless arguments[:body]
             raise ArgumentError, "Required argument 'name' missing" unless arguments[:name]
+
+            headers = arguments.delete(:headers) || {}
 
             arguments = arguments.clone
 
@@ -31,7 +33,7 @@ module Elasticsearch
             params = Elasticsearch::API::Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
 
             body = arguments[:body]
-            perform_request(method, path, params, body).body
+            perform_request(method, path, params, body, headers).body
           end
 
           # Register this action with its valid params when the module is loaded.

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/security/put_role_mapping.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/security/put_role_mapping.rb
@@ -7,13 +7,13 @@ module Elasticsearch
     module API
       module Security
         module Actions
-          # TODO: Description
-
+          # Creates and updates role mappings.
           #
           # @option arguments [String] :name Role-mapping name
           # @option arguments [String] :refresh If `true` (the default) then refresh the affected shards to make this operation visible to search, if `wait_for` then wait for a refresh to make this operation visible to search, if `false` then do nothing with refreshes.
           #   (options: true,false,wait_for)
 
+          # @option arguments [Hash] :headers Custom HTTP headers
           # @option arguments [Hash] :body The role mapping to add (*Required*)
           #
           # @see https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-put-role-mapping.html
@@ -21,6 +21,8 @@ module Elasticsearch
           def put_role_mapping(arguments = {})
             raise ArgumentError, "Required argument 'body' missing" unless arguments[:body]
             raise ArgumentError, "Required argument 'name' missing" unless arguments[:name]
+
+            headers = arguments.delete(:headers) || {}
 
             arguments = arguments.clone
 
@@ -31,7 +33,7 @@ module Elasticsearch
             params = Elasticsearch::API::Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
 
             body = arguments[:body]
-            perform_request(method, path, params, body).body
+            perform_request(method, path, params, body, headers).body
           end
 
           # Register this action with its valid params when the module is loaded.

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/security/put_user.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/security/put_user.rb
@@ -7,13 +7,13 @@ module Elasticsearch
     module API
       module Security
         module Actions
-          # TODO: Description
-
+          # Adds and updates users in the native realm. These users are commonly referred to as native users.
           #
           # @option arguments [String] :username The username of the User
           # @option arguments [String] :refresh If `true` (the default) then refresh the affected shards to make this operation visible to search, if `wait_for` then wait for a refresh to make this operation visible to search, if `false` then do nothing with refreshes.
           #   (options: true,false,wait_for)
 
+          # @option arguments [Hash] :headers Custom HTTP headers
           # @option arguments [Hash] :body The user to add (*Required*)
           #
           # @see https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-put-user.html
@@ -21,6 +21,8 @@ module Elasticsearch
           def put_user(arguments = {})
             raise ArgumentError, "Required argument 'body' missing" unless arguments[:body]
             raise ArgumentError, "Required argument 'username' missing" unless arguments[:username]
+
+            headers = arguments.delete(:headers) || {}
 
             arguments = arguments.clone
 
@@ -31,7 +33,7 @@ module Elasticsearch
             params = Elasticsearch::API::Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
 
             body = arguments[:body]
-            perform_request(method, path, params, body).body
+            perform_request(method, path, params, body, headers).body
           end
 
           # Register this action with its valid params when the module is loaded.

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/sql/clear_cursor.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/sql/clear_cursor.rb
@@ -9,13 +9,15 @@ module Elasticsearch
         module Actions
           # Clears the SQL cursor
           #
-
+          # @option arguments [Hash] :headers Custom HTTP headers
           # @option arguments [Hash] :body Specify the cursor value in the `cursor` element to clean the cursor. (*Required*)
           #
           # @see https://www.elastic.co/guide/en/elasticsearch/reference/current/sql-pagination.html
           #
           def clear_cursor(arguments = {})
             raise ArgumentError, "Required argument 'body' missing" unless arguments[:body]
+
+            headers = arguments.delete(:headers) || {}
 
             arguments = arguments.clone
 
@@ -24,7 +26,7 @@ module Elasticsearch
             params = {}
 
             body = arguments[:body]
-            perform_request(method, path, params, body).body
+            perform_request(method, path, params, body, headers).body
           end
       end
     end

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/sql/query.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/sql/query.rb
@@ -7,16 +7,18 @@ module Elasticsearch
     module API
       module SQL
         module Actions
-          # Executes an SQL request
+          # Executes a SQL request
           #
           # @option arguments [String] :format a short version of the Accept header, e.g. json, yaml
-
+          # @option arguments [Hash] :headers Custom HTTP headers
           # @option arguments [Hash] :body Use the `query` element to start a query. Use the `cursor` element to continue a query. (*Required*)
           #
           # @see https://www.elastic.co/guide/en/elasticsearch/reference/current/sql-rest-overview.html
           #
           def query(arguments = {})
             raise ArgumentError, "Required argument 'body' missing" unless arguments[:body]
+
+            headers = arguments.delete(:headers) || {}
 
             arguments = arguments.clone
 
@@ -25,7 +27,7 @@ module Elasticsearch
             params = Elasticsearch::API::Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
 
             body = arguments[:body]
-            perform_request(method, path, params, body).body
+            perform_request(method, path, params, body, headers).body
           end
 
           # Register this action with its valid params when the module is loaded.

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/sql/translate.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/sql/translate.rb
@@ -9,13 +9,15 @@ module Elasticsearch
         module Actions
           # Translates SQL into Elasticsearch queries
           #
-
+          # @option arguments [Hash] :headers Custom HTTP headers
           # @option arguments [Hash] :body Specify the query in the `query` element. (*Required*)
           #
           # @see https://www.elastic.co/guide/en/elasticsearch/reference/current/sql-translate.html
           #
           def translate(arguments = {})
             raise ArgumentError, "Required argument 'body' missing" unless arguments[:body]
+
+            headers = arguments.delete(:headers) || {}
 
             arguments = arguments.clone
 
@@ -24,7 +26,7 @@ module Elasticsearch
             params = {}
 
             body = arguments[:body]
-            perform_request(method, path, params, body).body
+            perform_request(method, path, params, body, headers).body
           end
       end
     end

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/ssl/certificates.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/ssl/certificates.rb
@@ -7,12 +7,15 @@ module Elasticsearch
     module API
       module SSL
         module Actions
-          # TODO: Description
-
+          # Retrieves information about the X.509 certificates used to encrypt communications in the cluster.
+          #
+          # @option arguments [Hash] :headers Custom HTTP headers
           #
           # @see https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-ssl.html
           #
           def certificates(arguments = {})
+            headers = arguments.delete(:headers) || {}
+
             arguments = arguments.clone
 
             method = Elasticsearch::API::HTTP_GET
@@ -20,7 +23,7 @@ module Elasticsearch
             params = {}
 
             body = nil
-            perform_request(method, path, params, body).body
+            perform_request(method, path, params, body, headers).body
           end
       end
     end

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/transform/delete_transform.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/transform/delete_transform.rb
@@ -7,17 +7,18 @@ module Elasticsearch
     module API
       module Transform
         module Actions
-          # TODO: Description
-
+          # Deletes an existing transform.
           #
           # @option arguments [String] :transform_id The id of the transform to delete
           # @option arguments [Boolean] :force When `true`, the transform is deleted regardless of its current state. The default value is `false`, meaning that the transform must be `stopped` before it can be deleted.
-
+          # @option arguments [Hash] :headers Custom HTTP headers
           #
           # @see https://www.elastic.co/guide/en/elasticsearch/reference/current/delete-transform.html
           #
           def delete_transform(arguments = {})
             raise ArgumentError, "Required argument 'transform_id' missing" unless arguments[:transform_id]
+
+            headers = arguments.delete(:headers) || {}
 
             arguments = arguments.clone
 
@@ -28,7 +29,7 @@ module Elasticsearch
             params = Elasticsearch::API::Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
 
             body = nil
-            perform_request(method, path, params, body).body
+            perform_request(method, path, params, body, headers).body
           end
 
           # Register this action with its valid params when the module is loaded.

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/transform/get_transform.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/transform/get_transform.rb
@@ -7,18 +7,19 @@ module Elasticsearch
     module API
       module Transform
         module Actions
-          # TODO: Description
-
+          # Retrieves configuration information for transforms.
           #
           # @option arguments [String] :transform_id The id or comma delimited list of id expressions of the transforms to get, '_all' or '*' implies get all transforms
           # @option arguments [Int] :from skips a number of transform configs, defaults to 0
           # @option arguments [Int] :size specifies a max number of transforms to get, defaults to 100
           # @option arguments [Boolean] :allow_no_match Whether to ignore if a wildcard expression matches no transforms. (This includes `_all` string or when no transforms have been specified)
-
+          # @option arguments [Hash] :headers Custom HTTP headers
           #
           # @see https://www.elastic.co/guide/en/elasticsearch/reference/current/get-transform.html
           #
           def get_transform(arguments = {})
+            headers = arguments.delete(:headers) || {}
+
             arguments = arguments.clone
 
             _transform_id = arguments.delete(:transform_id)
@@ -28,11 +29,11 @@ module Elasticsearch
                        "_transform/#{Elasticsearch::API::Utils.__listify(_transform_id)}"
                      else
                        "_transform"
-  end
+            end
             params = Elasticsearch::API::Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
 
             body = nil
-            perform_request(method, path, params, body).body
+            perform_request(method, path, params, body, headers).body
           end
 
           # Register this action with its valid params when the module is loaded.

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/transform/get_transform_stats.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/transform/get_transform_stats.rb
@@ -7,19 +7,20 @@ module Elasticsearch
     module API
       module Transform
         module Actions
-          # TODO: Description
-
+          # Retrieves usage information for transforms.
           #
           # @option arguments [String] :transform_id The id of the transform for which to get stats. '_all' or '*' implies all transforms
           # @option arguments [Number] :from skips a number of transform stats, defaults to 0
           # @option arguments [Number] :size specifies a max number of transform stats to get, defaults to 100
           # @option arguments [Boolean] :allow_no_match Whether to ignore if a wildcard expression matches no transforms. (This includes `_all` string or when no transforms have been specified)
-
+          # @option arguments [Hash] :headers Custom HTTP headers
           #
           # @see https://www.elastic.co/guide/en/elasticsearch/reference/current/get-transform-stats.html
           #
           def get_transform_stats(arguments = {})
             raise ArgumentError, "Required argument 'transform_id' missing" unless arguments[:transform_id]
+
+            headers = arguments.delete(:headers) || {}
 
             arguments = arguments.clone
 
@@ -30,7 +31,7 @@ module Elasticsearch
             params = Elasticsearch::API::Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
 
             body = nil
-            perform_request(method, path, params, body).body
+            perform_request(method, path, params, body, headers).body
           end
 
           # Register this action with its valid params when the module is loaded.

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/transform/preview_transform.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/transform/preview_transform.rb
@@ -7,14 +7,17 @@ module Elasticsearch
     module API
       module Transform
         module Actions
-          # TODO: Description
-
+          # Previews a transform.
+          #
+          # @option arguments [Hash] :headers Custom HTTP headers
           # @option arguments [Hash] :body The definition for the transform to preview (*Required*)
           #
           # @see https://www.elastic.co/guide/en/elasticsearch/reference/current/preview-transform.html
           #
           def preview_transform(arguments = {})
             raise ArgumentError, "Required argument 'body' missing" unless arguments[:body]
+
+            headers = arguments.delete(:headers) || {}
 
             arguments = arguments.clone
 
@@ -23,7 +26,7 @@ module Elasticsearch
             params = {}
 
             body = arguments[:body]
-            perform_request(method, path, params, body).body
+            perform_request(method, path, params, body, headers).body
           end
       end
     end

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/transform/put_transform.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/transform/put_transform.rb
@@ -7,12 +7,11 @@ module Elasticsearch
     module API
       module Transform
         module Actions
-          # TODO: Description
-
+          # Instantiates a transform.
           #
           # @option arguments [String] :transform_id The id of the new transform.
           # @option arguments [Boolean] :defer_validation If validations should be deferred until transform starts, defaults to false.
-
+          # @option arguments [Hash] :headers Custom HTTP headers
           # @option arguments [Hash] :body The transform definition (*Required*)
           #
           # @see https://www.elastic.co/guide/en/elasticsearch/reference/current/put-transform.html
@@ -20,6 +19,8 @@ module Elasticsearch
           def put_transform(arguments = {})
             raise ArgumentError, "Required argument 'body' missing" unless arguments[:body]
             raise ArgumentError, "Required argument 'transform_id' missing" unless arguments[:transform_id]
+
+            headers = arguments.delete(:headers) || {}
 
             arguments = arguments.clone
 
@@ -30,7 +31,7 @@ module Elasticsearch
             params = Elasticsearch::API::Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
 
             body = arguments[:body]
-            perform_request(method, path, params, body).body
+            perform_request(method, path, params, body, headers).body
           end
 
           # Register this action with its valid params when the module is loaded.

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/transform/start_transform.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/transform/start_transform.rb
@@ -7,17 +7,18 @@ module Elasticsearch
     module API
       module Transform
         module Actions
-          # TODO: Description
-
+          # Starts one or more transforms.
           #
           # @option arguments [String] :transform_id The id of the transform to start
           # @option arguments [Time] :timeout Controls the time to wait for the transform to start
-
+          # @option arguments [Hash] :headers Custom HTTP headers
           #
           # @see https://www.elastic.co/guide/en/elasticsearch/reference/current/start-transform.html
           #
           def start_transform(arguments = {})
             raise ArgumentError, "Required argument 'transform_id' missing" unless arguments[:transform_id]
+
+            headers = arguments.delete(:headers) || {}
 
             arguments = arguments.clone
 
@@ -28,7 +29,7 @@ module Elasticsearch
             params = Elasticsearch::API::Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
 
             body = nil
-            perform_request(method, path, params, body).body
+            perform_request(method, path, params, body, headers).body
           end
 
           # Register this action with its valid params when the module is loaded.

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/transform/stop_transform.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/transform/stop_transform.rb
@@ -7,8 +7,7 @@ module Elasticsearch
     module API
       module Transform
         module Actions
-          # TODO: Description
-
+          # Stops one or more transforms.
           #
           # @option arguments [String] :transform_id The id of the transform to stop
           # @option arguments [Boolean] :force Whether to force stop a failed transform or not. Default to false
@@ -16,12 +15,14 @@ module Elasticsearch
           # @option arguments [Time] :timeout Controls the time to wait until the transform has stopped. Default to 30 seconds
           # @option arguments [Boolean] :allow_no_match Whether to ignore if a wildcard expression matches no transforms. (This includes `_all` string or when no transforms have been specified)
           # @option arguments [Boolean] :wait_for_checkpoint Whether to wait for the transform to reach a checkpoint before stopping. Default to false
-
+          # @option arguments [Hash] :headers Custom HTTP headers
           #
           # @see https://www.elastic.co/guide/en/elasticsearch/reference/current/stop-transform.html
           #
           def stop_transform(arguments = {})
             raise ArgumentError, "Required argument 'transform_id' missing" unless arguments[:transform_id]
+
+            headers = arguments.delete(:headers) || {}
 
             arguments = arguments.clone
 
@@ -32,7 +33,7 @@ module Elasticsearch
             params = Elasticsearch::API::Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
 
             body = nil
-            perform_request(method, path, params, body).body
+            perform_request(method, path, params, body, headers).body
           end
 
           # Register this action with its valid params when the module is loaded.

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/transform/update_transform.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/transform/update_transform.rb
@@ -7,12 +7,11 @@ module Elasticsearch
     module API
       module Transform
         module Actions
-          # TODO: Description
-
+          # Updates certain properties of a transform.
           #
           # @option arguments [String] :transform_id The id of the transform.  (*Required*)
           # @option arguments [Boolean] :defer_validation If validations should be deferred until transform starts, defaults to false.
-
+          # @option arguments [Hash] :headers Custom HTTP headers
           # @option arguments [Hash] :body The update transform definition (*Required*)
           #
           # @see https://www.elastic.co/guide/en/elasticsearch/reference/current/update-transform.html
@@ -20,6 +19,8 @@ module Elasticsearch
           def update_transform(arguments = {})
             raise ArgumentError, "Required argument 'body' missing" unless arguments[:body]
             raise ArgumentError, "Required argument 'transform_id' missing" unless arguments[:transform_id]
+
+            headers = arguments.delete(:headers) || {}
 
             arguments = arguments.clone
 
@@ -30,7 +31,7 @@ module Elasticsearch
             params = Elasticsearch::API::Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
 
             body = arguments[:body]
-            perform_request(method, path, params, body).body
+            perform_request(method, path, params, body, headers).body
           end
 
           # Register this action with its valid params when the module is loaded.

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/usage.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/usage.rb
@@ -6,15 +6,16 @@ module Elasticsearch
   module XPack
     module API
       module Actions
-        # TODO: Description
-
+        # Retrieves usage information about the installed X-Pack features.
         #
         # @option arguments [Time] :master_timeout Specify timeout for watch write operation
-
+        # @option arguments [Hash] :headers Custom HTTP headers
         #
         # @see https://www.elastic.co/guide/en/elasticsearch/reference/current/usage-api.html
         #
         def usage(arguments = {})
+          headers = arguments.delete(:headers) || {}
+
           arguments = arguments.clone
 
           method = Elasticsearch::API::HTTP_GET
@@ -22,7 +23,7 @@ module Elasticsearch
           params = Elasticsearch::API::Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
 
           body = nil
-          perform_request(method, path, params, body).body
+          perform_request(method, path, params, body, headers).body
         end
 
         # Register this action with its valid params when the module is loaded.

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/watcher/ack_watch.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/watcher/ack_watch.rb
@@ -7,17 +7,18 @@ module Elasticsearch
     module API
       module Watcher
         module Actions
-          # TODO: Description
-
+          # Acknowledges a watch, manually throttling the execution of the watch's actions.
           #
           # @option arguments [String] :watch_id Watch ID
           # @option arguments [List] :action_id A comma-separated list of the action ids to be acked
-
+          # @option arguments [Hash] :headers Custom HTTP headers
           #
           # @see https://www.elastic.co/guide/en/elasticsearch/reference/current/watcher-api-ack-watch.html
           #
           def ack_watch(arguments = {})
             raise ArgumentError, "Required argument 'watch_id' missing" unless arguments[:watch_id]
+
+            headers = arguments.delete(:headers) || {}
 
             arguments = arguments.clone
 
@@ -34,7 +35,7 @@ module Elasticsearch
             params = {}
 
             body = nil
-            perform_request(method, path, params, body).body
+            perform_request(method, path, params, body, headers).body
           end
       end
     end

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/watcher/activate_watch.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/watcher/activate_watch.rb
@@ -7,16 +7,17 @@ module Elasticsearch
     module API
       module Watcher
         module Actions
-          # TODO: Description
-
+          # Activates a currently inactive watch.
           #
           # @option arguments [String] :watch_id Watch ID
-
+          # @option arguments [Hash] :headers Custom HTTP headers
           #
           # @see https://www.elastic.co/guide/en/elasticsearch/reference/current/watcher-api-activate-watch.html
           #
           def activate_watch(arguments = {})
             raise ArgumentError, "Required argument 'watch_id' missing" unless arguments[:watch_id]
+
+            headers = arguments.delete(:headers) || {}
 
             arguments = arguments.clone
 
@@ -27,7 +28,7 @@ module Elasticsearch
             params = {}
 
             body = nil
-            perform_request(method, path, params, body).body
+            perform_request(method, path, params, body, headers).body
           end
       end
     end

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/watcher/deactivate_watch.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/watcher/deactivate_watch.rb
@@ -7,16 +7,17 @@ module Elasticsearch
     module API
       module Watcher
         module Actions
-          # TODO: Description
-
+          # Deactivates a currently active watch.
           #
           # @option arguments [String] :watch_id Watch ID
-
+          # @option arguments [Hash] :headers Custom HTTP headers
           #
           # @see https://www.elastic.co/guide/en/elasticsearch/reference/current/watcher-api-deactivate-watch.html
           #
           def deactivate_watch(arguments = {})
             raise ArgumentError, "Required argument 'watch_id' missing" unless arguments[:watch_id]
+
+            headers = arguments.delete(:headers) || {}
 
             arguments = arguments.clone
 
@@ -27,7 +28,7 @@ module Elasticsearch
             params = {}
 
             body = nil
-            perform_request(method, path, params, body).body
+            perform_request(method, path, params, body, headers).body
           end
       end
     end

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/watcher/delete_watch.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/watcher/delete_watch.rb
@@ -7,16 +7,17 @@ module Elasticsearch
     module API
       module Watcher
         module Actions
-          # TODO: Description
-
+          # Removes a watch from Watcher.
           #
           # @option arguments [String] :id Watch ID
-
+          # @option arguments [Hash] :headers Custom HTTP headers
           #
           # @see https://www.elastic.co/guide/en/elasticsearch/reference/current/watcher-api-delete-watch.html
           #
           def delete_watch(arguments = {})
             raise ArgumentError, "Required argument 'id' missing" unless arguments[:id]
+
+            headers = arguments.delete(:headers) || {}
 
             arguments = arguments.clone
 
@@ -28,9 +29,9 @@ module Elasticsearch
 
             body = nil
             if Array(arguments[:ignore]).include?(404)
-              Elasticsearch::API::Utils.__rescue_from_not_found { perform_request(method, path, params, body).body }
+              Elasticsearch::API::Utils.__rescue_from_not_found { perform_request(method, path, params, body, headers).body }
             else
-              perform_request(method, path, params, body).body
+              perform_request(method, path, params, body, headers).body
             end
           end
       end

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/watcher/execute_watch.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/watcher/execute_watch.rb
@@ -7,17 +7,18 @@ module Elasticsearch
     module API
       module Watcher
         module Actions
-          # TODO: Description
-
+          # Forces the execution of a stored watch.
           #
           # @option arguments [String] :id Watch ID
           # @option arguments [Boolean] :debug indicates whether the watch should execute in debug mode
-
+          # @option arguments [Hash] :headers Custom HTTP headers
           # @option arguments [Hash] :body Execution control
           #
           # @see https://www.elastic.co/guide/en/elasticsearch/reference/current/watcher-api-execute-watch.html
           #
           def execute_watch(arguments = {})
+            headers = arguments.delete(:headers) || {}
+
             arguments = arguments.clone
 
             _id = arguments.delete(:id)
@@ -27,11 +28,11 @@ module Elasticsearch
                        "_watcher/watch/#{Elasticsearch::API::Utils.__listify(_id)}/_execute"
                      else
                        "_watcher/watch/_execute"
-  end
+            end
             params = Elasticsearch::API::Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
 
             body = arguments[:body]
-            perform_request(method, path, params, body).body
+            perform_request(method, path, params, body, headers).body
           end
 
           # Register this action with its valid params when the module is loaded.

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/watcher/get_watch.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/watcher/get_watch.rb
@@ -7,16 +7,17 @@ module Elasticsearch
     module API
       module Watcher
         module Actions
-          # TODO: Description
-
+          # Retrieves a watch by its ID.
           #
           # @option arguments [String] :id Watch ID
-
+          # @option arguments [Hash] :headers Custom HTTP headers
           #
           # @see https://www.elastic.co/guide/en/elasticsearch/reference/current/watcher-api-get-watch.html
           #
           def get_watch(arguments = {})
             raise ArgumentError, "Required argument 'id' missing" unless arguments[:id]
+
+            headers = arguments.delete(:headers) || {}
 
             arguments = arguments.clone
 
@@ -27,7 +28,7 @@ module Elasticsearch
             params = {}
 
             body = nil
-            perform_request(method, path, params, body).body
+            perform_request(method, path, params, body, headers).body
           end
       end
     end

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/watcher/put_watch.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/watcher/put_watch.rb
@@ -7,21 +7,22 @@ module Elasticsearch
     module API
       module Watcher
         module Actions
-          # TODO: Description
-
+          # Creates a new watch, or updates an existing one.
           #
           # @option arguments [String] :id Watch ID
           # @option arguments [Boolean] :active Specify whether the watch is in/active by default
           # @option arguments [Number] :version Explicit version number for concurrency control
           # @option arguments [Number] :if_seq_no only update the watch if the last operation that has changed the watch has the specified sequence number
           # @option arguments [Number] :if_primary_term only update the watch if the last operation that has changed the watch has the specified primary term
-
+          # @option arguments [Hash] :headers Custom HTTP headers
           # @option arguments [Hash] :body The watch
           #
           # @see https://www.elastic.co/guide/en/elasticsearch/reference/current/watcher-api-put-watch.html
           #
           def put_watch(arguments = {})
             raise ArgumentError, "Required argument 'id' missing" unless arguments[:id]
+
+            headers = arguments.delete(:headers) || {}
 
             arguments = arguments.clone
 
@@ -32,7 +33,7 @@ module Elasticsearch
             params = Elasticsearch::API::Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
 
             body = arguments[:body]
-            perform_request(method, path, params, body).body
+            perform_request(method, path, params, body, headers).body
           end
 
           # Register this action with its valid params when the module is loaded.

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/watcher/start.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/watcher/start.rb
@@ -7,12 +7,15 @@ module Elasticsearch
     module API
       module Watcher
         module Actions
-          # TODO: Description
-
+          # Starts Watcher if it is not already running.
+          #
+          # @option arguments [Hash] :headers Custom HTTP headers
           #
           # @see https://www.elastic.co/guide/en/elasticsearch/reference/current/watcher-api-start.html
           #
           def start(arguments = {})
+            headers = arguments.delete(:headers) || {}
+
             arguments = arguments.clone
 
             method = Elasticsearch::API::HTTP_POST
@@ -20,7 +23,7 @@ module Elasticsearch
             params = {}
 
             body = nil
-            perform_request(method, path, params, body).body
+            perform_request(method, path, params, body, headers).body
           end
       end
     end

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/watcher/stats.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/watcher/stats.rb
@@ -7,8 +7,7 @@ module Elasticsearch
     module API
       module Watcher
         module Actions
-          # TODO: Description
-
+          # Retrieves the current Watcher metrics.
           #
           # @option arguments [List] :metric Controls what additional stat metrics should be include in the response
           #   (options: _all,queued_watches,current_watches,pending_watches)
@@ -17,11 +16,13 @@ module Elasticsearch
           #   (options: _all,queued_watches,current_watches,pending_watches)
 
           # @option arguments [Boolean] :emit_stacktraces Emits stack traces of currently running watches
-
+          # @option arguments [Hash] :headers Custom HTTP headers
           #
           # @see https://www.elastic.co/guide/en/elasticsearch/reference/current/watcher-api-stats.html
           #
           def stats(arguments = {})
+            headers = arguments.delete(:headers) || {}
+
             arguments = arguments.clone
 
             _metric = arguments.delete(:metric)
@@ -31,11 +32,11 @@ module Elasticsearch
                        "_watcher/stats/#{Elasticsearch::API::Utils.__listify(_metric)}"
                      else
                        "_watcher/stats"
-  end
+            end
             params = Elasticsearch::API::Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
 
             body = nil
-            perform_request(method, path, params, body).body
+            perform_request(method, path, params, body, headers).body
           end
 
           # Register this action with its valid params when the module is loaded.

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/watcher/stop.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/watcher/stop.rb
@@ -7,12 +7,15 @@ module Elasticsearch
     module API
       module Watcher
         module Actions
-          # TODO: Description
-
+          # Stops Watcher if it is running.
+          #
+          # @option arguments [Hash] :headers Custom HTTP headers
           #
           # @see https://www.elastic.co/guide/en/elasticsearch/reference/current/watcher-api-stop.html
           #
           def stop(arguments = {})
+            headers = arguments.delete(:headers) || {}
+
             arguments = arguments.clone
 
             method = Elasticsearch::API::HTTP_POST
@@ -20,7 +23,7 @@ module Elasticsearch
             params = {}
 
             body = nil
-            perform_request(method, path, params, body).body
+            perform_request(method, path, params, body, headers).body
           end
       end
     end

--- a/elasticsearch-xpack/spec/xpack/data_frame/update_data_frame_transform_spec.rb
+++ b/elasticsearch-xpack/spec/xpack/data_frame/update_data_frame_transform_spec.rb
@@ -12,7 +12,7 @@ describe 'client#update_data_frame_transform' do
         '_data_frame/transforms/foo/_update',
         params,
         {},
-        nil
+        {}
     ]
   end
 

--- a/elasticsearch-xpack/spec/xpack/machine_learning/set_upgrade_mode_spec.rb
+++ b/elasticsearch-xpack/spec/xpack/machine_learning/set_upgrade_mode_spec.rb
@@ -12,7 +12,7 @@ describe 'client#set_upgrade_mode' do
        '_ml/set_upgrade_mode',
        {},
        nil,
-       nil
+       {}
     ]
   end
 
@@ -28,7 +28,7 @@ describe 'client#set_upgrade_mode' do
         '_ml/set_upgrade_mode',
         { enabled: true, timeout: '10m' },
         nil,
-        nil
+        {}
       ]
     end
 

--- a/elasticsearch-xpack/spec/xpack/security/create_api_key_spec.rb
+++ b/elasticsearch-xpack/spec/xpack/security/create_api_key_spec.rb
@@ -12,7 +12,7 @@ describe 'client#security#create_api_key' do
         '_security/api_key',
         {},
         body,
-        nil
+        {}
     ]
   end
 
@@ -55,7 +55,7 @@ describe 'client#security#create_api_key' do
           '_security/api_key',
           { refresh: 'wait_for' },
           body,
-          nil
+          {}
       ]
     end
 

--- a/elasticsearch-xpack/spec/xpack/security/get_api_key_spec.rb
+++ b/elasticsearch-xpack/spec/xpack/security/get_api_key_spec.rb
@@ -12,7 +12,7 @@ describe 'client#security#get_api_key' do
         '_security/api_key',
         params,
         nil,
-        nil
+        {}
     ]
   end
 

--- a/elasticsearch-xpack/spec/xpack/security/get_builtin_privileges_spec.rb
+++ b/elasticsearch-xpack/spec/xpack/security/get_builtin_privileges_spec.rb
@@ -12,7 +12,7 @@ describe 'client#security#get_builtin_privileges' do
         '_security/privilege/_builtin',
         {},
         nil,
-        nil
+        {}
     ]
   end
 

--- a/elasticsearch-xpack/spec/xpack/security/invalidate_api_key_spec.rb
+++ b/elasticsearch-xpack/spec/xpack/security/invalidate_api_key_spec.rb
@@ -12,7 +12,7 @@ describe 'client#security#create_api_key' do
         '_security/api_key',
         {},
         body,
-        nil
+        {}
     ]
   end
 


### PR DESCRIPTION
Currently you can set a custom HTTP header on the client's initializer:
```ruby
client = Elasticsearch::Client.new(
  transport_options: {
    headers:
      {user_agent: "My Ruby App"}
  }
)
```

This Pull Request adds the ability of setting a custom HTTP header for each API endpoint request. E.g.:
```ruby
client = Elasticsearch::Client.new
client.search(index: 'myindex', q: 'title:test', headers: {'user-agent': 'My Ruby App'})
```

Code has been regenerated for OSS and X-Pack to include the headers parameter when performing a client request, specs updated and a unit test was added.