### PR TITLE
[CI] Fix JUnit test paths

### DIFF
--- a/.ci/jobs/defaults.yml
+++ b/.ci/jobs/defaults.yml
@@ -68,5 +68,5 @@
       - email:
           recipients: infra-root+build@elastic.co
       - junit:
-          results: "*-junit.xml"
+          results: "elasticsearch-api/tmp/*-junit.xml"
           allow-empty-results: true

--- a/.ci/run-repository.sh
+++ b/.ci/run-repository.sh
@@ -54,6 +54,8 @@ docker build \
 
 echo -e "\033[1m>>>>> Run [elastic/elasticsearch-ruby container] >>>>>>>>>>>>>>>>>>>>>>>>>>>>>\033[0m"
 
+mkdir -p elasticsearch-api/tmp
+
 repo=`pwd`
 
 # run the client tests
@@ -63,7 +65,6 @@ if [[ $TEST_SUITE != "xpack" ]]; then
            --env "TEST_ES_SERVER=${ELASTICSEARCH_URL}" \
            --env "TEST_SUITE=${TEST_SUITE}" \
            --volume $repo:/usr/src/app \
-           --volume=/tmp:/tmp \
            --name elasticsearch-ruby \
            --rm \
            elastic/elasticsearch-ruby \

--- a/elasticsearch-api/spec/spec_helper.rb
+++ b/elasticsearch-api/spec/spec_helper.rb
@@ -50,7 +50,7 @@ end
 RSpec.configure do |config|
   config.include(HelperModule)
   config.add_formatter('documentation')
-  config.add_formatter('RspecJunitFormatter', '/tmp/elasticsearch-api-junit.xml')
+  config.add_formatter('RspecJunitFormatter', 'tmp/elasticsearch-api-junit.xml')
   config.color_mode = :on
 end
 


### PR DESCRIPTION
The tests run from the project's root directory, but I'm generating the JUnit output for oss tests which run in `elasticsearch-api`. So I'm creating a `tmp` folder (since it's already in `.gitignore`) and publishing the xml file there.

Running this locally, `elasticsearch-api-junit.xml` is generated in `elasticsearch-api/tmp`.