### PR TITLE
Surface deprecation headers from Elasticsearch [master]

### DIFF
--- a/elasticsearch-transport/lib/elasticsearch/transport/transport/base.rb
+++ b/elasticsearch-transport/lib/elasticsearch/transport/transport/base.rb
@@ -355,6 +355,8 @@ module Elasticsearch
 
           __trace  method, path, params, connection.connection.headers, body, url, response, nil, 'N/A', duration if tracer
 
+          warnings(response.headers['warning']) if response.headers&.[]('warning')
+
           Response.new response.status, json || response.body, response.headers
         ensure
           @last_request_at = Time.now
@@ -427,6 +429,10 @@ module Elasticsearch
             end
             "elasticsearch-ruby/#{VERSION} (#{meta.join('; ')})"
           end
+        end
+
+        def warnings(warning)
+          warn("warning: #{warning}")
         end
       end
     end

--- a/elasticsearch-transport/lib/elasticsearch/transport/transport/response.rb
+++ b/elasticsearch-transport/lib/elasticsearch/transport/transport/response.rb
@@ -18,7 +18,6 @@
 module Elasticsearch
   module Transport
     module Transport
-
       # Wraps the response from Elasticsearch.
       #
       class Response

--- a/elasticsearch-transport/spec/elasticsearch/transport/base_spec.rb
+++ b/elasticsearch-transport/spec/elasticsearch/transport/base_spec.rb
@@ -114,7 +114,6 @@ describe Elasticsearch::Transport::Transport::Base do
     end
 
     context 'when `perform_request` is called without a `retry_on_failure` option value' do
-
       before do
         expect(client.transport).to receive(:get_connection).exactly(3).times.and_call_original
       end
@@ -127,7 +126,6 @@ describe Elasticsearch::Transport::Transport::Base do
     end
 
     context 'when `perform_request` is called with a `retry_on_failure` option value' do
-
       before do
         expect(client.transport).to receive(:get_connection).exactly(6).times.and_call_original
       end
@@ -141,7 +139,6 @@ describe Elasticsearch::Transport::Transport::Base do
   end
 
   context 'when the client has `retry_on_failure` set to true' do
-
     let(:client) do
       Elasticsearch::Transport::Client.new(arguments)
     end
@@ -154,7 +151,6 @@ describe Elasticsearch::Transport::Transport::Base do
     end
 
     context 'when `perform_request` is called without a `retry_on_failure` option value' do
-
       before do
         expect(client.transport).to receive(:get_connection).exactly(4).times.and_call_original
       end
@@ -167,7 +163,6 @@ describe Elasticsearch::Transport::Transport::Base do
     end
 
     context 'when `perform_request` is called with a `retry_on_failure` option value' do
-
       before do
         expect(client.transport).to receive(:get_connection).exactly(6).times.and_call_original
       end
@@ -181,7 +176,6 @@ describe Elasticsearch::Transport::Transport::Base do
   end
 
   context 'when the client has `retry_on_failure` set to false' do
-
     let(:client) do
       Elasticsearch::Transport::Client.new(arguments)
     end
@@ -194,7 +188,6 @@ describe Elasticsearch::Transport::Transport::Base do
     end
 
     context 'when `perform_request` is called without a `retry_on_failure` option value' do
-
       before do
         expect(client.transport).to receive(:get_connection).once.and_call_original
       end

--- a/elasticsearch-transport/spec/elasticsearch/transport/client_spec.rb
+++ b/elasticsearch-transport/spec/elasticsearch/transport/client_spec.rb
@@ -18,7 +18,6 @@
 require 'spec_helper'
 
 describe Elasticsearch::Transport::Client do
-
   let(:client) do
     described_class.new.tap do |_client|
       allow(_client).to receive(:__build_connections)

--- a/elasticsearch-transport/spec/elasticsearch/transport/client_spec.rb
+++ b/elasticsearch-transport/spec/elasticsearch/transport/client_spec.rb
@@ -1333,6 +1333,32 @@ describe Elasticsearch::Transport::Client do
       end
     end
 
+    context 'when Elasticsearch response includes a warning header' do
+      let(:client) do
+        Elasticsearch::Transport::Client.new(hosts: hosts)
+      end
+
+      let(:warning) { 'Elasticsearch warning: "deprecation warning"' }
+
+      it 'prints a warning' do
+        allow_any_instance_of(Elasticsearch::Transport::Transport::Response).to receive(:headers) do
+          { 'warning' => warning }
+        end
+
+        begin
+          stderr      = $stderr
+          fake_stderr = StringIO.new
+          $stderr     = fake_stderr
+
+          client.perform_request('GET', '/')
+          fake_stderr.rewind
+          expect(fake_stderr.string).to eq("warning: #{warning}\n")
+        ensure
+          $stderr = stderr
+        end
+      end
+    end
+
     context 'when a header is set on an endpoint request' do
       let(:client) { described_class.new(host: hosts) }
       let(:headers) { { 'user-agent' => 'my ruby app' } }


### PR DESCRIPTION
Warn the user when there's a warning header in the Elasticsearch response.