### PR TITLE
[CI] Add JUnit to X-Pack

### DIFF
--- a/elasticsearch-xpack/Gemfile
+++ b/elasticsearch-xpack/Gemfile
@@ -9,6 +9,7 @@ gemspec
 
 group :development do
   gem 'rspec'
+  gem 'rspec_junit_formatter'
   if defined?(JRUBY_VERSION)
     gem 'pry-nav'
   else

--- a/elasticsearch-xpack/spec/spec_helper.rb
+++ b/elasticsearch-xpack/spec/spec_helper.rb
@@ -34,4 +34,5 @@ RSpec.configure do |config|
   config.include(HelperModule)
   config.formatter = 'documentation'
   config.color = true
+  config.add_formatter('RspecJunitFormatter', '../elasticsearch-api/tmp/elasticsearch-xpack-junit.xml')
 end


### PR DESCRIPTION
The Ruby client is currently printing JUnit output for OSS only. It creates the following file:
`elasticsearch-api/tmp/elasticsearch-api-junit.xml`
Which is being picked up by Jenkins.

With this PR, I'm creating a file when running the x-pack tests in:
`elasticsearch-api/tmp/elasticsearch-xpack-junit.xml`

My `jobs/defaults.yml` file is looking for any xml files ending in `*-junit.xml`:
```yml
- junit:
  results: "elasticsearch-api/tmp/*-junit.xml"
```
@Mpdreamz and @karmi, do you know if this would work?