### PR TITLE
fix-finding-query-methods

### DIFF
--- a/elasticsearch-dsl/lib/elasticsearch/dsl/search/query.rb
+++ b/elasticsearch-dsl/lib/elasticsearch/dsl/search/query.rb
@@ -38,8 +38,8 @@ module Elasticsearch
         #
         def method_missing(name, *args, &block)
           klass = Utils.__camelize(name)
-          if Queries.const_defined? klass
-            @value = Queries.const_get(klass).new *args, &block
+          if Queries.const_defined? klass, false
+            @value = Queries.const_get(klass, false).new *args, &block
           elsif @block
            @block.binding.eval('self').send(name, *args, &block)
           else


### PR DESCRIPTION
`Queirs.const_defined? 'Foo'` find not only `Queries::Foo` but also `::Foo`,
so if program has `Foo` class, this `method_missing` call `Foo.new` instead of call `foo` method.

```ruby

class Foo
   include ActiveModel::Model
   include ActiveModel::Attributes

   attribute :name, :string
end

class SearchForm
  include ActiveModel::Model
  include ActiveModel::Attributes
  include Elasticsearch::DSL

  attribute :foo

  def condition
    search do
      query do
        bool { must { term name: foo.name } }
      end
    end
  end
end

p SearchForm.new(foo: Foo.new(name: 'hello')).condition.to_hash
```

- expect: `{:query=>{:bool=>{:must=>[{:term=>{:name=>"name"}}]}}}`
- actual: `{:query=>{:bool=>{:must=>[{:term=>{:name=>nil}}]}}}`