### PR TITLE
Max retries

### DIFF
--- a/elasticsearch-transport/README.md
+++ b/elasticsearch-transport/README.md
@@ -172,7 +172,7 @@ Elasticsearch::Client.new hosts: [
     user: 'USERNAME',
     password: 'PASSWORD',
     scheme: 'https'
-  } 
+  }
 ]
 ```
 ... or simply use the common URL format:
@@ -326,7 +326,7 @@ You can specify how many times should the client retry the request before it rai
 (the default is 3 times):
 
 ```ruby
-Elasticsearch::Client.new hosts: ['localhost:9200', 'localhost:9201'], retry_on_failure: 5
+Elasticsearch::Client.new hosts: ['localhost:9200', 'localhost:9201'], max_retries: 5
 ```
 
 You can also use `retry_on_status` to retry when specific status codes are returned:
@@ -334,6 +334,7 @@ You can also use `retry_on_status` to retry when specific status codes are retur
 ```ruby
 Elasticsearch::Client.new hosts: ['localhost:9200', 'localhost:9201'], retry_on_status: [502, 503]
 ```
+`max_retries` works with `retry_on_status` as well.
 
 ### Reloading Hosts
 

--- a/elasticsearch-transport/spec/elasticsearch/transport/client_spec.rb
+++ b/elasticsearch-transport/spec/elasticsearch/transport/client_spec.rb
@@ -1726,6 +1726,7 @@ describe Elasticsearch::Transport::Client do
       context 'when an invalid url is specified' do
 
         it 'raises an exception' do
+          client.perform_request('DELETE', 'myindex')
           expect {
             client.perform_request('GET', 'myindex/mydoc/1?routing=FOOBARBAZ')
           }.to raise_exception(Elasticsearch::Transport::Transport::Errors::NotFound)

--- a/elasticsearch/test/integration/client_integration_test.rb
+++ b/elasticsearch/test/integration/client_integration_test.rb
@@ -48,7 +48,7 @@ module Elasticsearch
             #
             response = @client.search index: 'test-index', body: { query: { match: { title: 'test' } } }
 
-            assert_equal 1,      response['hits']['total']
+            assert_equal 1,      response['hits']['total']['value']
             assert_equal 'Test', response['hits']['hits'][0]['_source']['title']
 
             # Delete the index

--- a/elasticsearch/test/integration/client_integration_test.rb
+++ b/elasticsearch/test/integration/client_integration_test.rb
@@ -48,7 +48,7 @@ module Elasticsearch
             #
             response = @client.search index: 'test-index', body: { query: { match: { title: 'test' } } }
 
-            assert_equal 1,      response['hits']['total']['value']
+            assert_equal 1,      response['hits']['total']
             assert_equal 'Test', response['hits']['hits'][0]['_source']['title']
 
             # Delete the index


### PR DESCRIPTION
It was brought to my attention that `max_retries` option wasn't available when using the `retry_on_status` option for the transport client.  This PR enables that functionality while maintaining compatibility with previous versions.

I've added some tests for the new functionality and made a couple changes to get existing tests to pass on my machine.

Please let me know if anything else is needed.