### PR TITLE
Typhoeus update

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ Both of these libraries are extensively documented.
 and the [`elasticsearch-api`](http://rubydoc.info/gems/elasticsearch-api) documentation carefully.**
 
 _Keep in mind, that for optimal performance, you should use a HTTP library which supports persistent
-("keep-alive") connections, e.g. [Patron](https://github.com/toland/patron)._ These libraries are not dependencies of the elasticsearch gems, so be sure to define a dependency in your own application.
+("keep-alive") connections, e.g. [Patron](https://github.com/toland/patron) or [Typhoeus](https://github.com/typhoeus/typhoeus)._ These libraries are not dependencies of the elasticsearch gems, so be sure to define a dependency in your own application.
 
 This repository contains these additional Ruby libraries:
 

--- a/elasticsearch-transport/README.md
+++ b/elasticsearch-transport/README.md
@@ -28,16 +28,16 @@ Features overview:
 * Node reloading (based on cluster state) on errors or on demand
 
 For optimal performance, use a HTTP library which supports persistent ("keep-alive") connections,
-such as [patron](https://github.com/toland/patron).
-Just require the library (`require 'patron'`) in your code,
-and it will be automatically used.
+such as [patron](https://github.com/toland/patron) or [Typhoeus](https://github.com/typhoeus/typhoeus).
+Just require the library (`require 'patron'`) in your code, and it will be automatically used.
 
 Currently these libraries will be automatically detected and used:
 - [Patron](https://github.com/toland/patron)
+- [Typhoeus](https://github.com/typhoeus/typhoeus)
 - [HTTPClient](https://rubygems.org/gems/httpclient)
 - [Net::HTTP::Persistent](https://rubygems.org/gems/net-http-persistent)
 
-**Note on [Typhoeus](https://github.com/typhoeus/typhoeus)**: Typhoeus is compatible and will be automatically detected too. However, the latest release (v1.3.1 at the moment of writing this) is not compatible with Faraday 1.0. [It still uses the deprecated `Faraday::Error` namespace](https://github.com/typhoeus/typhoeus/blob/v1.3.1/lib/typhoeus/adapters/faraday.rb#L100). If you want to use it with this gem, we suggest getting `master` from GitHub, since this has been fixed for v1.4.0. We'll update this if/when v1.4.0 is released.a
+**Note on [Typhoeus](https://github.com/typhoeus/typhoeus)**: You need to use v1.4.0 or up since older versions are not compatible with Faraday 1.0.
 
 For detailed information, see example configurations [below](#transport-implementations).
 

--- a/elasticsearch-transport/elasticsearch-transport.gemspec
+++ b/elasticsearch-transport/elasticsearch-transport.gemspec
@@ -68,7 +68,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'simplecov', '~> 0.17', '< 0.18'
   s.add_development_dependency 'simplecov-rcov'
   s.add_development_dependency 'test-unit', '~> 2'
-  s.add_development_dependency 'typhoeus', '~> 0.6'
+  s.add_development_dependency 'typhoeus', '~> 1.4'
   s.add_development_dependency 'yard'
 
   s.description = <<-DESC.gsub(/^    /, '')

--- a/elasticsearch-transport/spec/elasticsearch/transport/client_spec.rb
+++ b/elasticsearch-transport/spec/elasticsearch/transport/client_spec.rb
@@ -283,7 +283,6 @@ describe Elasticsearch::Transport::Client do
     end
 
     context 'when the adapter can be detected', unless: jruby? do
-
       around do |example|
         require 'patron'; load 'patron.rb'
         example.run
@@ -299,7 +298,6 @@ describe Elasticsearch::Transport::Client do
     end
 
     context 'when the Faraday adapter is configured' do
-
       let(:client) do
         described_class.new do |faraday|
           faraday.adapter :patron
@@ -326,7 +324,6 @@ describe Elasticsearch::Transport::Client do
   end
 
   context 'when cloud credentials are provided' do
-
     let(:client) do
       described_class.new(cloud_id: 'name:bG9jYWxob3N0JGFiY2QkZWZnaA==', user: 'elastic', password: 'changeme')
     end
@@ -348,7 +345,6 @@ describe Elasticsearch::Transport::Client do
     end
 
     context 'when a port is specified' do
-
       let(:client) do
         described_class.new(cloud_id: 'name:bG9jYWxob3N0JGFiY2QkZWZnaA==', user: 'elastic', password: 'changeme', port: 9250 )
       end
@@ -367,7 +363,6 @@ describe Elasticsearch::Transport::Client do
     end
 
     context 'when the cluster has alternate names' do
-
       let(:client) do
         described_class.new(cloud_id: 'myCluster:bG9jYWxob3N0JGFiY2QkZWZnaA==', user: 'elasticfantastic', password: 'tobechanged')
       end
@@ -392,13 +387,9 @@ describe Elasticsearch::Transport::Client do
   end
 
   shared_examples_for 'a client that extracts hosts' do
-
     context 'when the host is a String' do
-
       context 'when there is a protocol specified' do
-
         context 'when credentials are specified \'http://USERNAME:PASSWORD@myhost:8080\'' do
-
           let(:host) do
             'http://USERNAME:PASSWORD@myhost:8080'
           end
@@ -418,7 +409,6 @@ describe Elasticsearch::Transport::Client do
         end
 
         context 'when there is a trailing slash \'http://myhost/\'' do
-
           let(:host) do
             'http://myhost/'
           end
@@ -439,7 +429,6 @@ describe Elasticsearch::Transport::Client do
         end
 
         context 'when there is a trailing slash with a path \'http://myhost/foo/bar/\'' do
-
           let(:host) do
             'http://myhost/foo/bar/'
           end
@@ -452,9 +441,7 @@ describe Elasticsearch::Transport::Client do
         end
 
         context 'when the protocol is http' do
-
           context 'when there is no port specified \'http://myhost\'' do
-
             let(:host) do
               'http://myhost'
             end
@@ -1617,7 +1604,6 @@ describe Elasticsearch::Transport::Client do
           end
 
           context 'when using the Patron adapter', unless: jruby? do
-
             let(:client) do
               described_class.new(hosts: ELASTICSEARCH_HOSTS, compression: true, adapter: :patron)
             end
@@ -1636,7 +1622,6 @@ describe Elasticsearch::Transport::Client do
           end
 
           context 'when using the Net::HTTP::Persistent adapter' do
-
             let(:client) do
               described_class.new(hosts: ELASTICSEARCH_HOSTS, compression: true, adapter: :net_http_persistent)
             end
@@ -1655,7 +1640,6 @@ describe Elasticsearch::Transport::Client do
           end
 
           context 'when using the Typhoeus adapter' do
-
             let(:client) do
               described_class.new(hosts: ELASTICSEARCH_HOSTS, compression: true, adapter: :typhoeus)
             end
@@ -1676,7 +1660,6 @@ describe Elasticsearch::Transport::Client do
       end
 
       context 'when using Curb as the transport', unless: jruby? do
-
         let(:client) do
           described_class.new(hosts: ELASTICSEARCH_HOSTS,
                               compression: true,
@@ -1697,7 +1680,6 @@ describe Elasticsearch::Transport::Client do
       end
 
       context 'when using Manticore as the transport', if: jruby? do
-
         let(:client) do
           described_class.new(hosts: ELASTICSEARCH_HOSTS,
                               compression: true,
@@ -1711,9 +1693,7 @@ describe Elasticsearch::Transport::Client do
     end
 
     describe '#perform_request' do
-
       context 'when a request is made' do
-
         before do
           client.perform_request('DELETE', '_all')
           client.perform_request('DELETE', 'myindex') rescue
@@ -1801,7 +1781,6 @@ describe Elasticsearch::Transport::Client do
       end
 
       context 'when patron is used as an adapter', unless: jruby? do
-
         before do
           require 'patron'
         end

--- a/elasticsearch-transport/spec/elasticsearch/transport/client_spec.rb
+++ b/elasticsearch-transport/spec/elasticsearch/transport/client_spec.rb
@@ -240,8 +240,7 @@ describe Elasticsearch::Transport::Client do
       end
     end
 
-    context 'when the adapter is specified' do
-
+    context 'when the adapter is patron' do
       let(:adapter) do
         client.transport.connections.all.first.connection.builder.adapter
       end
@@ -255,8 +254,21 @@ describe Elasticsearch::Transport::Client do
       end
     end
 
-    context 'when the adapter is specified as a string key' do
+    context 'when the adapter is typhoeus' do
+      let(:adapter) do
+        client.transport.connections.all.first.connection.builder.adapter
+      end
 
+      let(:client) do
+        described_class.new(adapter: :typhoeus)
+      end
+
+      it 'uses Faraday with the adapter' do
+        expect(adapter).to eq Faraday::Adapter::Typhoeus
+      end
+    end
+
+    context 'when the adapter is specified as a string key' do
       let(:adapter) do
         client.transport.connections.all.first.connection.builder.adapter
       end
@@ -1804,6 +1816,33 @@ describe Elasticsearch::Transport::Client do
 
         it 'uses the patron connection handler' do
           expect(adapter).to eq('Faraday::Adapter::Patron')
+        end
+
+        it 'keeps connections open' do
+          response = client.perform_request('GET', '_nodes/stats/http')
+          connections_before = response.body['nodes'].values.find { |n| n['name'] == node_names.first }['http']['total_opened']
+          client.transport.reload_connections!
+          response = client.perform_request('GET', '_nodes/stats/http')
+          connections_after = response.body['nodes'].values.find { |n| n['name'] == node_names.first }['http']['total_opened']
+          expect(connections_after).to be >= (connections_before)
+        end
+      end
+
+      context 'when typhoeus is used as an adapter', unless: jruby? do
+        before do
+          require 'typhoeus'
+        end
+
+        let(:options) do
+          { adapter: :typhoeus }
+        end
+
+        let(:adapter) do
+          client.transport.connections.first.connection.builder.adapter
+        end
+
+        it 'uses the patron connection handler' do
+          expect(adapter).to eq('Faraday::Adapter::Typhoeus')
         end
 
         it 'keeps connections open' do


### PR DESCRIPTION
Since we migrated to Faraday 1.0, we were not using [Typhoeus](https://github.com/typhoeus/typhoeus/) in docs and tests because it wasn't compatible. Now that typhoeus 1.4 has been released, we can use it with the latest versions of the client. This PR updates docs and specs.