### PR TITLE
Backport #696 to 6.x

### DIFF
--- a/elasticsearch-transport/lib/elasticsearch/transport/transport/http/curb.rb
+++ b/elasticsearch-transport/lib/elasticsearch/transport/transport/http/curb.rb
@@ -15,8 +15,8 @@ module Elasticsearch
           # @return [Response]
           # @see    Transport::Base#perform_request
           #
-          def perform_request(method, path, params={}, body=nil, headers=nil)
-            super do |connection,url|
+          def perform_request(method, path, params={}, body=nil, headers=nil, opts={})
+            super do |connection, url|
               connection.connection.url = url
 
               case method

--- a/elasticsearch-transport/lib/elasticsearch/transport/transport/http/faraday.rb
+++ b/elasticsearch-transport/lib/elasticsearch/transport/transport/http/faraday.rb
@@ -16,7 +16,7 @@ module Elasticsearch
           # @return [Response]
           # @see    Transport::Base#perform_request
           #
-          def perform_request(method, path, params={}, body=nil, headers=nil)
+          def perform_request(method, path, params={}, body=nil, headers=nil, opts={})
             super do |connection, url|
               headers = headers || connection.connection.headers
 

--- a/elasticsearch-transport/lib/elasticsearch/transport/transport/http/manticore.rb
+++ b/elasticsearch-transport/lib/elasticsearch/transport/transport/http/manticore.rb
@@ -63,7 +63,7 @@ module Elasticsearch
           # @return [Response]
           # @see    Transport::Base#perform_request
           #
-          def perform_request(method, path, params={}, body=nil, headers=nil)
+          def perform_request(method, path, params={}, body=nil, headers=nil, opts={})
             super do |connection, url|
               params[:body] = __convert_to_json(body) if body
               params[:headers] = headers if headers

--- a/elasticsearch-transport/lib/elasticsearch/transport/transport/sniffer.rb
+++ b/elasticsearch-transport/lib/elasticsearch/transport/transport/sniffer.rb
@@ -28,7 +28,8 @@ module Elasticsearch
         #
         def hosts
           Timeout::timeout(timeout, SnifferTimeoutError) do
-            nodes = transport.perform_request('GET', '_nodes/http').body
+            nodes = transport.perform_request('GET', '_nodes/http', {}, nil, nil,
+                                              reload_on_failure: false).body
 
             hosts = nodes['nodes'].map do |id,info|
               if info[PROTOCOL]

--- a/elasticsearch-transport/spec/elasticsearch/transport/base_spec.rb
+++ b/elasticsearch-transport/spec/elasticsearch/transport/base_spec.rb
@@ -82,7 +82,7 @@ describe Elasticsearch::Transport::Transport::Base do
 
     let(:arguments) do
       {
-          hosts: ['http://unavabilable:9200', 'http://unavabilable:9201'],
+          hosts: ['http://unavailable:9200', 'http://unavailable:9201'],
           reload_on_failure: true,
           sniffer_timeout: 5
       }
@@ -103,7 +103,7 @@ describe Elasticsearch::Transport::Transport::Base do
 
     let(:arguments) do
       {
-          hosts: ['http://unavabilable:9200', 'http://unavabilable:9201'],
+          hosts: ['http://unavailable:9200', 'http://unavailable:9201'],
           retry_on_failure: 2
       }
     end
@@ -143,7 +143,7 @@ describe Elasticsearch::Transport::Transport::Base do
 
     let(:arguments) do
       {
-          hosts: ['http://unavabilable:9200', 'http://unavabilable:9201'],
+          hosts: ['http://unavailable:9200', 'http://unavailable:9201'],
           retry_on_failure: true
       }
     end
@@ -183,7 +183,7 @@ describe Elasticsearch::Transport::Transport::Base do
 
     let(:arguments) do
       {
-          hosts: ['http://unavabilable:9200', 'http://unavabilable:9201'],
+          hosts: ['http://unavailable:9200', 'http://unavailable:9201'],
           retry_on_failure: false
       }
     end
@@ -223,7 +223,7 @@ describe Elasticsearch::Transport::Transport::Base do
 
     let(:arguments) do
       {
-          hosts: ['http://unavabilable:9200', 'http://unavabilable:9201'],
+          hosts: ['http://unavailable:9200', 'http://unavailable:9201'],
       }
     end
 

--- a/elasticsearch-transport/spec/elasticsearch/transport/base_spec.rb
+++ b/elasticsearch-transport/spec/elasticsearch/transport/base_spec.rb
@@ -73,4 +73,184 @@ describe Elasticsearch::Transport::Transport::Base do
       it_behaves_like 'a redacted string'
     end
   end
+
+  context 'when reload_on_failure is true and and hosts are unreachable' do
+
+    let(:client) do
+      Elasticsearch::Transport::Client.new(arguments)
+    end
+
+    let(:arguments) do
+      {
+          hosts: ['http://unavabilable:9200', 'http://unavabilable:9201'],
+          reload_on_failure: true,
+          sniffer_timeout: 5
+      }
+    end
+
+    it 'raises an exception' do
+      expect {
+        client.info
+      }.to raise_exception(Faraday::ConnectionFailed)
+    end
+  end
+
+  context 'when the client has `retry_on_failure` set to an integer' do
+
+    let(:client) do
+      Elasticsearch::Transport::Client.new(arguments)
+    end
+
+    let(:arguments) do
+      {
+          hosts: ['http://unavabilable:9200', 'http://unavabilable:9201'],
+          retry_on_failure: 2
+      }
+    end
+
+    context 'when `perform_request` is called without a `retry_on_failure` option value' do
+
+      before do
+        expect(client.transport).to receive(:get_connection).exactly(3).times.and_call_original
+      end
+
+      it 'uses the client `retry_on_failure` value' do
+        expect {
+          client.transport.perform_request('GET', '/info')
+        }.to raise_exception(Faraday::ConnectionFailed)
+      end
+    end
+
+    context 'when `perform_request` is called with a `retry_on_failure` option value' do
+
+      before do
+        expect(client.transport).to receive(:get_connection).exactly(6).times.and_call_original
+      end
+
+      it 'uses the option `retry_on_failure` value' do
+        expect {
+          client.transport.perform_request('GET', '/info', {}, nil, nil, retry_on_failure: 5)
+        }.to raise_exception(Faraday::ConnectionFailed)
+      end
+    end
+  end
+
+  context 'when the client has `retry_on_failure` set to true' do
+
+    let(:client) do
+      Elasticsearch::Transport::Client.new(arguments)
+    end
+
+    let(:arguments) do
+      {
+          hosts: ['http://unavabilable:9200', 'http://unavabilable:9201'],
+          retry_on_failure: true
+      }
+    end
+
+    context 'when `perform_request` is called without a `retry_on_failure` option value' do
+
+      before do
+        expect(client.transport).to receive(:get_connection).exactly(4).times.and_call_original
+      end
+
+      it 'uses the default `MAX_RETRIES` value' do
+        expect {
+          client.transport.perform_request('GET', '/info')
+        }.to raise_exception(Faraday::ConnectionFailed)
+      end
+    end
+
+    context 'when `perform_request` is called with a `retry_on_failure` option value' do
+
+      before do
+        expect(client.transport).to receive(:get_connection).exactly(6).times.and_call_original
+      end
+
+      it 'uses the option `retry_on_failure` value' do
+        expect {
+          client.transport.perform_request('GET', '/info', {}, nil, nil, retry_on_failure: 5)
+        }.to raise_exception(Faraday::ConnectionFailed)
+      end
+    end
+  end
+
+  context 'when the client has `retry_on_failure` set to false' do
+
+    let(:client) do
+      Elasticsearch::Transport::Client.new(arguments)
+    end
+
+    let(:arguments) do
+      {
+          hosts: ['http://unavabilable:9200', 'http://unavabilable:9201'],
+          retry_on_failure: false
+      }
+    end
+
+    context 'when `perform_request` is called without a `retry_on_failure` option value' do
+
+      before do
+        expect(client.transport).to receive(:get_connection).once.and_call_original
+      end
+
+      it 'does not retry' do
+        expect {
+          client.transport.perform_request('GET', '/info')
+        }.to raise_exception(Faraday::ConnectionFailed)
+      end
+    end
+
+    context 'when `perform_request` is called with a `retry_on_failure` option value' do
+
+      before do
+        expect(client.transport).to receive(:get_connection).exactly(6).times.and_call_original
+      end
+
+      it 'uses the option `retry_on_failure` value' do
+        expect {
+          client.transport.perform_request('GET', '/info', {}, nil, nil, retry_on_failure: 5)
+        }.to raise_exception(Faraday::ConnectionFailed)
+      end
+    end
+  end
+
+  context 'when the client has no `retry_on_failure` set' do
+
+    let(:client) do
+      Elasticsearch::Transport::Client.new(arguments)
+    end
+
+    let(:arguments) do
+      {
+          hosts: ['http://unavabilable:9200', 'http://unavabilable:9201'],
+      }
+    end
+
+    context 'when `perform_request` is called without a `retry_on_failure` option value' do
+
+      before do
+        expect(client.transport).to receive(:get_connection).exactly(1).times.and_call_original
+      end
+
+      it 'does not retry' do
+        expect {
+          client.transport.perform_request('GET', '/info')
+        }.to raise_exception(Faraday::ConnectionFailed)
+      end
+    end
+
+    context 'when `perform_request` is called with a `retry_on_failure` option value' do
+
+      before do
+        expect(client.transport).to receive(:get_connection).exactly(6).times.and_call_original
+      end
+
+      it 'uses the option `retry_on_failure` value' do
+        expect {
+          client.transport.perform_request('GET', '/info', {}, nil, nil, retry_on_failure: 5)
+        }.to raise_exception(Faraday::ConnectionFailed)
+      end
+    end
+  end
 end


### PR DESCRIPTION
Backport https://github.com/elastic/elasticsearch-ruby/pull/696 to 6.x branch

The issue https://github.com/elastic/elasticsearch-ruby/issues/695 is happening with 6.x versions of the gem (https://github.com/elastic/elasticsearch-ruby/issues/177). The fix is relatively easy to backport.

