### PR TITLE
Transport/Connection: consider attributes values for equality

### DIFF
--- a/elasticsearch-transport/lib/elasticsearch/transport/transport/connections/connection.rb
+++ b/elasticsearch-transport/lib/elasticsearch/transport/transport/connections/connection.rb
@@ -135,14 +135,15 @@ module Elasticsearch
             }
           end
 
-          # Equality operator based on connection protocol, host and port
+          # Equality operator based on connection protocol, host, port and attributes
           #
           # @return [Boolean]
           #
           def ==(other)
             self.host[:protocol] == other.host[:protocol] && \
             self.host[:host] == other.host[:host] && \
-            self.host[:port].to_i == other.host[:port].to_i
+            self.host[:port].to_i == other.host[:port].to_i && \
+            self.host[:attributes] == other.host[:attributes]
           end
 
           # @return [String]


### PR DESCRIPTION
Two hosts must be considered as different if their attributes differ.
If we don't, on hosts list refreshing, if hosts have the same IP and
port, but have updated attributes, we will always consider hosts are the
same and won't take the new attributes into account.

On startup, hosts do not have any attributes.
On the first call of client.transport.reload_connections!, we fetch the
nodes list with their attributes, remove hosts that have been
disappeared and add new hosts.
However, we use this equality to detect if the hosts were already in the
current list of nodes or node.
If the client was configured with a nodes list that have the same name
as the published hostname and port, the nodes with attributes will be
considered equals as nodes without and we will never save the attributes
in the list. And the Selector can't use attributes.