### PR TITLE
Fix master build

### DIFF
--- a/elasticsearch-api/lib/elasticsearch/api/actions/bulk.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/bulk.rb
@@ -20,6 +20,7 @@ module Elasticsearch
       # @option arguments [List] :_source_excludes Default list of fields to exclude from the returned _source field, can be overridden on each sub-request
       # @option arguments [List] :_source_includes Default list of fields to extract and return from the _source field, can be overridden on each sub-request
       # @option arguments [String] :pipeline The pipeline id to preprocess incoming documents with
+      # @option arguments [Boolean] :prefer_v2_templates favor V2 templates instead of V1 templates during automatic index creation
       # @option arguments [Hash] :headers Custom HTTP headers
       # @option arguments [Hash] :body The operation definition and data (action-data pairs), separated by newlines (*Required*)
       #
@@ -69,7 +70,8 @@ module Elasticsearch
         :_source,
         :_source_excludes,
         :_source_includes,
-        :pipeline
+        :pipeline,
+        :prefer_v2_templates
       ].freeze)
     end
     end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/create.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/create.rb
@@ -23,6 +23,7 @@ module Elasticsearch
       #   (options: internal,external,external_gte)
 
       # @option arguments [String] :pipeline The pipeline id to preprocess incoming documents with
+      # @option arguments [Boolean] :prefer_v2_templates favor V2 templates instead of V1 templates during automatic index creation
       # @option arguments [Hash] :headers Custom HTTP headers
       # @option arguments [Hash] :body The document (*Required*)
       #

--- a/elasticsearch-api/lib/elasticsearch/api/actions/index.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/index.rb
@@ -25,6 +25,7 @@ module Elasticsearch
       # @option arguments [Number] :if_seq_no only perform the index operation if the last operation that has changed the document has the specified sequence number
       # @option arguments [Number] :if_primary_term only perform the index operation if the last operation that has changed the document has the specified primary term
       # @option arguments [String] :pipeline The pipeline id to preprocess incoming documents with
+      # @option arguments [Boolean] :prefer_v2_templates favor V2 templates instead of V1 templates during automatic index creation
       # @option arguments [Hash] :headers Custom HTTP headers
       # @option arguments [Hash] :body The document (*Required*)
       #
@@ -67,7 +68,8 @@ module Elasticsearch
         :version_type,
         :if_seq_no,
         :if_primary_term,
-        :pipeline
+        :pipeline,
+        :prefer_v2_templates
       ].freeze)
     end
     end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/create.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/create.rb
@@ -12,6 +12,7 @@ module Elasticsearch
         # @option arguments [String] :wait_for_active_shards Set the number of active shards to wait for before the operation returns.
         # @option arguments [Time] :timeout Explicit operation timeout
         # @option arguments [Time] :master_timeout Specify timeout for connection to master
+        # @option arguments [Boolean] :prefer_v2_templates favor V2 templates instead of V1 templates during index creation
         # @option arguments [Hash] :headers Custom HTTP headers
         # @option arguments [Hash] :body The configuration for the index (`settings` and `mappings`)
         #
@@ -40,7 +41,8 @@ module Elasticsearch
         ParamsRegistry.register(:create, [
           :wait_for_active_shards,
           :timeout,
-          :master_timeout
+          :master_timeout,
+          :prefer_v2_templates
         ].freeze)
 end
       end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/rollover.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/rollover.rb
@@ -15,6 +15,7 @@ module Elasticsearch
         # @option arguments [Boolean] :dry_run If set to true the rollover action will only be validated but not actually performed even if a condition matches. The default is false
         # @option arguments [Time] :master_timeout Specify timeout for connection to master
         # @option arguments [String] :wait_for_active_shards Set the number of active shards to wait for on the newly created rollover index before the operation returns.
+        # @option arguments [Boolean] :prefer_v2_templates favor V2 templates instead of V1 templates during automatic index creation
         # @option arguments [Hash] :headers Custom HTTP headers
         # @option arguments [Hash] :body The conditions that needs to be met for executing rollover
         #
@@ -50,7 +51,8 @@ module Elasticsearch
           :timeout,
           :dry_run,
           :master_timeout,
-          :wait_for_active_shards
+          :wait_for_active_shards,
+          :prefer_v2_templates
         ].freeze)
 end
       end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/stats.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/stats.rb
@@ -9,7 +9,7 @@ module Elasticsearch
         # Provides statistics on operations happening in an index.
         #
         # @option arguments [List] :metric Limit the information returned the specific metrics.
-        #   (options: _all,completion,docs,fielddata,query_cache,flush,get,indexing,merge,request_cache,refresh,search,segments,store,warmer,suggest)
+        #   (options: _all,completion,docs,fielddata,query_cache,flush,get,indexing,merge,request_cache,refresh,search,segments,store,warmer,suggest,bulk)
 
         # @option arguments [List] :index A comma-separated list of index names; use `_all` or empty string to perform the operation on all indices
         # @option arguments [List] :completion_fields A comma-separated list of fields for `fielddata` and `suggest` index metric (supports wildcards)
@@ -77,6 +77,7 @@ module Elasticsearch
           :store,
           :warmer,
           :suggest,
+          :bulk,
           :metric
         ].freeze)
 end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/nodes/hot_threads.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/nodes/hot_threads.rb
@@ -19,11 +19,6 @@ module Elasticsearch
         # @option arguments [Time] :timeout Explicit operation timeout
         # @option arguments [Hash] :headers Custom HTTP headers
         #
-        # *Deprecation notice*:
-        # The hot accepts /_cluster/nodes as prefix for backwards compatibility reasons
-        # Deprecated since version 7.0.0
-        #
-        #
         # @see https://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-nodes-hot-threads.html
         #
         def hot_threads(arguments = {})
@@ -35,9 +30,9 @@ module Elasticsearch
 
           method = Elasticsearch::API::HTTP_GET
           path   = if _node_id
-                     "_cluster/nodes/#{Utils.__listify(_node_id)}/hot_threads"
+                     "_nodes/#{Utils.__listify(_node_id)}/hot_threads"
                    else
-                     "_cluster/nodes/hot_threads"
+                     "_nodes/hot_threads"
       end
           params = Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/nodes/reload_secure_settings.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/nodes/reload_secure_settings.rb
@@ -11,6 +11,7 @@ module Elasticsearch
         # @option arguments [List] :node_id A comma-separated list of node IDs to span the reload/reinit call. Should stay empty because reloading usually involves all cluster nodes.
         # @option arguments [Time] :timeout Explicit operation timeout
         # @option arguments [Hash] :headers Custom HTTP headers
+        # @option arguments [Hash] :body An object containing the password for the elasticsearch keystore
         #
         # @see https://www.elastic.co/guide/en/elasticsearch/reference/master/secure-settings.html#reloadable-secure-settings
         #
@@ -29,7 +30,7 @@ module Elasticsearch
       end
           params = Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
 
-          body = nil
+          body = arguments[:body]
           perform_request(method, path, params, body, headers).body
         end
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/nodes/stats.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/nodes/stats.rb
@@ -13,7 +13,7 @@ module Elasticsearch
         #   (options: _all,breaker,fs,http,indices,jvm,os,process,thread_pool,transport,discovery)
 
         # @option arguments [List] :index_metric Limit the information returned for `indices` metric to the specific index metrics. Isn't used if `indices` (or `all`) metric isn't specified.
-        #   (options: _all,completion,docs,fielddata,query_cache,flush,get,indexing,merge,request_cache,refresh,search,segments,store,warmer,suggest)
+        #   (options: _all,completion,docs,fielddata,query_cache,flush,get,indexing,merge,request_cache,refresh,search,segments,store,warmer,suggest,bulk)
 
         # @option arguments [List] :completion_fields A comma-separated list of fields for `fielddata` and `suggest` index metric (supports wildcards)
         # @option arguments [List] :fielddata_fields A comma-separated list of fields for `fielddata` index metric (supports wildcards)

--- a/elasticsearch-api/lib/elasticsearch/api/actions/update.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/update.rb
@@ -23,6 +23,7 @@ module Elasticsearch
       # @option arguments [Time] :timeout Explicit operation timeout
       # @option arguments [Number] :if_seq_no only perform the update operation if the last operation that has changed the document has the specified sequence number
       # @option arguments [Number] :if_primary_term only perform the update operation if the last operation that has changed the document has the specified primary term
+      # @option arguments [Boolean] :prefer_v2_templates favor V2 templates instead of V1 templates during automatic index creation
       # @option arguments [Hash] :headers Custom HTTP headers
       # @option arguments [Hash] :body The request definition requires either `script` or partial `doc` (*Required*)
       #
@@ -78,7 +79,8 @@ module Elasticsearch
         :routing,
         :timeout,
         :if_seq_no,
-        :if_primary_term
+        :if_primary_term,
+        :prefer_v2_templates
       ].freeze)
     end
     end

--- a/elasticsearch-api/spec/elasticsearch/api/actions/nodes/hot_threads_spec.rb
+++ b/elasticsearch-api/spec/elasticsearch/api/actions/nodes/hot_threads_spec.rb
@@ -17,7 +17,7 @@ describe 'client.nodes#hot_threads' do
   end
 
   let(:url) do
-    '_cluster/nodes/hot_threads'
+    '_nodes/hot_threads'
   end
 
   it 'performs the request' do
@@ -27,7 +27,7 @@ describe 'client.nodes#hot_threads' do
   context 'when the node id is specified' do
 
     let(:url) do
-      '_cluster/nodes/foo/hot_threads'
+      '_nodes/foo/hot_threads'
     end
 
     it 'performs the request' do
@@ -38,7 +38,7 @@ describe 'client.nodes#hot_threads' do
   context 'when the path must be URL-escaped' do
 
     let(:url) do
-      '_cluster/nodes/foo%5Ebar/hot_threads'
+      '_nodes/foo%5Ebar/hot_threads'
     end
 
     it 'performs the request' do

--- a/elasticsearch-api/spec/elasticsearch/api/actions/nodes/reload_secure_settings_spec.rb
+++ b/elasticsearch-api/spec/elasticsearch/api/actions/nodes/reload_secure_settings_spec.rb
@@ -11,18 +11,14 @@ describe 'client#reload_secure_settings' do
         'POST',
         url,
         params,
-        nil,
+        body,
         {}
     ]
   end
 
-  let(:params) do
-    {}
-  end
-
-  let(:url) do
-    '_nodes/reload_secure_settings'
-  end
+  let(:params) { {} }
+  let(:url) { '_nodes/reload_secure_settings' }
+  let(:body) { nil }
 
   it 'performs the request' do
     expect(client_double.nodes.reload_secure_settings()).to eq({})
@@ -40,6 +36,7 @@ describe 'client#reload_secure_settings' do
   end
 
   context 'when more than one node id is specified as a string' do
+    let(:body){ { foo: 'bar' } }
 
     let(:url) do
       '_nodes/foo,bar/reload_secure_settings'
@@ -51,7 +48,7 @@ describe 'client#reload_secure_settings' do
   end
 
   context 'when more than one node id is specified as a list' do
-
+    let(:body){ { foo: 'bar' } }
     let(:url) do
       '_nodes/foo,bar/reload_secure_settings'
     end

--- a/elasticsearch-api/spec/rest_yaml_tests_helper.rb
+++ b/elasticsearch-api/spec/rest_yaml_tests_helper.rb
@@ -85,6 +85,14 @@ skipped_tests << { file: 'indices.upgrade/20_deprecated.yml',
 skipped_tests << { file: 'indices.put_mapping/10_basic.yml',
                    description: 'Put mappings with explicit _doc type bwc' }
 
+# Responses are there but not equal (eg.: yellow status)
+skipped_tests << { file: 'cluster.health/10_basic.yml',
+                   description: 'cluster health with closed index (pre 7.2.0)' }
+
+# Regular expression not catching exact match:
+skipped_tests << { file: 'cat.indices/10_basic.yml',
+                   description: 'Test cat indices output for closed index (pre 7.2.0)' }
+
 SKIPPED_TESTS = skipped_tests
 
 # The directory of rest api YAML files.

--- a/elasticsearch-api/spec/rest_yaml_tests_helper.rb
+++ b/elasticsearch-api/spec/rest_yaml_tests_helper.rb
@@ -76,6 +76,14 @@ skipped_tests << { file:        'cat.templates/10_basic.yml',
 # node_selector is not supported yet
 skipped_tests << { file: 'cat.aliases/10_basic.yml',
                    description: '*' }
+skipped_tests << { file: 'indices.upgrade/20_deprecated.yml',
+                   description: 'Basic test for upgrade indices < 8.0.0' }
+skipped_tests << { file: 'indices.upgrade/20_deprecated.yml',
+                   description: 'Upgrade indices ignore unavailable < 8.0.0' }
+skipped_tests << { file: 'indices.upgrade/20_deprecated.yml',
+                   description: 'Upgrade indices allow no indices < 8.0.0' }
+skipped_tests << { file: 'indices.put_mapping/10_basic.yml',
+                   description: 'Put mappings with explicit _doc type bwc' }
 
 SKIPPED_TESTS = skipped_tests
 

--- a/elasticsearch-xpack/spec/rest_yaml_tests_helper.rb
+++ b/elasticsearch-xpack/spec/rest_yaml_tests_helper.rb
@@ -155,6 +155,22 @@ SKIPPED_TESTS << { file: 'api_key/10_basic.yml',
 SKIPPED_TESTS << { file: 'ml/explain_data_frame_analytics.yml',
                    description: 'Test non-empty data frame given body'}
 
+# Transform tests have issues with text fields/keywords in setup
+SKIPPED_TESTS << { file: 'transform/transforms_stats.yml',
+                   description: '*'}
+SKIPPED_TESTS << { file: 'transform/transforms_update.yml',
+                   description: '*'}
+SKIPPED_TESTS << { file: 'transform/transforms_cat_apis.yml',
+                   description: '*'}
+SKIPPED_TESTS << { file: 'transform/transforms_crud.yml',
+                   description: '*'}
+SKIPPED_TESTS << { file: 'transform/transforms_stats_continuous.yml',
+                   description: '*'}
+SKIPPED_TESTS << { file: 'transform/transforms_force_delete.yml',
+                   description: '*'}
+SKIPPED_TESTS << { file: 'transform/transforms_start_stop.yml',
+                   description: '*'}
+
 # The directory of rest api YAML files.
 REST_API_YAML_FILES = SINGLE_TEST || Dir.glob("#{YAML_FILES_DIRECTORY}/**/*.yml")
 

--- a/elasticsearch-xpack/spec/rest_yaml_tests_helper.rb
+++ b/elasticsearch-xpack/spec/rest_yaml_tests_helper.rb
@@ -175,6 +175,10 @@ SKIPPED_TESTS << { file: 'transform/transforms_start_stop.yml',
 SKIPPED_TESTS << { file: 'analytics/usage.yml',
                    description: 'Usage stats on analytics indices' }
 
+# TODO https://github.com/elastic/elasticsearch-ruby/issues/853
+SKIPPED_TESTS << { file: 'ml/jobs_crud.yml',
+                   description: 'Test put job with model_memory_limit as string and lazy open' }
+
 # The directory of rest api YAML files.
 REST_API_YAML_FILES = SINGLE_TEST || Dir.glob("#{YAML_FILES_DIRECTORY}/**/*.yml")
 

--- a/elasticsearch-xpack/spec/rest_yaml_tests_helper.rb
+++ b/elasticsearch-xpack/spec/rest_yaml_tests_helper.rb
@@ -157,19 +157,23 @@ SKIPPED_TESTS << { file: 'ml/explain_data_frame_analytics.yml',
 
 # Transform tests have issues with text fields/keywords in setup
 SKIPPED_TESTS << { file: 'transform/transforms_stats.yml',
-                   description: '*'}
+                   description: '*' }
 SKIPPED_TESTS << { file: 'transform/transforms_update.yml',
-                   description: '*'}
+                   description: '*' }
 SKIPPED_TESTS << { file: 'transform/transforms_cat_apis.yml',
-                   description: '*'}
+                   description: '*' }
 SKIPPED_TESTS << { file: 'transform/transforms_crud.yml',
-                   description: '*'}
+                   description: '*' }
 SKIPPED_TESTS << { file: 'transform/transforms_stats_continuous.yml',
-                   description: '*'}
+                   description: '*' }
 SKIPPED_TESTS << { file: 'transform/transforms_force_delete.yml',
-                   description: '*'}
+                   description: '*' }
 SKIPPED_TESTS << { file: 'transform/transforms_start_stop.yml',
-                   description: '*'}
+                   description: '*' }
+
+# TODO https://github.com/elastic/elasticsearch-ruby/issues/852
+SKIPPED_TESTS << { file: 'analytics/usage.yml',
+                   description: 'Usage stats on analytics indices' }
 
 # The directory of rest api YAML files.
 REST_API_YAML_FILES = SINGLE_TEST || Dir.glob("#{YAML_FILES_DIRECTORY}/**/*.yml")

--- a/elasticsearch-xpack/spec/xpack/data_frame/update_data_frame_transform_spec.rb
+++ b/elasticsearch-xpack/spec/xpack/data_frame/update_data_frame_transform_spec.rb
@@ -4,12 +4,12 @@
 
 require 'spec_helper'
 
-describe 'client#update_data_frame_transform' do
+describe 'client#update_transform' do
 
   let(:expected_args) do
     [
         'POST',
-        '_data_frame/transforms/foo/_update',
+        '_transform/foo/_update',
         params,
         {},
         {}
@@ -21,19 +21,20 @@ describe 'client#update_data_frame_transform' do
   end
 
   it 'performs the request' do
-    expect(client_double.data_frame.
-        update_data_frame_transform(transform_id: 'foo', body: {})).to eq({})
+    expect(
+      client_double.transform
+        .update_transform(transform_id: 'foo', body: {})
+    ).to eq({})
   end
 
   context 'when body is not provided' do
-
     let(:client) do
       Class.new { include Elasticsearch::XPack::API }.new
     end
 
     it 'raises an exception' do
       expect {
-        client.data_frame.update_data_frame_transform(transform_id: 'foo')
+        client.transform.update_transform(transform_id: 'foo')
       }.to raise_exception(ArgumentError)
     end
   end
@@ -46,7 +47,7 @@ describe 'client#update_data_frame_transform' do
 
     it 'raises an exception' do
       expect {
-        client.data_frame.update_data_frame_transform(body: {})
+        client.transform.update_transform(body: {})
       }.to raise_exception(ArgumentError)
     end
   end
@@ -58,8 +59,10 @@ describe 'client#update_data_frame_transform' do
     end
 
     it 'performs the request' do
-      expect(client_double.data_frame.
-          update_data_frame_transform(transform_id: 'foo', body: {}, defer_validation: true)).to eq({})
+      expect(
+        client_double.transform
+          .update_transform(transform_id: 'foo', body: {}, defer_validation: true)
+      ).to eq({})
     end
   end
 end


### PR DESCRIPTION
Steps so far:

- Ignore tests with `node_selector`, the client does not implemented this yet.
- Cherry pick https://github.com/elastic/elasticsearch-ruby/commit/0aaf09741b42d37e078d2058c0f78798a308564d from `7.x`, cluster health tests are ignored due to:
  - Responses are there but not equal (eg.: yellow status).
  - Regular expression not catching exact match, but the returned result is expected.
- Skip `transforms` tests in X-Pack. There's an error with text fields/keywords in setup.
- Skip `analytics/usage.yml`. Related to #852