### PR TITLE
Method and body

### DIFF
--- a/elasticsearch-api/lib/elasticsearch/api/actions/bulk.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/bulk.rb
@@ -57,7 +57,7 @@ module Elasticsearch
                    "#{Utils.__listify(_index)}/_bulk"
                  else
                    "_bulk"
-  end
+                 end
         params = Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
 
         body = arguments[:body]
@@ -65,7 +65,7 @@ module Elasticsearch
           payload = Elasticsearch::API::Utils.__bulkify(body)
         else
           payload = body
-      end
+        end
 
         headers.merge!("Content-Type" => "application/x-ndjson")
         perform_request(method, path, params, payload, headers).body
@@ -86,5 +86,5 @@ module Elasticsearch
         :pipeline
       ].freeze)
     end
-    end
+  end
 end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/cat/aliases.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/cat/aliases.rb
@@ -47,7 +47,7 @@ module Elasticsearch
                      "_cat/aliases/#{Utils.__listify(_name)}"
                    else
                      "_cat/aliases"
-      end
+                   end
           params = Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
           params[:h] = Utils.__listify(params[:h]) if params[:h]
 
@@ -67,7 +67,7 @@ module Elasticsearch
           :v,
           :expand_wildcards
         ].freeze)
-end
       end
+    end
   end
 end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/cat/allocation.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/cat/allocation.rb
@@ -48,7 +48,7 @@ module Elasticsearch
                      "_cat/allocation/#{Utils.__listify(_node_id)}"
                    else
                      "_cat/allocation"
-      end
+                   end
           params = Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
           params[:h] = Utils.__listify(params[:h]) if params[:h]
 
@@ -69,7 +69,7 @@ module Elasticsearch
           :s,
           :v
         ].freeze)
-end
       end
+    end
   end
 end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/cat/count.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/cat/count.rb
@@ -43,7 +43,7 @@ module Elasticsearch
                      "_cat/count/#{Utils.__listify(_index)}"
                    else
                      "_cat/count"
-      end
+                   end
           params = Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
           params[:h] = Utils.__listify(params[:h]) if params[:h]
 
@@ -61,7 +61,7 @@ module Elasticsearch
           :s,
           :v
         ].freeze)
-end
       end
+    end
   end
 end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/cat/fielddata.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/cat/fielddata.rb
@@ -47,7 +47,7 @@ module Elasticsearch
                      "_cat/fielddata/#{Utils.__listify(_fields)}"
                    else
                      "_cat/fielddata"
-      end
+                   end
           params = Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
 
           body = nil
@@ -66,7 +66,7 @@ module Elasticsearch
           :v,
           :fields
         ].freeze)
-end
       end
+    end
   end
 end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/cat/health.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/cat/health.rb
@@ -60,7 +60,7 @@ module Elasticsearch
           :ts,
           :v
         ].freeze)
-end
       end
+    end
   end
 end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/cat/help.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/cat/help.rb
@@ -47,7 +47,7 @@ module Elasticsearch
           :help,
           :s
         ].freeze)
-end
       end
+    end
   end
 end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/cat/indices.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/cat/indices.rb
@@ -59,7 +59,7 @@ module Elasticsearch
                      "_cat/indices/#{Utils.__listify(_index)}"
                    else
                      "_cat/indices"
-      end
+                   end
           params = Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
           params[:h] = Utils.__listify(params[:h]) if params[:h]
 
@@ -85,7 +85,7 @@ module Elasticsearch
           :include_unloaded_segments,
           :expand_wildcards
         ].freeze)
-end
       end
+    end
   end
 end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/cat/master.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/cat/master.rb
@@ -57,7 +57,7 @@ module Elasticsearch
           :s,
           :v
         ].freeze)
-end
       end
+    end
   end
 end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/cat/nodeattrs.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/cat/nodeattrs.rb
@@ -57,7 +57,7 @@ module Elasticsearch
           :s,
           :v
         ].freeze)
-end
       end
+    end
   end
 end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/cat/nodes.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/cat/nodes.rb
@@ -66,7 +66,7 @@ module Elasticsearch
           :time,
           :v
         ].freeze)
-end
       end
+    end
   end
 end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/cat/pending_tasks.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/cat/pending_tasks.rb
@@ -62,7 +62,7 @@ module Elasticsearch
           :time,
           :v
         ].freeze)
-end
       end
+    end
   end
 end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/cat/plugins.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/cat/plugins.rb
@@ -57,7 +57,7 @@ module Elasticsearch
           :s,
           :v
         ].freeze)
-end
       end
+    end
   end
 end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/cat/recovery.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/cat/recovery.rb
@@ -52,7 +52,7 @@ module Elasticsearch
                      "_cat/recovery/#{Utils.__listify(_index)}"
                    else
                      "_cat/recovery"
-      end
+                   end
           params = Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
           params[:h] = Utils.__listify(params[:h]) if params[:h]
 
@@ -75,7 +75,7 @@ module Elasticsearch
           :time,
           :v
         ].freeze)
-end
       end
+    end
   end
 end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/cat/repositories.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/cat/repositories.rb
@@ -57,7 +57,7 @@ module Elasticsearch
           :s,
           :v
         ].freeze)
-end
       end
+    end
   end
 end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/cat/segments.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/cat/segments.rb
@@ -46,7 +46,7 @@ module Elasticsearch
                      "_cat/segments/#{Utils.__listify(_index)}"
                    else
                      "_cat/segments"
-      end
+                   end
           params = Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
 
           body = nil
@@ -64,7 +64,7 @@ module Elasticsearch
           :s,
           :v
         ].freeze)
-end
       end
+    end
   end
 end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/cat/shards.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/cat/shards.rb
@@ -51,7 +51,7 @@ module Elasticsearch
                      "_cat/shards/#{Utils.__listify(_index)}"
                    else
                      "_cat/shards"
-      end
+                   end
           params = Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
           params[:h] = Utils.__listify(params[:h]) if params[:h]
 
@@ -73,7 +73,7 @@ module Elasticsearch
           :time,
           :v
         ].freeze)
-end
       end
+    end
   end
 end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/cat/snapshots.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/cat/snapshots.rb
@@ -48,7 +48,7 @@ module Elasticsearch
                      "_cat/snapshots/#{Utils.__listify(_repository)}"
                    else
                      "_cat/snapshots"
-      end
+                   end
           params = Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
 
           body = nil
@@ -68,7 +68,7 @@ module Elasticsearch
           :time,
           :v
         ].freeze)
-end
       end
+    end
   end
 end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/cat/tasks.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/cat/tasks.rb
@@ -65,7 +65,7 @@ module Elasticsearch
           :time,
           :v
         ].freeze)
-end
       end
+    end
   end
 end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/cat/templates.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/cat/templates.rb
@@ -45,7 +45,7 @@ module Elasticsearch
                      "_cat/templates/#{Utils.__listify(_name)}"
                    else
                      "_cat/templates"
-      end
+                   end
           params = Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
 
           body = nil
@@ -64,7 +64,7 @@ module Elasticsearch
           :s,
           :v
         ].freeze)
-end
       end
+    end
   end
 end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/cat/thread_pool.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/cat/thread_pool.rb
@@ -49,7 +49,7 @@ module Elasticsearch
                      "_cat/thread_pool/#{Utils.__listify(_thread_pool_patterns)}"
                    else
                      "_cat/thread_pool"
-      end
+                   end
           params = Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
           params[:h] = Utils.__listify(params[:h]) if params[:h]
 
@@ -70,7 +70,7 @@ module Elasticsearch
           :s,
           :v
         ].freeze)
-end
       end
+    end
   end
 end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/clear_scroll.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/clear_scroll.rb
@@ -43,12 +43,12 @@ module Elasticsearch
                    "_search/scroll/#{Utils.__listify(_scroll_id)}"
                  else
                    "_search/scroll"
-    end
+                 end
         params = {}
 
         body = arguments[:body]
         perform_request(method, path, params, body, headers).body
       end
     end
-    end
+  end
 end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/cluster/allocation_explain.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/cluster/allocation_explain.rb
@@ -33,8 +33,13 @@ module Elasticsearch
 
           arguments = arguments.clone
 
-          method = Elasticsearch::API::HTTP_GET
-          path   = "_cluster/allocation/explain"
+          method = if arguments[:body]
+                     Elasticsearch::API::HTTP_POST
+                   else
+                     Elasticsearch::API::HTTP_GET
+                   end
+
+          path = "_cluster/allocation/explain"
           params = Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
 
           body = arguments[:body]
@@ -48,7 +53,7 @@ module Elasticsearch
           :include_yes_decisions,
           :include_disk_info
         ].freeze)
-end
       end
+    end
   end
 end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/cluster/delete_component_template.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/cluster/delete_component_template.rb
@@ -52,7 +52,7 @@ module Elasticsearch
           :timeout,
           :master_timeout
         ].freeze)
-end
       end
+    end
   end
 end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/cluster/delete_voting_config_exclusions.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/cluster/delete_voting_config_exclusions.rb
@@ -45,7 +45,7 @@ module Elasticsearch
         ParamsRegistry.register(:delete_voting_config_exclusions, [
           :wait_for_removal
         ].freeze)
-end
       end
+    end
   end
 end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/cluster/exists_component_template.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/cluster/exists_component_template.rb
@@ -53,7 +53,7 @@ module Elasticsearch
           :master_timeout,
           :local
         ].freeze)
-end
       end
+    end
   end
 end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/cluster/get_component_template.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/cluster/get_component_template.rb
@@ -40,7 +40,7 @@ module Elasticsearch
                      "_component_template/#{Utils.__listify(_name)}"
                    else
                      "_component_template"
-      end
+                   end
           params = Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
 
           body = nil
@@ -54,7 +54,7 @@ module Elasticsearch
           :master_timeout,
           :local
         ].freeze)
-end
       end
+    end
   end
 end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/cluster/get_settings.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/cluster/get_settings.rb
@@ -51,7 +51,7 @@ module Elasticsearch
           :timeout,
           :include_defaults
         ].freeze)
-end
       end
+    end
   end
 end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/cluster/health.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/cluster/health.rb
@@ -57,7 +57,7 @@ module Elasticsearch
                      "_cluster/health/#{Utils.__listify(_index)}"
                    else
                      "_cluster/health"
-      end
+                   end
           params = Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
 
           body = nil
@@ -80,7 +80,7 @@ module Elasticsearch
           :wait_for_no_initializing_shards,
           :wait_for_status
         ].freeze)
-end
       end
+    end
   end
 end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/cluster/pending_tasks.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/cluster/pending_tasks.rb
@@ -48,7 +48,7 @@ module Elasticsearch
           :local,
           :master_timeout
         ].freeze)
-end
       end
+    end
   end
 end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/cluster/post_voting_config_exclusions.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/cluster/post_voting_config_exclusions.rb
@@ -49,7 +49,7 @@ module Elasticsearch
           :node_names,
           :timeout
         ].freeze)
-end
       end
+    end
   end
 end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/cluster/put_component_template.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/cluster/put_component_template.rb
@@ -56,7 +56,7 @@ module Elasticsearch
           :timeout,
           :master_timeout
         ].freeze)
-end
       end
+    end
   end
 end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/cluster/put_settings.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/cluster/put_settings.rb
@@ -52,7 +52,7 @@ module Elasticsearch
           :master_timeout,
           :timeout
         ].freeze)
-end
       end
+    end
   end
 end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/cluster/remote_info.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/cluster/remote_info.rb
@@ -37,7 +37,7 @@ module Elasticsearch
           body = nil
           perform_request(method, path, params, body, headers).body
         end
-end
       end
+    end
   end
 end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/cluster/reroute.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/cluster/reroute.rb
@@ -58,7 +58,7 @@ module Elasticsearch
           :master_timeout,
           :timeout
         ].freeze)
-end
       end
+    end
   end
 end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/cluster/state.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/cluster/state.rb
@@ -55,7 +55,7 @@ module Elasticsearch
                      "_cluster/state/#{Utils.__listify(_metric)}"
                    else
                      "_cluster/state"
-      end
+                   end
           params = Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
 
           body = nil
@@ -75,7 +75,7 @@ module Elasticsearch
           :allow_no_indices,
           :expand_wildcards
         ].freeze)
-end
       end
+    end
   end
 end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/cluster/stats.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/cluster/stats.rb
@@ -40,7 +40,7 @@ module Elasticsearch
                      "_cluster/stats/nodes/#{Utils.__listify(_node_id)}"
                    else
                      "_cluster/stats"
-      end
+                   end
           params = Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
 
           body = nil
@@ -54,7 +54,7 @@ module Elasticsearch
           :flat_settings,
           :timeout
         ].freeze)
-end
       end
+    end
   end
 end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/count.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/count.rb
@@ -51,17 +51,12 @@ module Elasticsearch
 
         _index = arguments.delete(:index)
 
-        method = if arguments[:body]
-                   Elasticsearch::API::HTTP_POST
+        method = Elasticsearch::API::HTTP_POST
+        path   = if _index
+                   "#{Utils.__listify(_index)}/_count"
                  else
-                   Elasticsearch::API::HTTP_GET
-    end
-
-        path = if _index
-                 "#{Utils.__listify(_index)}/_count"
-               else
-                 "_count"
-    end
+                   "_count"
+                 end
         params = Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
 
         body = arguments[:body]
@@ -88,5 +83,5 @@ module Elasticsearch
         :terminate_after
       ].freeze)
     end
-    end
+  end
 end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/create.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/create.rb
@@ -54,5 +54,5 @@ module Elasticsearch
         end
       end
     end
-    end
+  end
 end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/delete.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/delete.rb
@@ -63,7 +63,7 @@ module Elasticsearch
                    "#{Utils.__listify(_index)}/#{Utils.__listify(_type)}/#{Utils.__listify(_id)}"
                  else
                    "#{Utils.__listify(_index)}/_doc/#{Utils.__listify(_id)}"
-  end
+                 end
         params = Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
 
         body = nil
@@ -88,5 +88,5 @@ module Elasticsearch
         :version_type
       ].freeze)
     end
-    end
+  end
 end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/delete_by_query.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/delete_by_query.rb
@@ -122,5 +122,5 @@ module Elasticsearch
         :slices
       ].freeze)
     end
-    end
+  end
 end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/delete_by_query_rethrottle.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/delete_by_query_rethrottle.rb
@@ -50,5 +50,5 @@ module Elasticsearch
         :requests_per_second
       ].freeze)
     end
-    end
+  end
 end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/delete_script.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/delete_script.rb
@@ -52,5 +52,5 @@ module Elasticsearch
         :master_timeout
       ].freeze)
     end
-    end
+  end
 end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/exists.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/exists.rb
@@ -78,5 +78,5 @@ module Elasticsearch
         :version_type
       ].freeze)
     end
-    end
+  end
 end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/exists_source.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/exists_source.rb
@@ -62,7 +62,7 @@ module Elasticsearch
                    "#{Utils.__listify(_index)}/#{Utils.__listify(_type)}/#{Utils.__listify(_id)}/_source"
                  else
                    "#{Utils.__listify(_index)}/_source/#{Utils.__listify(_id)}"
-  end
+                 end
         params = Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
 
         body = nil
@@ -85,5 +85,5 @@ module Elasticsearch
         :version_type
       ].freeze)
     end
-    end
+  end
 end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/explain.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/explain.rb
@@ -53,8 +53,13 @@ module Elasticsearch
 
         _index = arguments.delete(:index)
 
-        method = Elasticsearch::API::HTTP_GET
-        path   = "#{Utils.__listify(_index)}/_explain/#{Utils.__listify(_id)}"
+        method = if arguments[:body]
+                   Elasticsearch::API::HTTP_POST
+                 else
+                   Elasticsearch::API::HTTP_GET
+                 end
+
+        path = "#{Utils.__listify(_index)}/_explain/#{Utils.__listify(_id)}"
         params = Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
 
         body = arguments[:body]
@@ -79,5 +84,5 @@ module Elasticsearch
         :_source_includes
       ].freeze)
     end
-    end
+  end
 end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/field_caps.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/field_caps.rb
@@ -44,7 +44,7 @@ module Elasticsearch
                    "#{Utils.__listify(_index)}/_field_caps"
                  else
                    "_field_caps"
-    end
+                 end
         params = Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
 
         body = nil
@@ -62,5 +62,5 @@ module Elasticsearch
         :include_unmapped
       ].freeze)
     end
-    end
+  end
 end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/get.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/get.rb
@@ -78,5 +78,5 @@ module Elasticsearch
         :version_type
       ].freeze)
     end
-    end
+  end
 end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/get_script.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/get_script.rb
@@ -50,5 +50,5 @@ module Elasticsearch
         :master_timeout
       ].freeze)
     end
-    end
+  end
 end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/get_script_context.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/get_script_context.rb
@@ -37,5 +37,5 @@ module Elasticsearch
         perform_request(method, path, params, body, headers).body
       end
     end
-    end
+  end
 end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/get_script_languages.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/get_script_languages.rb
@@ -37,5 +37,5 @@ module Elasticsearch
         perform_request(method, path, params, body, headers).body
       end
     end
-    end
+  end
 end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/get_source.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/get_source.rb
@@ -72,5 +72,5 @@ module Elasticsearch
         :version_type
       ].freeze)
     end
-    end
+  end
 end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/index.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/index.rb
@@ -60,7 +60,7 @@ module Elasticsearch
                    "#{Utils.__listify(_index)}/_doc/#{Utils.__listify(_id)}"
                  else
                    "#{Utils.__listify(_index)}/_doc"
-  end
+                 end
         params = Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
 
         body = arguments[:body]
@@ -83,5 +83,5 @@ module Elasticsearch
         :pipeline
       ].freeze)
     end
-    end
+  end
 end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/analyze.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/analyze.rb
@@ -35,12 +35,17 @@ module Elasticsearch
 
           _index = arguments.delete(:index)
 
-          method = Elasticsearch::API::HTTP_GET
-          path   = if _index
-                     "#{Utils.__listify(_index)}/_analyze"
+          method = if arguments[:body]
+                     Elasticsearch::API::HTTP_POST
                    else
-                     "_analyze"
-      end
+                     Elasticsearch::API::HTTP_GET
+                   end
+
+          path = if _index
+                   "#{Utils.__listify(_index)}/_analyze"
+                 else
+                   "_analyze"
+                 end
           params = Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
 
           body = arguments[:body]
@@ -53,7 +58,7 @@ module Elasticsearch
         ParamsRegistry.register(:analyze, [
           :index
         ].freeze)
-end
       end
+    end
   end
 end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/clear_cache.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/clear_cache.rb
@@ -48,7 +48,7 @@ module Elasticsearch
                      "#{Utils.__listify(_index)}/_cache/clear"
                    else
                      "_cache/clear"
-      end
+                   end
           params = Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
 
           body = nil
@@ -68,7 +68,7 @@ module Elasticsearch
           :index,
           :request
         ].freeze)
-end
       end
+    end
   end
 end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/clone.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/clone.rb
@@ -59,7 +59,7 @@ module Elasticsearch
           :master_timeout,
           :wait_for_active_shards
         ].freeze)
-end
       end
+    end
   end
 end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/close.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/close.rb
@@ -62,7 +62,7 @@ module Elasticsearch
           :expand_wildcards,
           :wait_for_active_shards
         ].freeze)
-end
       end
+    end
   end
 end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/create.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/create.rb
@@ -55,7 +55,7 @@ module Elasticsearch
           :timeout,
           :master_timeout
         ].freeze)
-end
       end
+    end
   end
 end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/create_data_stream.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/create_data_stream.rb
@@ -43,7 +43,7 @@ module Elasticsearch
           body = arguments[:body]
           perform_request(method, path, params, body, headers).body
         end
-end
       end
+    end
   end
 end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/delete.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/delete.rb
@@ -64,7 +64,7 @@ module Elasticsearch
           :allow_no_indices,
           :expand_wildcards
         ].freeze)
-end
       end
+    end
   end
 end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/delete_alias.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/delete_alias.rb
@@ -44,7 +44,7 @@ module Elasticsearch
           method = Elasticsearch::API::HTTP_DELETE
           path   = if _index && _name
                      "#{Utils.__listify(_index)}/_aliases/#{Utils.__listify(_name)}"
-  end
+                   end
           params = Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
 
           body = nil
@@ -58,7 +58,7 @@ module Elasticsearch
           :timeout,
           :master_timeout
         ].freeze)
-end
       end
+    end
   end
 end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/delete_data_stream.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/delete_data_stream.rb
@@ -42,7 +42,7 @@ module Elasticsearch
           body = nil
           perform_request(method, path, params, body, headers).body
         end
-end
       end
+    end
   end
 end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/delete_index_template.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/delete_index_template.rb
@@ -52,7 +52,7 @@ module Elasticsearch
           :timeout,
           :master_timeout
         ].freeze)
-end
       end
+    end
   end
 end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/delete_template.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/delete_template.rb
@@ -56,7 +56,7 @@ module Elasticsearch
           :timeout,
           :master_timeout
         ].freeze)
-end
       end
+    end
   end
 end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/exists.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/exists.rb
@@ -66,7 +66,7 @@ module Elasticsearch
           :flat_settings,
           :include_defaults
         ].freeze)
-end
       end
+    end
   end
 end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/exists_alias.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/exists_alias.rb
@@ -49,7 +49,7 @@ module Elasticsearch
                      "#{Utils.__listify(_index)}/_alias/#{Utils.__listify(_name)}"
                    else
                      "_alias/#{Utils.__listify(_name)}"
-  end
+                   end
           params = Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
 
           body = nil
@@ -69,7 +69,7 @@ module Elasticsearch
           :expand_wildcards,
           :local
         ].freeze)
-end
       end
+    end
   end
 end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/exists_index_template.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/exists_index_template.rb
@@ -55,7 +55,7 @@ module Elasticsearch
           :master_timeout,
           :local
         ].freeze)
-end
       end
+    end
   end
 end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/exists_template.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/exists_template.rb
@@ -58,7 +58,7 @@ module Elasticsearch
           :master_timeout,
           :local
         ].freeze)
-end
       end
+    end
   end
 end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/exists_type.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/exists_type.rb
@@ -66,7 +66,7 @@ module Elasticsearch
           :expand_wildcards,
           :local
         ].freeze)
-end
       end
+    end
   end
 end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/flush.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/flush.rb
@@ -45,7 +45,7 @@ module Elasticsearch
                      "#{Utils.__listify(_index)}/_flush"
                    else
                      "_flush"
-      end
+                   end
           params = Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
 
           body = nil
@@ -62,7 +62,7 @@ module Elasticsearch
           :allow_no_indices,
           :expand_wildcards
         ].freeze)
-end
       end
+    end
   end
 end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/forcemerge.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/forcemerge.rb
@@ -46,7 +46,7 @@ module Elasticsearch
                      "#{Utils.__listify(_index)}/_forcemerge"
                    else
                      "_forcemerge"
-      end
+                   end
           params = Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
 
           body = nil
@@ -64,7 +64,7 @@ module Elasticsearch
           :max_num_segments,
           :only_expunge_deletes
         ].freeze)
-end
       end
+    end
   end
 end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/get.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/get.rb
@@ -64,7 +64,7 @@ module Elasticsearch
           :include_defaults,
           :master_timeout
         ].freeze)
-end
       end
+    end
   end
 end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/get_alias.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/get_alias.rb
@@ -51,7 +51,7 @@ module Elasticsearch
                      "_alias/#{Utils.__listify(_name)}"
                    else
                      "_alias"
-      end
+                   end
           params = Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
 
           body = nil
@@ -67,7 +67,7 @@ module Elasticsearch
           :expand_wildcards,
           :local
         ].freeze)
-end
       end
+    end
   end
 end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/get_data_stream.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/get_data_stream.rb
@@ -38,13 +38,13 @@ module Elasticsearch
                      "_data_stream/#{Utils.__listify(_name)}"
                    else
                      "_data_stream"
-      end
+                   end
           params = {}
 
           body = nil
           perform_request(method, path, params, body, headers).body
         end
-end
       end
+    end
   end
 end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/get_field_mapping.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/get_field_mapping.rb
@@ -49,7 +49,7 @@ module Elasticsearch
                      "#{Utils.__listify(_index)}/_mapping/field/#{Utils.__listify(_fields)}"
                    else
                      "_mapping/field/#{Utils.__listify(_fields)}"
-      end
+                   end
           params = Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
 
           body = nil
@@ -66,7 +66,7 @@ module Elasticsearch
           :expand_wildcards,
           :local
         ].freeze)
-end
       end
+    end
   end
 end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/get_index_template.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/get_index_template.rb
@@ -41,7 +41,7 @@ module Elasticsearch
                      "_index_template/#{Utils.__listify(_name)}"
                    else
                      "_index_template"
-      end
+                   end
           params = Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
 
           body = nil
@@ -56,7 +56,7 @@ module Elasticsearch
           :master_timeout,
           :local
         ].freeze)
-end
       end
+    end
   end
 end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/get_mapping.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/get_mapping.rb
@@ -45,7 +45,7 @@ module Elasticsearch
                      "#{Utils.__listify(_index)}/_mapping"
                    else
                      "_mapping"
-      end
+                   end
           params = Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
 
           body = nil
@@ -62,7 +62,7 @@ module Elasticsearch
           :master_timeout,
           :local
         ].freeze)
-end
       end
+    end
   end
 end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/get_settings.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/get_settings.rb
@@ -54,7 +54,7 @@ module Elasticsearch
                      "_settings/#{Utils.__listify(_name)}"
                    else
                      "_settings"
-      end
+                   end
           params = Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
 
           body = nil
@@ -73,7 +73,7 @@ module Elasticsearch
           :local,
           :include_defaults
         ].freeze)
-end
       end
+    end
   end
 end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/get_template.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/get_template.rb
@@ -41,7 +41,7 @@ module Elasticsearch
                      "_template/#{Utils.__listify(_name)}"
                    else
                      "_template"
-      end
+                   end
           params = Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
 
           body = nil
@@ -56,7 +56,7 @@ module Elasticsearch
           :master_timeout,
           :local
         ].freeze)
-end
       end
+    end
   end
 end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/get_upgrade.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/get_upgrade.rb
@@ -48,7 +48,7 @@ module Elasticsearch
                      "#{Utils.__listify(_index)}/_upgrade"
                    else
                      "_upgrade"
-      end
+                   end
           params = Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
 
           body = nil
@@ -63,7 +63,7 @@ module Elasticsearch
           :allow_no_indices,
           :expand_wildcards
         ].freeze)
-end
       end
+    end
   end
 end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/open.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/open.rb
@@ -62,7 +62,7 @@ module Elasticsearch
           :expand_wildcards,
           :wait_for_active_shards
         ].freeze)
-end
       end
+    end
   end
 end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/put_alias.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/put_alias.rb
@@ -45,7 +45,7 @@ module Elasticsearch
           method = Elasticsearch::API::HTTP_PUT
           path   = if _index && _name
                      "#{Utils.__listify(_index)}/_aliases/#{Utils.__listify(_name)}"
-  end
+                   end
           params = Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
 
           body = arguments[:body]
@@ -59,7 +59,7 @@ module Elasticsearch
           :timeout,
           :master_timeout
         ].freeze)
-end
       end
+    end
   end
 end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/put_index_template.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/put_index_template.rb
@@ -56,7 +56,7 @@ module Elasticsearch
           :cause,
           :master_timeout
         ].freeze)
-end
       end
+    end
   end
 end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/put_mapping.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/put_mapping.rb
@@ -62,7 +62,7 @@ module Elasticsearch
           :allow_no_indices,
           :expand_wildcards
         ].freeze)
-end
       end
+    end
   end
 end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/put_settings.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/put_settings.rb
@@ -50,7 +50,7 @@ module Elasticsearch
                      "#{Utils.__listify(_index)}/_settings"
                    else
                      "_settings"
-  end
+                   end
           params = Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
 
           body = arguments[:body]
@@ -69,7 +69,7 @@ module Elasticsearch
           :expand_wildcards,
           :flat_settings
         ].freeze)
-end
       end
+    end
   end
 end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/put_template.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/put_template.rb
@@ -56,7 +56,7 @@ module Elasticsearch
           :create,
           :master_timeout
         ].freeze)
-end
       end
+    end
   end
 end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/recovery.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/recovery.rb
@@ -40,7 +40,7 @@ module Elasticsearch
                      "#{Utils.__listify(_index)}/_recovery"
                    else
                      "_recovery"
-      end
+                   end
           params = Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
 
           body = nil
@@ -54,7 +54,7 @@ module Elasticsearch
           :detailed,
           :active_only
         ].freeze)
-end
       end
+    end
   end
 end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/refresh.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/refresh.rb
@@ -43,7 +43,7 @@ module Elasticsearch
                      "#{Utils.__listify(_index)}/_refresh"
                    else
                      "_refresh"
-      end
+                   end
           params = Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
 
           body = nil
@@ -58,7 +58,7 @@ module Elasticsearch
           :allow_no_indices,
           :expand_wildcards
         ].freeze)
-end
       end
+    end
   end
 end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/resolve_index.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/resolve_index.rb
@@ -52,7 +52,7 @@ module Elasticsearch
         ParamsRegistry.register(:resolve_index, [
           :expand_wildcards
         ].freeze)
-end
       end
+    end
   end
 end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/rollover.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/rollover.rb
@@ -49,7 +49,7 @@ module Elasticsearch
                      "#{Utils.__listify(_alias)}/_rollover/#{Utils.__listify(_new_index)}"
                    else
                      "#{Utils.__listify(_alias)}/_rollover"
-  end
+                   end
           params = Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
 
           body = arguments[:body]
@@ -65,7 +65,7 @@ module Elasticsearch
           :master_timeout,
           :wait_for_active_shards
         ].freeze)
-end
       end
+    end
   end
 end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/segments.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/segments.rb
@@ -44,7 +44,7 @@ module Elasticsearch
                      "#{Utils.__listify(_index)}/_segments"
                    else
                      "_segments"
-      end
+                   end
           params = Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
 
           body = nil
@@ -60,7 +60,7 @@ module Elasticsearch
           :expand_wildcards,
           :verbose
         ].freeze)
-end
       end
+    end
   end
 end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/shard_stores.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/shard_stores.rb
@@ -46,7 +46,7 @@ module Elasticsearch
                      "#{Utils.__listify(_index)}/_shard_stores"
                    else
                      "_shard_stores"
-      end
+                   end
           params = Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
 
           body = nil
@@ -62,7 +62,7 @@ module Elasticsearch
           :allow_no_indices,
           :expand_wildcards
         ].freeze)
-end
       end
+    end
   end
 end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/shrink.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/shrink.rb
@@ -59,7 +59,7 @@ module Elasticsearch
           :master_timeout,
           :wait_for_active_shards
         ].freeze)
-end
       end
+    end
   end
 end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/simulate_index_template.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/simulate_index_template.rb
@@ -55,7 +55,7 @@ module Elasticsearch
           :cause,
           :master_timeout
         ].freeze)
-end
       end
+    end
   end
 end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/simulate_template.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/simulate_template.rb
@@ -42,7 +42,7 @@ module Elasticsearch
                      "_index_template/_simulate/#{Utils.__listify(_name)}"
                    else
                      "_index_template/_simulate"
-      end
+                   end
           params = Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
 
           body = arguments[:body]
@@ -57,7 +57,7 @@ module Elasticsearch
           :cause,
           :master_timeout
         ].freeze)
-end
       end
+    end
   end
 end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/split.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/split.rb
@@ -59,7 +59,7 @@ module Elasticsearch
           :master_timeout,
           :wait_for_active_shards
         ].freeze)
-end
       end
+    end
   end
 end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/stats.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/stats.rb
@@ -93,7 +93,7 @@ module Elasticsearch
           :bulk,
           :metric
         ].freeze)
-end
       end
+    end
   end
 end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/update_aliases.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/update_aliases.rb
@@ -50,7 +50,7 @@ module Elasticsearch
           :timeout,
           :master_timeout
         ].freeze)
-end
       end
+    end
   end
 end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/upgrade.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/upgrade.rb
@@ -50,7 +50,7 @@ module Elasticsearch
                      "#{Utils.__listify(_index)}/_upgrade"
                    else
                      "_upgrade"
-      end
+                   end
           params = Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
 
           body = nil
@@ -67,7 +67,7 @@ module Elasticsearch
           :wait_for_completion,
           :only_ancient_segments
         ].freeze)
-end
       end
+    end
   end
 end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/validate_query.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/validate_query.rb
@@ -58,14 +58,19 @@ module Elasticsearch
 
           _type = arguments.delete(:type)
 
-          method = Elasticsearch::API::HTTP_GET
-          path   = if _index && _type
-                     "#{Utils.__listify(_index)}/#{Utils.__listify(_type)}/_validate/query"
-                   elsif _index
-                     "#{Utils.__listify(_index)}/_validate/query"
+          method = if arguments[:body]
+                     Elasticsearch::API::HTTP_POST
                    else
-                     "_validate/query"
-      end
+                     Elasticsearch::API::HTTP_GET
+                   end
+
+          path = if _index && _type
+                   "#{Utils.__listify(_index)}/#{Utils.__listify(_type)}/_validate/query"
+                 elsif _index
+                   "#{Utils.__listify(_index)}/_validate/query"
+                 else
+                   "_validate/query"
+                 end
           params = Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
 
           body = arguments[:body]
@@ -89,7 +94,7 @@ module Elasticsearch
           :rewrite,
           :all_shards
         ].freeze)
-end
       end
+    end
   end
 end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/info.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/info.rb
@@ -37,5 +37,5 @@ module Elasticsearch
         perform_request(method, path, params, body, headers).body
       end
     end
-    end
+  end
 end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/ingest/delete_pipeline.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/ingest/delete_pipeline.rb
@@ -52,7 +52,7 @@ module Elasticsearch
           :master_timeout,
           :timeout
         ].freeze)
-end
       end
+    end
   end
 end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/ingest/get_pipeline.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/ingest/get_pipeline.rb
@@ -39,7 +39,7 @@ module Elasticsearch
                      "_ingest/pipeline/#{Utils.__listify(_id)}"
                    else
                      "_ingest/pipeline"
-      end
+                   end
           params = Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
 
           body = nil
@@ -52,7 +52,7 @@ module Elasticsearch
         ParamsRegistry.register(:get_pipeline, [
           :master_timeout
         ].freeze)
-end
       end
+    end
   end
 end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/ingest/processor_grok.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/ingest/processor_grok.rb
@@ -37,7 +37,7 @@ module Elasticsearch
           body = nil
           perform_request(method, path, params, body, headers).body
         end
-end
       end
+    end
   end
 end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/ingest/put_pipeline.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/ingest/put_pipeline.rb
@@ -54,7 +54,7 @@ module Elasticsearch
           :master_timeout,
           :timeout
         ].freeze)
-end
       end
+    end
   end
 end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/ingest/simulate.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/ingest/simulate.rb
@@ -37,12 +37,17 @@ module Elasticsearch
 
           _id = arguments.delete(:id)
 
-          method = Elasticsearch::API::HTTP_GET
-          path   = if _id
-                     "_ingest/pipeline/#{Utils.__listify(_id)}/_simulate"
+          method = if arguments[:body]
+                     Elasticsearch::API::HTTP_POST
                    else
-                     "_ingest/pipeline/_simulate"
-  end
+                     Elasticsearch::API::HTTP_GET
+                   end
+
+          path = if _id
+                   "_ingest/pipeline/#{Utils.__listify(_id)}/_simulate"
+                 else
+                   "_ingest/pipeline/_simulate"
+                 end
           params = Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
 
           body = arguments[:body]
@@ -55,7 +60,7 @@ module Elasticsearch
         ParamsRegistry.register(:simulate, [
           :verbose
         ].freeze)
-end
       end
+    end
   end
 end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/mget.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/mget.rb
@@ -43,12 +43,17 @@ module Elasticsearch
 
         _index = arguments.delete(:index)
 
-        method = Elasticsearch::API::HTTP_GET
-        path   = if _index
-                   "#{Utils.__listify(_index)}/_mget"
+        method = if arguments[:body]
+                   Elasticsearch::API::HTTP_POST
                  else
-                   "_mget"
-  end
+                   Elasticsearch::API::HTTP_GET
+                 end
+
+        path = if _index
+                 "#{Utils.__listify(_index)}/_mget"
+               else
+                 "_mget"
+               end
         params = Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
 
         body = arguments[:body]
@@ -69,5 +74,5 @@ module Elasticsearch
         :_source_includes
       ].freeze)
     end
-    end
+  end
 end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/msearch.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/msearch.rb
@@ -44,12 +44,17 @@ module Elasticsearch
 
         _index = arguments.delete(:index)
 
-        method = Elasticsearch::API::HTTP_GET
-        path   = if _index
-                   "#{Utils.__listify(_index)}/_msearch"
+        method = if arguments[:body]
+                   Elasticsearch::API::HTTP_POST
                  else
-                   "_msearch"
-  end
+                   Elasticsearch::API::HTTP_GET
+                 end
+
+        path = if _index
+                 "#{Utils.__listify(_index)}/_msearch"
+               else
+                 "_msearch"
+               end
         params = Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
 
         body = arguments[:body]
@@ -75,7 +80,7 @@ module Elasticsearch
 ")
         else
           payload = body
-      end
+        end
 
         headers.merge!("Content-Type" => "application/x-ndjson")
         perform_request(method, path, params, payload, headers).body
@@ -94,5 +99,5 @@ module Elasticsearch
         :ccs_minimize_roundtrips
       ].freeze)
     end
-    end
+  end
 end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/msearch_template.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/msearch_template.rb
@@ -42,12 +42,17 @@ module Elasticsearch
 
         _index = arguments.delete(:index)
 
-        method = Elasticsearch::API::HTTP_GET
-        path   = if _index
-                   "#{Utils.__listify(_index)}/_msearch/template"
+        method = if arguments[:body]
+                   Elasticsearch::API::HTTP_POST
                  else
-                   "_msearch/template"
-  end
+                   Elasticsearch::API::HTTP_GET
+                 end
+
+        path = if _index
+                 "#{Utils.__listify(_index)}/_msearch/template"
+               else
+                 "_msearch/template"
+               end
         params = Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
 
         body = arguments[:body]
@@ -59,7 +64,7 @@ module Elasticsearch
 ")
         else
           payload = body
-      end
+        end
 
         headers.merge!("Content-Type" => "application/x-ndjson")
         perform_request(method, path, params, payload, headers).body
@@ -76,5 +81,5 @@ module Elasticsearch
         :ccs_minimize_roundtrips
       ].freeze)
     end
-    end
+  end
 end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/mtermvectors.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/mtermvectors.rb
@@ -48,19 +48,24 @@ module Elasticsearch
 
         _index = arguments.delete(:index)
 
-        method = Elasticsearch::API::HTTP_GET
-        path   = if _index
-                   "#{Utils.__listify(_index)}/_mtermvectors"
+        method = if arguments[:body]
+                   Elasticsearch::API::HTTP_POST
                  else
-                   "_mtermvectors"
-    end
+                   Elasticsearch::API::HTTP_GET
+                 end
+
+        path = if _index
+                 "#{Utils.__listify(_index)}/_mtermvectors"
+               else
+                 "_mtermvectors"
+               end
         params = Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
 
         if ids
           body = { :ids => ids }
         else
           body = arguments[:body]
-    end
+        end
         perform_request(method, path, params, body, headers).body
       end
 
@@ -82,5 +87,5 @@ module Elasticsearch
         :version_type
       ].freeze)
     end
-    end
+  end
 end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/nodes/hot_threads.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/nodes/hot_threads.rb
@@ -46,7 +46,7 @@ module Elasticsearch
                      "_nodes/#{Utils.__listify(_node_id)}/hot_threads"
                    else
                      "_nodes/hot_threads"
-      end
+                   end
           params = Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
 
           body = nil
@@ -64,7 +64,7 @@ module Elasticsearch
           :type,
           :timeout
         ].freeze)
-end
       end
+    end
   end
 end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/nodes/info.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/nodes/info.rb
@@ -49,7 +49,7 @@ module Elasticsearch
                      "_nodes/#{Utils.__listify(_metric)}"
                    else
                      "_nodes"
-      end
+                   end
           params = Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
 
           body = nil
@@ -63,7 +63,7 @@ module Elasticsearch
           :flat_settings,
           :timeout
         ].freeze)
-end
       end
+    end
   end
 end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/nodes/reload_secure_settings.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/nodes/reload_secure_settings.rb
@@ -40,7 +40,7 @@ module Elasticsearch
                      "_nodes/#{Utils.__listify(_node_id)}/reload_secure_settings"
                    else
                      "_nodes/reload_secure_settings"
-      end
+                   end
           params = Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
 
           body = arguments[:body]
@@ -53,7 +53,7 @@ module Elasticsearch
         ParamsRegistry.register(:reload_secure_settings, [
           :timeout
         ].freeze)
-end
       end
+    end
   end
 end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/nodes/stats.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/nodes/stats.rb
@@ -66,7 +66,7 @@ module Elasticsearch
                      "_nodes/stats/#{Utils.__listify(_metric)}"
                    else
                      "_nodes/stats"
-      end
+                   end
           params = Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
 
           body = nil
@@ -86,7 +86,7 @@ module Elasticsearch
           :timeout,
           :include_segment_file_sizes
         ].freeze)
-end
       end
+    end
   end
 end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/nodes/usage.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/nodes/usage.rb
@@ -48,7 +48,7 @@ module Elasticsearch
                      "_nodes/usage/#{Utils.__listify(_metric)}"
                    else
                      "_nodes/usage"
-      end
+                   end
           params = Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
 
           body = nil
@@ -61,7 +61,7 @@ module Elasticsearch
         ParamsRegistry.register(:usage, [
           :timeout
         ].freeze)
-end
       end
+    end
   end
 end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/ping.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/ping.rb
@@ -45,5 +45,5 @@ module Elasticsearch
       end
       end
     end
-    end
+  end
 end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/put_script.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/put_script.rb
@@ -47,7 +47,7 @@ module Elasticsearch
                    "_scripts/#{Utils.__listify(_id)}/#{Utils.__listify(_context)}"
                  else
                    "_scripts/#{Utils.__listify(_id)}"
-  end
+                 end
         params = Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
 
         body = arguments[:body]
@@ -63,5 +63,5 @@ module Elasticsearch
         :context
       ].freeze)
     end
-    end
+  end
 end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/rank_eval.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/rank_eval.rb
@@ -43,12 +43,17 @@ module Elasticsearch
 
         _index = arguments.delete(:index)
 
-        method = Elasticsearch::API::HTTP_GET
-        path   = if _index
-                   "#{Utils.__listify(_index)}/_rank_eval"
+        method = if arguments[:body]
+                   Elasticsearch::API::HTTP_POST
                  else
-                   "_rank_eval"
-  end
+                   Elasticsearch::API::HTTP_GET
+                 end
+
+        path = if _index
+                 "#{Utils.__listify(_index)}/_rank_eval"
+               else
+                 "_rank_eval"
+               end
         params = Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
 
         body = arguments[:body]
@@ -65,5 +70,5 @@ module Elasticsearch
         :search_type
       ].freeze)
     end
-    end
+  end
 end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/reindex.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/reindex.rb
@@ -64,5 +64,5 @@ module Elasticsearch
         :max_docs
       ].freeze)
     end
-    end
+  end
 end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/reindex_rethrottle.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/reindex_rethrottle.rb
@@ -50,5 +50,5 @@ module Elasticsearch
         :requests_per_second
       ].freeze)
     end
-    end
+  end
 end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/render_search_template.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/render_search_template.rb
@@ -33,17 +33,22 @@ module Elasticsearch
 
         _id = arguments.delete(:id)
 
-        method = Elasticsearch::API::HTTP_GET
-        path   = if _id
-                   "_render/template/#{Utils.__listify(_id)}"
+        method = if arguments[:body]
+                   Elasticsearch::API::HTTP_POST
                  else
-                   "_render/template"
-    end
+                   Elasticsearch::API::HTTP_GET
+                 end
+
+        path = if _id
+                 "_render/template/#{Utils.__listify(_id)}"
+               else
+                 "_render/template"
+               end
         params = {}
 
         body = arguments[:body]
         perform_request(method, path, params, body, headers).body
       end
     end
-    end
+  end
 end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/scripts_painless_execute.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/scripts_painless_execute.rb
@@ -30,13 +30,18 @@ module Elasticsearch
 
         arguments = arguments.clone
 
-        method = Elasticsearch::API::HTTP_GET
-        path   = "_scripts/painless/_execute"
+        method = if arguments[:body]
+                   Elasticsearch::API::HTTP_POST
+                 else
+                   Elasticsearch::API::HTTP_GET
+                 end
+
+        path = "_scripts/painless/_execute"
         params = {}
 
         body = arguments[:body]
         perform_request(method, path, params, body, headers).body
       end
     end
-    end
+  end
 end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/scroll.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/scroll.rb
@@ -41,12 +41,17 @@ module Elasticsearch
 
         _scroll_id = arguments.delete(:scroll_id)
 
-        method = Elasticsearch::API::HTTP_GET
-        path   = if _scroll_id
-                   "_search/scroll/#{Utils.__listify(_scroll_id)}"
+        method = if arguments[:body]
+                   Elasticsearch::API::HTTP_POST
                  else
-                   "_search/scroll"
-    end
+                   Elasticsearch::API::HTTP_GET
+                 end
+
+        path = if _scroll_id
+                 "_search/scroll/#{Utils.__listify(_scroll_id)}"
+               else
+                 "_search/scroll"
+               end
         params = Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
 
         body = arguments[:body]
@@ -62,5 +67,5 @@ module Elasticsearch
         :rest_total_hits_as_int
       ].freeze)
     end
-    end
+  end
 end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/search.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/search.rb
@@ -84,12 +84,17 @@ module Elasticsearch
 
         _index = arguments.delete(:index)
 
-        method = Elasticsearch::API::HTTP_GET
-        path   = if _index
-                   "#{Utils.__listify(_index)}/_search"
+        method = if arguments[:body]
+                   Elasticsearch::API::HTTP_POST
                  else
-                   "_search"
-    end
+                   Elasticsearch::API::HTTP_GET
+                 end
+
+        path = if _index
+                 "#{Utils.__listify(_index)}/_search"
+               else
+                 "_search"
+               end
         params = Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
 
         body = arguments[:body]
@@ -144,5 +149,5 @@ module Elasticsearch
         :rest_total_hits_as_int
       ].freeze)
     end
-    end
+  end
 end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/search_shards.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/search_shards.rb
@@ -45,7 +45,7 @@ module Elasticsearch
                    "#{Utils.__listify(_index)}/_search_shards"
                  else
                    "_search_shards"
-    end
+                 end
         params = Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
 
         body = nil
@@ -64,5 +64,5 @@ module Elasticsearch
         :expand_wildcards
       ].freeze)
     end
-    end
+  end
 end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/search_template.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/search_template.rb
@@ -52,12 +52,17 @@ module Elasticsearch
 
         _index = arguments.delete(:index)
 
-        method = Elasticsearch::API::HTTP_GET
-        path   = if _index
-                   "#{Utils.__listify(_index)}/_search/template"
+        method = if arguments[:body]
+                   Elasticsearch::API::HTTP_POST
                  else
-                   "_search/template"
-  end
+                   Elasticsearch::API::HTTP_GET
+                 end
+
+        path = if _index
+                 "#{Utils.__listify(_index)}/_search/template"
+               else
+                 "_search/template"
+               end
         params = Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
 
         body = arguments[:body]
@@ -83,5 +88,5 @@ module Elasticsearch
         :ccs_minimize_roundtrips
       ].freeze)
     end
-    end
+  end
 end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/snapshot/cleanup_repository.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/snapshot/cleanup_repository.rb
@@ -52,7 +52,7 @@ module Elasticsearch
           :master_timeout,
           :timeout
         ].freeze)
-end
       end
+    end
   end
 end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/snapshot/create.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/snapshot/create.rb
@@ -57,7 +57,7 @@ module Elasticsearch
           :master_timeout,
           :wait_for_completion
         ].freeze)
-end
       end
+    end
   end
 end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/snapshot/create_repository.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/snapshot/create_repository.rb
@@ -56,7 +56,7 @@ module Elasticsearch
           :timeout,
           :verify
         ].freeze)
-end
       end
+    end
   end
 end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/snapshot/delete.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/snapshot/delete.rb
@@ -58,7 +58,7 @@ module Elasticsearch
         ParamsRegistry.register(:delete, [
           :master_timeout
         ].freeze)
-end
       end
+    end
   end
 end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/snapshot/delete_repository.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/snapshot/delete_repository.rb
@@ -56,7 +56,7 @@ module Elasticsearch
           :master_timeout,
           :timeout
         ].freeze)
-end
       end
+    end
   end
 end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/snapshot/get.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/snapshot/get.rb
@@ -62,7 +62,7 @@ module Elasticsearch
           :ignore_unavailable,
           :verbose
         ].freeze)
-end
       end
+    end
   end
 end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/snapshot/get_repository.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/snapshot/get_repository.rb
@@ -40,7 +40,7 @@ module Elasticsearch
                      "_snapshot/#{Utils.__listify(_repository)}"
                    else
                      "_snapshot"
-      end
+                   end
           params = Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
 
           body = nil
@@ -58,7 +58,7 @@ module Elasticsearch
           :master_timeout,
           :local
         ].freeze)
-end
       end
+    end
   end
 end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/snapshot/restore.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/snapshot/restore.rb
@@ -57,7 +57,7 @@ module Elasticsearch
           :master_timeout,
           :wait_for_completion
         ].freeze)
-end
       end
+    end
   end
 end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/snapshot/status.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/snapshot/status.rb
@@ -45,7 +45,7 @@ module Elasticsearch
                      "_snapshot/#{Utils.__listify(_repository)}/_status"
                    else
                      "_snapshot/_status"
-      end
+                   end
           params = Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
 
           body = nil
@@ -63,7 +63,7 @@ module Elasticsearch
           :master_timeout,
           :ignore_unavailable
         ].freeze)
-end
       end
+    end
   end
 end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/snapshot/verify_repository.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/snapshot/verify_repository.rb
@@ -52,7 +52,7 @@ module Elasticsearch
           :master_timeout,
           :timeout
         ].freeze)
-end
       end
+    end
   end
 end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/tasks/cancel.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/tasks/cancel.rb
@@ -42,7 +42,7 @@ module Elasticsearch
                      "_tasks/#{Utils.__listify(_task_id)}/_cancel"
                    else
                      "_tasks/_cancel"
-      end
+                   end
           params = Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
 
           body = nil
@@ -58,7 +58,7 @@ module Elasticsearch
           :parent_task_id,
           :wait_for_completion
         ].freeze)
-end
       end
+    end
   end
 end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/tasks/get.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/tasks/get.rb
@@ -50,7 +50,7 @@ module Elasticsearch
           :wait_for_completion,
           :timeout
         ].freeze)
-end
       end
+    end
   end
 end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/tasks/list.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/tasks/list.rb
@@ -59,7 +59,7 @@ module Elasticsearch
           :group_by,
           :timeout
         ].freeze)
-end
       end
+    end
   end
 end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/termvectors.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/termvectors.rb
@@ -51,14 +51,18 @@ module Elasticsearch
 
         _id = arguments.delete(:id)
 
-        method = Elasticsearch::API::HTTP_GET
+        method = if arguments[:body]
+                   Elasticsearch::API::HTTP_POST
+                 else
+                   Elasticsearch::API::HTTP_GET
+                 end
 
         endpoint = arguments.delete(:endpoint) || '_termvectors'
         path = if _index && _id
                  "#{Utils.__listify(_index)}/_termvectors/#{Utils.__listify(_id)}"
                else
                  "#{Utils.__listify(_index)}/_termvectors"
-  end
+               end
         params = Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
 
         body = arguments[:body]
@@ -87,5 +91,5 @@ module Elasticsearch
         :version_type
       ].freeze)
     end
-    end
+  end
 end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/update.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/update.rb
@@ -66,7 +66,7 @@ module Elasticsearch
                    "#{Utils.__listify(_index)}/#{Utils.__listify(_type)}/#{Utils.__listify(_id)}/_update"
                  else
                    "#{Utils.__listify(_index)}/_update/#{Utils.__listify(_id)}"
-  end
+                 end
         params = Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
 
         body = arguments[:body]
@@ -94,5 +94,5 @@ module Elasticsearch
         :if_primary_term
       ].freeze)
     end
-    end
+  end
 end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/update_by_query.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/update_by_query.rb
@@ -126,5 +126,5 @@ module Elasticsearch
         :slices
       ].freeze)
     end
-    end
+  end
 end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/update_by_query_rethrottle.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/update_by_query_rethrottle.rb
@@ -50,5 +50,5 @@ module Elasticsearch
         :requests_per_second
       ].freeze)
     end
-    end
+  end
 end

--- a/elasticsearch-api/spec/elasticsearch/api/actions/count_spec.rb
+++ b/elasticsearch-api/spec/elasticsearch/api/actions/count_spec.rb
@@ -21,7 +21,7 @@ describe 'client#count' do
 
   let(:expected_args) do
     [
-      'GET',
+      'POST',
       '_count',
       {},
       nil,
@@ -37,7 +37,7 @@ describe 'client#count' do
 
     let(:expected_args) do
       [
-        'GET',
+        'POST',
         'foo,bar/_count',
         {},
         nil,

--- a/elasticsearch-api/spec/elasticsearch/api/actions/explain_document_spec.rb
+++ b/elasticsearch-api/spec/elasticsearch/api/actions/explain_document_spec.rb
@@ -18,16 +18,17 @@
 require 'spec_helper'
 
 describe 'client#explain' do
-
   let(:expected_args) do
     [
-        'GET',
-        url,
-        params,
-        body,
-        {}
+      method,
+      url,
+      params,
+      body,
+      {}
     ]
   end
+
+  let(:method) { 'POST' }
 
   let(:params) do
     {}
@@ -62,7 +63,7 @@ describe 'client#explain' do
   end
 
   context 'when a query is provided' do
-
+    let(:method) { 'GET' }
     let(:params) do
       { q: 'abc123' }
     end
@@ -77,7 +78,6 @@ describe 'client#explain' do
   end
 
   context 'when a query definition is provided' do
-
     let(:body) do
       { query: { match: {} } }
     end
@@ -88,7 +88,6 @@ describe 'client#explain' do
   end
 
   context 'when the request needs to be URL-escaped' do
-
     let(:url) do
       'foo%5Ebar/_explain/1'
     end

--- a/elasticsearch-api/spec/elasticsearch/api/actions/indices/analyze_spec.rb
+++ b/elasticsearch-api/spec/elasticsearch/api/actions/indices/analyze_spec.rb
@@ -18,16 +18,16 @@
 require 'spec_helper'
 
 describe 'client.indices#analyze' do
-
   let(:expected_args) do
     [
-        'GET',
-        url,
-        params,
-        body,
-        {}
+      method,
+      url,
+      params,
+      body,
+      {}
     ]
   end
+  let(:method) { 'GET' }
 
   let(:body) do
     nil
@@ -46,7 +46,6 @@ describe 'client.indices#analyze' do
   end
 
   context 'when an index is specified' do
-
     let(:url) do
       'foo/_analyze'
     end
@@ -57,10 +56,10 @@ describe 'client.indices#analyze' do
   end
 
   context 'when a body is specified' do
-
     let(:body) do
       'foo'
     end
+    let(:method) { 'POST' }
 
     it 'performs the request' do
       expect(client_double.indices.analyze(body: 'foo')).to eq({})

--- a/elasticsearch-api/spec/elasticsearch/api/actions/indices/validate_query_spec.rb
+++ b/elasticsearch-api/spec/elasticsearch/api/actions/indices/validate_query_spec.rb
@@ -18,16 +18,16 @@
 require 'spec_helper'
 
 describe 'client.cluster#validate_query' do
-
   let(:expected_args) do
     [
-        'GET',
-        url,
-        params,
-        body,
-        {}
+      method,
+      url,
+      params,
+      body,
+      {}
     ]
   end
+  let(:method) { 'GET' }
 
   let(:url) do
     '_validate/query'
@@ -46,7 +46,6 @@ describe 'client.cluster#validate_query' do
   end
 
   context 'when an index is specified' do
-
     let(:url) do
       'foo/_validate/query'
     end
@@ -57,7 +56,6 @@ describe 'client.cluster#validate_query' do
   end
 
   context 'when a type and index are specified' do
-
     let(:url) do
       'foo/bar/_validate/query'
     end
@@ -68,7 +66,6 @@ describe 'client.cluster#validate_query' do
   end
 
   context 'when multiple indicies are specified as a list' do
-
     let(:url) do
       'foo,bar/_validate/query'
     end
@@ -79,7 +76,6 @@ describe 'client.cluster#validate_query' do
   end
 
   context 'when multiple indicies are specified as a string' do
-
     let(:url) do
       'foo,bar/_validate/query'
     end
@@ -90,7 +86,6 @@ describe 'client.cluster#validate_query' do
   end
 
   context 'when parameters are specified' do
-
     let(:params) do
       { explain: true, q: 'foo' }
     end
@@ -105,10 +100,10 @@ describe 'client.cluster#validate_query' do
   end
 
   context 'when a body is specified' do
-
     let(:body) do
       { filtered: {} }
     end
+    let(:method) { 'POST' }
 
     it 'performs the request' do
       expect(client_double.indices.validate_query(body: { filtered: {} })).to eq({})
@@ -116,7 +111,6 @@ describe 'client.cluster#validate_query' do
   end
 
   context 'when the path needs to be URL-escaped' do
-
     let(:url) do
       'foo%5Ebar/_validate/query'
     end

--- a/elasticsearch-api/spec/elasticsearch/api/actions/ingest/simulate_spec.rb
+++ b/elasticsearch-api/spec/elasticsearch/api/actions/ingest/simulate_spec.rb
@@ -18,16 +18,16 @@
 require 'spec_helper'
 
 describe 'client.ingest#simulate' do
-
   let(:expected_args) do
     [
-        'GET',
-        url,
-        {},
-        {},
-        {}
+      method,
+      url,
+      {},
+      {},
+      {}
     ]
   end
+  let(:method) { 'POST' }
 
   let(:url) do
     '_ingest/pipeline/_simulate'
@@ -38,7 +38,6 @@ describe 'client.ingest#simulate' do
   end
 
   context 'when a pipeline id is provided' do
-
     let(:url) do
       '_ingest/pipeline/foo/_simulate'
     end

--- a/elasticsearch-api/spec/elasticsearch/api/actions/json_builders_spec.rb
+++ b/elasticsearch-api/spec/elasticsearch/api/actions/json_builders_spec.rb
@@ -18,16 +18,14 @@
 require 'spec_helper'
 
 describe 'JSON builders' do
-
   context 'JBuilder' do
-
     let(:expected_args) do
       [
-          'GET',
-          '_search',
-          {},
-          body,
-          {}
+        'POST',
+        '_search',
+        {},
+        body,
+        {}
       ]
     end
 
@@ -53,14 +51,13 @@ describe 'JSON builders' do
   end
 
   context 'Jsonify' do
-
     let(:expected_args) do
       [
-          'GET',
-          '_search',
-          {},
-          body,
-          {}
+        'POST',
+        '_search',
+        {},
+        body,
+        {}
       ]
     end
 

--- a/elasticsearch-api/spec/elasticsearch/api/actions/mget_spec.rb
+++ b/elasticsearch-api/spec/elasticsearch/api/actions/mget_spec.rb
@@ -18,14 +18,13 @@
 require 'spec_helper'
 
 describe 'client#mget' do
-
   let(:expected_args) do
     [
-        'GET',
-        url,
-        params,
-        body,
-        {}
+      'POST',
+      url,
+      params,
+      body,
+      {}
     ]
   end
 

--- a/elasticsearch-api/spec/elasticsearch/api/actions/msearch_spec.rb
+++ b/elasticsearch-api/spec/elasticsearch/api/actions/msearch_spec.rb
@@ -18,14 +18,13 @@
 require 'spec_helper'
 
 describe 'client#msearch' do
-
   let(:expected_args) do
     [
-        'GET',
-        url,
-        params,
-        body,
-        headers
+      'POST',
+      url,
+      params,
+      body,
+      headers
     ]
   end
 

--- a/elasticsearch-api/spec/elasticsearch/api/actions/msearch_template_spec.rb
+++ b/elasticsearch-api/spec/elasticsearch/api/actions/msearch_template_spec.rb
@@ -18,14 +18,13 @@
 require 'spec_helper'
 
 describe 'client#msearch_template' do
-
   let(:expected_args) do
     [
-        'GET',
-        url,
-        params,
-        body,
-        headers
+      'POST',
+      url,
+      params,
+      body,
+      headers
     ]
   end
 

--- a/elasticsearch-api/spec/elasticsearch/api/actions/mtermvectors_spec.rb
+++ b/elasticsearch-api/spec/elasticsearch/api/actions/mtermvectors_spec.rb
@@ -18,16 +18,16 @@
 require 'spec_helper'
 
 describe 'client#mtermvectors' do
-
   let(:expected_args) do
     [
-        'GET',
-        'my-index/_mtermvectors',
-        { },
-        body,
-        {}
+      method,
+      'my-index/_mtermvectors',
+      {},
+      body,
+      {}
     ]
   end
+  let(:method) { 'POST' }
 
   let(:body) do
     { ids: [1, 2, 3] }
@@ -38,7 +38,7 @@ describe 'client#mtermvectors' do
   end
 
   context 'when a list of ids is passed instead of a body' do
-
+    let(:method) { 'GET' }
     it 'performs the request' do
       expect(client_double.mtermvectors(index: 'my-index', ids: [1, 2, 3])).to eq({})
     end

--- a/elasticsearch-api/spec/elasticsearch/api/actions/rank_eval_spec.rb
+++ b/elasticsearch-api/spec/elasticsearch/api/actions/rank_eval_spec.rb
@@ -8,11 +8,11 @@ describe 'client#rank_eval' do
 
   let(:expected_args) do
     [
-        'GET',
-        url,
-        params,
-        body,
-        {}
+      'POST',
+      url,
+      params,
+      body,
+      {}
     ]
   end
 

--- a/elasticsearch-api/spec/elasticsearch/api/actions/render_search_template_spec.rb
+++ b/elasticsearch-api/spec/elasticsearch/api/actions/render_search_template_spec.rb
@@ -21,7 +21,7 @@ describe 'client#render_search_template' do
   context 'when no id is specified' do
     let(:expected_args) do
       [
-        'GET',
+        'POST',
         '_render/template',
         {},
         { foo: 'bar' },
@@ -37,7 +37,7 @@ describe 'client#render_search_template' do
   context 'when id is specified' do
     let(:expected_args) do
       [
-        'GET',
+        'POST',
         '_render/template/foo',
         {},
         { foo: 'bar' },

--- a/elasticsearch-api/spec/elasticsearch/api/actions/scroll_spec.rb
+++ b/elasticsearch-api/spec/elasticsearch/api/actions/scroll_spec.rb
@@ -37,7 +37,7 @@ describe 'client#scroll' do
   context 'with scroll_id in the body' do
     let(:expected_args) do
       [
-        'GET',
+        'POST',
         '_search/scroll',
         {},
         { scroll_id: 'cXVlcn...' },

--- a/elasticsearch-api/spec/elasticsearch/api/actions/search_spec.rb
+++ b/elasticsearch-api/spec/elasticsearch/api/actions/search_spec.rb
@@ -18,16 +18,16 @@
 require 'spec_helper'
 
 describe 'client#search' do
-
   let(:expected_args) do
     [
-        'GET',
-        url,
-        params,
-        body,
-        {}
+      method,
+      url,
+      params,
+      body,
+      {}
     ]
   end
+  let(:method) { 'GET' }
 
   let(:body) do
     nil
@@ -46,10 +46,10 @@ describe 'client#search' do
   end
 
   context 'when a request definition is specified' do
-
     let(:body) do
       { query: { match: {} } }
     end
+    let(:method) { 'POST' }
 
     let(:url) do
       '_search'

--- a/elasticsearch-api/spec/elasticsearch/api/actions/search_template_spec.rb
+++ b/elasticsearch-api/spec/elasticsearch/api/actions/search_template_spec.rb
@@ -18,14 +18,13 @@
 require 'spec_helper'
 
 describe 'client#search_template' do
-
   let(:expected_args) do
     [
-        'GET',
-        'foo/_search/template',
-        { },
-        { foo: 'bar' },
-        {}
+      'POST',
+      'foo/_search/template',
+      { },
+      { foo: 'bar' },
+      {}
     ]
   end
 

--- a/elasticsearch-api/spec/elasticsearch/api/actions/termvectors_spec.rb
+++ b/elasticsearch-api/spec/elasticsearch/api/actions/termvectors_spec.rb
@@ -18,14 +18,13 @@
 require 'spec_helper'
 
 describe 'client#termvectors' do
-
   let(:expected_args) do
     [
-        'GET',
-        url,
-        params,
-        body,
-        {}
+      'POST',
+      url,
+      params,
+      body,
+      {}
     ]
   end
 
@@ -56,7 +55,6 @@ describe 'client#termvectors' do
   end
 
   context 'when the older api name \'termvector\' is used' do
-
     let(:url) do
       'foo/_termvectors/123'
     end

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/async_search/delete.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/async_search/delete.rb
@@ -43,8 +43,8 @@ module Elasticsearch
             body = nil
             perform_request(method, path, params, body, headers).body
           end
+        end
       end
-    end
     end
   end
 end

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/async_search/get.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/async_search/get.rb
@@ -55,8 +55,8 @@ module Elasticsearch
             :keep_alive,
             :typed_keys
           ].freeze)
+        end
       end
-    end
     end
   end
 end

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/async_search/submit.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/async_search/submit.rb
@@ -89,7 +89,7 @@ module Elasticsearch
                        "#{Elasticsearch::API::Utils.__listify(_index)}/_async_search"
                      else
                        "_async_search"
-            end
+                     end
             params = Elasticsearch::API::Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
 
             body = arguments[:body]
@@ -142,8 +142,8 @@ module Elasticsearch
             :seq_no_primary_term,
             :max_concurrent_shard_requests
           ].freeze)
+        end
       end
-    end
     end
   end
 end

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/autoscaling/delete_autoscaling_policy.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/autoscaling/delete_autoscaling_policy.rb
@@ -43,8 +43,8 @@ module Elasticsearch
             body = nil
             perform_request(method, path, params, body, headers).body
           end
+        end
       end
-    end
     end
   end
 end

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/autoscaling/get_autoscaling_decision.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/autoscaling/get_autoscaling_decision.rb
@@ -38,8 +38,8 @@ module Elasticsearch
             body = nil
             perform_request(method, path, params, body, headers).body
           end
+        end
       end
-    end
     end
   end
 end

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/autoscaling/get_autoscaling_policy.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/autoscaling/get_autoscaling_policy.rb
@@ -43,8 +43,8 @@ module Elasticsearch
             body = nil
             perform_request(method, path, params, body, headers).body
           end
+        end
       end
-    end
     end
   end
 end

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/autoscaling/put_autoscaling_policy.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/autoscaling/put_autoscaling_policy.rb
@@ -45,8 +45,8 @@ module Elasticsearch
             body = arguments[:body]
             perform_request(method, path, params, body, headers).body
           end
+        end
       end
-    end
     end
   end
 end

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/cat/ml_data_frame_analytics.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/cat/ml_data_frame_analytics.rb
@@ -51,7 +51,7 @@ module Elasticsearch
                        "_cat/ml/data_frame/analytics/#{Elasticsearch::API::Utils.__listify(_id)}"
                      else
                        "_cat/ml/data_frame/analytics"
-            end
+                     end
             params = Elasticsearch::API::Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
 
             body = nil
@@ -71,8 +71,8 @@ module Elasticsearch
             :time,
             :v
           ].freeze)
+        end
       end
-    end
     end
   end
 end

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/cat/ml_datafeeds.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/cat/ml_datafeeds.rb
@@ -48,7 +48,7 @@ module Elasticsearch
                        "_cat/ml/datafeeds/#{Elasticsearch::API::Utils.__listify(_datafeed_id)}"
                      else
                        "_cat/ml/datafeeds"
-            end
+                     end
             params = Elasticsearch::API::Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
 
             body = nil
@@ -67,8 +67,8 @@ module Elasticsearch
             :time,
             :v
           ].freeze)
+        end
       end
-    end
     end
   end
 end

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/cat/ml_jobs.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/cat/ml_jobs.rb
@@ -51,7 +51,7 @@ module Elasticsearch
                        "_cat/ml/anomaly_detectors/#{Elasticsearch::API::Utils.__listify(_job_id)}"
                      else
                        "_cat/ml/anomaly_detectors"
-            end
+                     end
             params = Elasticsearch::API::Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
 
             body = nil
@@ -71,8 +71,8 @@ module Elasticsearch
             :time,
             :v
           ].freeze)
+        end
       end
-    end
     end
   end
 end

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/cat/ml_trained_models.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/cat/ml_trained_models.rb
@@ -53,7 +53,7 @@ module Elasticsearch
                        "_cat/ml/trained_models/#{Elasticsearch::API::Utils.__listify(_model_id)}"
                      else
                        "_cat/ml/trained_models"
-            end
+                     end
             params = Elasticsearch::API::Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
 
             body = nil
@@ -75,8 +75,8 @@ module Elasticsearch
             :time,
             :v
           ].freeze)
+        end
       end
-    end
     end
   end
 end

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/cat/transform.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/cat/transform.rb
@@ -49,7 +49,7 @@ module Elasticsearch
                        "_cat/transforms/#{Elasticsearch::API::Utils.__listify(_transform_id)}"
                      else
                        "_cat/transforms"
-  end
+                     end
             params = Elasticsearch::API::Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
 
             body = nil
@@ -70,8 +70,8 @@ module Elasticsearch
             :time,
             :v
           ].freeze)
+        end
       end
-    end
     end
   end
 end

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/cat/transforms.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/cat/transforms.rb
@@ -50,7 +50,7 @@ module Elasticsearch
                        "_cat/transforms/#{Elasticsearch::API::Utils.__listify(_transform_id)}"
                      else
                        "_cat/transforms"
-            end
+                     end
             params = Elasticsearch::API::Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
 
             body = nil
@@ -71,8 +71,8 @@ module Elasticsearch
             :time,
             :v
           ].freeze)
+        end
       end
-    end
     end
   end
 end

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/cross_cluster_replication/delete_auto_follow_pattern.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/cross_cluster_replication/delete_auto_follow_pattern.rb
@@ -43,8 +43,8 @@ module Elasticsearch
             body = nil
             perform_request(method, path, params, body, headers).body
           end
+        end
       end
-    end
     end
   end
 end

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/cross_cluster_replication/follow.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/cross_cluster_replication/follow.rb
@@ -53,8 +53,8 @@ module Elasticsearch
           ParamsRegistry.register(:follow, [
             :wait_for_active_shards
           ].freeze)
+        end
       end
-    end
     end
   end
 end

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/cross_cluster_replication/follow_info.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/cross_cluster_replication/follow_info.rb
@@ -43,8 +43,8 @@ module Elasticsearch
             body = nil
             perform_request(method, path, params, body, headers).body
           end
+        end
       end
-    end
     end
   end
 end

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/cross_cluster_replication/follow_stats.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/cross_cluster_replication/follow_stats.rb
@@ -43,8 +43,8 @@ module Elasticsearch
             body = nil
             perform_request(method, path, params, body, headers).body
           end
+        end
       end
-    end
     end
   end
 end

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/cross_cluster_replication/forget_follower.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/cross_cluster_replication/forget_follower.rb
@@ -45,8 +45,8 @@ module Elasticsearch
             body = arguments[:body]
             perform_request(method, path, params, body, headers).body
           end
+        end
       end
-    end
     end
   end
 end

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/cross_cluster_replication/get_auto_follow_pattern.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/cross_cluster_replication/get_auto_follow_pattern.rb
@@ -39,14 +39,14 @@ module Elasticsearch
                        "_ccr/auto_follow/#{Elasticsearch::API::Utils.__listify(_name)}"
                      else
                        "_ccr/auto_follow"
-            end
+                     end
             params = {}
 
             body = nil
             perform_request(method, path, params, body, headers).body
           end
+        end
       end
-    end
     end
   end
 end

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/cross_cluster_replication/pause_auto_follow_pattern.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/cross_cluster_replication/pause_auto_follow_pattern.rb
@@ -43,8 +43,8 @@ module Elasticsearch
             body = nil
             perform_request(method, path, params, body, headers).body
           end
+        end
       end
-    end
     end
   end
 end

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/cross_cluster_replication/pause_follow.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/cross_cluster_replication/pause_follow.rb
@@ -43,8 +43,8 @@ module Elasticsearch
             body = nil
             perform_request(method, path, params, body, headers).body
           end
+        end
       end
-    end
     end
   end
 end

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/cross_cluster_replication/put_auto_follow_pattern.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/cross_cluster_replication/put_auto_follow_pattern.rb
@@ -45,8 +45,8 @@ module Elasticsearch
             body = arguments[:body]
             perform_request(method, path, params, body, headers).body
           end
+        end
       end
-    end
     end
   end
 end

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/cross_cluster_replication/resume_auto_follow_pattern.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/cross_cluster_replication/resume_auto_follow_pattern.rb
@@ -43,8 +43,8 @@ module Elasticsearch
             body = nil
             perform_request(method, path, params, body, headers).body
           end
+        end
       end
-    end
     end
   end
 end

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/cross_cluster_replication/resume_follow.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/cross_cluster_replication/resume_follow.rb
@@ -44,8 +44,8 @@ module Elasticsearch
             body = arguments[:body]
             perform_request(method, path, params, body, headers).body
           end
+        end
       end
-    end
     end
   end
 end

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/cross_cluster_replication/stats.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/cross_cluster_replication/stats.rb
@@ -38,8 +38,8 @@ module Elasticsearch
             body = nil
             perform_request(method, path, params, body, headers).body
           end
+        end
       end
-    end
     end
   end
 end

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/cross_cluster_replication/unfollow.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/cross_cluster_replication/unfollow.rb
@@ -43,8 +43,8 @@ module Elasticsearch
             body = nil
             perform_request(method, path, params, body, headers).body
           end
+        end
       end
-    end
     end
   end
 end

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/data_frame_transform_deprecated/delete_transform.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/data_frame_transform_deprecated/delete_transform.rb
@@ -56,8 +56,8 @@ module Elasticsearch
           ParamsRegistry.register(:delete_transform, [
             :force
           ].freeze)
+        end
       end
-    end
     end
   end
 end

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/data_frame_transform_deprecated/get_transform.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/data_frame_transform_deprecated/get_transform.rb
@@ -47,7 +47,7 @@ module Elasticsearch
                        "_data_frame/transforms/#{Elasticsearch::API::Utils.__listify(_transform_id)}"
                      else
                        "_data_frame/transforms"
-            end
+                     end
             params = Elasticsearch::API::Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
 
             body = nil
@@ -62,8 +62,8 @@ module Elasticsearch
             :size,
             :allow_no_match
           ].freeze)
+        end
       end
-    end
     end
   end
 end

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/data_frame_transform_deprecated/get_transform_stats.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/data_frame_transform_deprecated/get_transform_stats.rb
@@ -60,8 +60,8 @@ module Elasticsearch
             :size,
             :allow_no_match
           ].freeze)
+        end
       end
-    end
     end
   end
 end

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/data_frame_transform_deprecated/preview_transform.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/data_frame_transform_deprecated/preview_transform.rb
@@ -46,8 +46,8 @@ module Elasticsearch
             body = arguments[:body]
             perform_request(method, path, params, body, headers).body
           end
+        end
       end
-    end
     end
   end
 end

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/data_frame_transform_deprecated/put_transform.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/data_frame_transform_deprecated/put_transform.rb
@@ -58,8 +58,8 @@ module Elasticsearch
           ParamsRegistry.register(:put_transform, [
             :defer_validation
           ].freeze)
+        end
       end
-    end
     end
   end
 end

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/data_frame_transform_deprecated/start_transform.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/data_frame_transform_deprecated/start_transform.rb
@@ -56,8 +56,8 @@ module Elasticsearch
           ParamsRegistry.register(:start_transform, [
             :timeout
           ].freeze)
+        end
       end
-    end
     end
   end
 end

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/data_frame_transform_deprecated/stop_transform.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/data_frame_transform_deprecated/stop_transform.rb
@@ -60,8 +60,8 @@ module Elasticsearch
             :timeout,
             :allow_no_match
           ].freeze)
+        end
       end
-    end
     end
   end
 end

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/data_frame_transform_deprecated/update_transform.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/data_frame_transform_deprecated/update_transform.rb
@@ -58,8 +58,8 @@ module Elasticsearch
           ParamsRegistry.register(:update_transform, [
             :defer_validation
           ].freeze)
+        end
       end
-    end
     end
   end
 end

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/enrich/delete_policy.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/enrich/delete_policy.rb
@@ -43,8 +43,8 @@ module Elasticsearch
             body = nil
             perform_request(method, path, params, body, headers).body
           end
+        end
       end
-    end
     end
   end
 end

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/enrich/execute_policy.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/enrich/execute_policy.rb
@@ -51,8 +51,8 @@ module Elasticsearch
           ParamsRegistry.register(:execute_policy, [
             :wait_for_completion
           ].freeze)
+        end
       end
-    end
     end
   end
 end

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/enrich/get_policy.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/enrich/get_policy.rb
@@ -39,14 +39,14 @@ module Elasticsearch
                        "_enrich/policy/#{Elasticsearch::API::Utils.__listify(_name)}"
                      else
                        "_enrich/policy"
-            end
+                     end
             params = {}
 
             body = nil
             perform_request(method, path, params, body, headers).body
           end
+        end
       end
-    end
     end
   end
 end

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/enrich/put_policy.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/enrich/put_policy.rb
@@ -45,8 +45,8 @@ module Elasticsearch
             body = arguments[:body]
             perform_request(method, path, params, body, headers).body
           end
+        end
       end
-    end
     end
   end
 end

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/enrich/stats.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/enrich/stats.rb
@@ -38,8 +38,8 @@ module Elasticsearch
             body = nil
             perform_request(method, path, params, body, headers).body
           end
+        end
       end
-    end
     end
   end
 end

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/graph/explore.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/graph/explore.rb
@@ -39,8 +39,13 @@ module Elasticsearch
 
             _index = arguments.delete(:index)
 
-            method = Elasticsearch::API::HTTP_GET
-            path   = "#{Elasticsearch::API::Utils.__listify(_index)}/_graph/explore"
+            method = if arguments[:body]
+                       Elasticsearch::API::HTTP_POST
+                     else
+                       Elasticsearch::API::HTTP_GET
+                     end
+
+            path = "#{Elasticsearch::API::Utils.__listify(_index)}/_graph/explore"
             params = Elasticsearch::API::Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
 
             body = arguments[:body]
@@ -54,8 +59,8 @@ module Elasticsearch
             :routing,
             :timeout
           ].freeze)
+        end
       end
-    end
     end
   end
 end

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/index_lifecycle_management/delete_lifecycle.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/index_lifecycle_management/delete_lifecycle.rb
@@ -43,8 +43,8 @@ module Elasticsearch
             body = nil
             perform_request(method, path, params, body, headers).body
           end
+        end
       end
-    end
     end
   end
 end

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/index_lifecycle_management/explain_lifecycle.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/index_lifecycle_management/explain_lifecycle.rb
@@ -53,8 +53,8 @@ module Elasticsearch
             :only_managed,
             :only_errors
           ].freeze)
+        end
       end
-    end
     end
   end
 end

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/index_lifecycle_management/get_lifecycle.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/index_lifecycle_management/get_lifecycle.rb
@@ -39,14 +39,14 @@ module Elasticsearch
                        "_ilm/policy/#{Elasticsearch::API::Utils.__listify(_policy)}"
                      else
                        "_ilm/policy"
-            end
+                     end
             params = {}
 
             body = nil
             perform_request(method, path, params, body, headers).body
           end
+        end
       end
-    end
     end
   end
 end

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/index_lifecycle_management/get_status.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/index_lifecycle_management/get_status.rb
@@ -38,8 +38,8 @@ module Elasticsearch
             body = nil
             perform_request(method, path, params, body, headers).body
           end
+        end
       end
-    end
     end
   end
 end

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/index_lifecycle_management/move_to_step.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/index_lifecycle_management/move_to_step.rb
@@ -44,8 +44,8 @@ module Elasticsearch
             body = arguments[:body]
             perform_request(method, path, params, body, headers).body
           end
+        end
       end
-    end
     end
   end
 end

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/index_lifecycle_management/put_lifecycle.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/index_lifecycle_management/put_lifecycle.rb
@@ -44,8 +44,8 @@ module Elasticsearch
             body = arguments[:body]
             perform_request(method, path, params, body, headers).body
           end
+        end
       end
-    end
     end
   end
 end

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/index_lifecycle_management/remove_policy.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/index_lifecycle_management/remove_policy.rb
@@ -43,8 +43,8 @@ module Elasticsearch
             body = nil
             perform_request(method, path, params, body, headers).body
           end
+        end
       end
-    end
     end
   end
 end

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/index_lifecycle_management/retry.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/index_lifecycle_management/retry.rb
@@ -43,8 +43,8 @@ module Elasticsearch
             body = nil
             perform_request(method, path, params, body, headers).body
           end
+        end
       end
-    end
     end
   end
 end

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/index_lifecycle_management/start.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/index_lifecycle_management/start.rb
@@ -38,8 +38,8 @@ module Elasticsearch
             body = nil
             perform_request(method, path, params, body, headers).body
           end
+        end
       end
-    end
     end
   end
 end

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/index_lifecycle_management/stop.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/index_lifecycle_management/stop.rb
@@ -38,8 +38,8 @@ module Elasticsearch
             body = nil
             perform_request(method, path, params, body, headers).body
           end
+        end
       end
-    end
     end
   end
 end

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/indices/freeze.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/indices/freeze.rb
@@ -63,8 +63,8 @@ module Elasticsearch
             :expand_wildcards,
             :wait_for_active_shards
           ].freeze)
+        end
       end
-    end
     end
   end
 end

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/indices/reload_search_analyzers.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/indices/reload_search_analyzers.rb
@@ -57,8 +57,8 @@ module Elasticsearch
             :allow_no_indices,
             :expand_wildcards
           ].freeze)
+        end
       end
-    end
     end
   end
 end

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/indices/unfreeze.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/indices/unfreeze.rb
@@ -63,8 +63,8 @@ module Elasticsearch
             :expand_wildcards,
             :wait_for_active_shards
           ].freeze)
+        end
       end
-    end
     end
   end
 end

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/info.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/info.rb
@@ -45,7 +45,7 @@ module Elasticsearch
         ParamsRegistry.register(:info, [
           :categories
         ].freeze)
-  end
       end
-end
+    end
+  end
 end

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/license/delete.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/license/delete.rb
@@ -38,8 +38,8 @@ module Elasticsearch
             body = nil
             perform_request(method, path, params, body, headers).body
           end
+        end
       end
-    end
     end
   end
 end

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/license/get.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/license/get.rb
@@ -48,8 +48,8 @@ module Elasticsearch
             :local,
             :accept_enterprise
           ].freeze)
+        end
       end
-    end
     end
   end
 end

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/license/get_basic_status.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/license/get_basic_status.rb
@@ -38,8 +38,8 @@ module Elasticsearch
             body = nil
             perform_request(method, path, params, body, headers).body
           end
+        end
       end
-    end
     end
   end
 end

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/license/get_trial_status.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/license/get_trial_status.rb
@@ -38,8 +38,8 @@ module Elasticsearch
             body = nil
             perform_request(method, path, params, body, headers).body
           end
+        end
       end
-    end
     end
   end
 end

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/license/post.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/license/post.rb
@@ -47,8 +47,8 @@ module Elasticsearch
           ParamsRegistry.register(:post, [
             :acknowledge
           ].freeze)
+        end
       end
-    end
     end
   end
 end

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/license/post_start_basic.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/license/post_start_basic.rb
@@ -46,8 +46,8 @@ module Elasticsearch
           ParamsRegistry.register(:post_start_basic, [
             :acknowledge
           ].freeze)
+        end
       end
-    end
     end
   end
 end

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/license/post_start_trial.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/license/post_start_trial.rb
@@ -48,8 +48,8 @@ module Elasticsearch
             :type,
             :acknowledge
           ].freeze)
+        end
       end
-    end
     end
   end
 end

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/machine_learning/close_job.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/machine_learning/close_job.rb
@@ -56,8 +56,8 @@ module Elasticsearch
             :force,
             :timeout
           ].freeze)
+        end
       end
-    end
     end
   end
 end

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/machine_learning/delete_calendar.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/machine_learning/delete_calendar.rb
@@ -43,8 +43,8 @@ module Elasticsearch
             body = nil
             perform_request(method, path, params, body, headers).body
           end
+        end
       end
-    end
     end
   end
 end

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/machine_learning/delete_calendar_event.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/machine_learning/delete_calendar_event.rb
@@ -47,8 +47,8 @@ module Elasticsearch
             body = nil
             perform_request(method, path, params, body, headers).body
           end
+        end
       end
-    end
     end
   end
 end

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/machine_learning/delete_calendar_job.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/machine_learning/delete_calendar_job.rb
@@ -47,8 +47,8 @@ module Elasticsearch
             body = nil
             perform_request(method, path, params, body, headers).body
           end
+        end
       end
-    end
     end
   end
 end

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/machine_learning/delete_data_frame_analytics.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/machine_learning/delete_data_frame_analytics.rb
@@ -53,8 +53,8 @@ module Elasticsearch
             :force,
             :timeout
           ].freeze)
+        end
       end
-    end
     end
   end
 end

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/machine_learning/delete_datafeed.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/machine_learning/delete_datafeed.rb
@@ -51,8 +51,8 @@ module Elasticsearch
           ParamsRegistry.register(:delete_datafeed, [
             :force
           ].freeze)
+        end
       end
-    end
     end
   end
 end

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/machine_learning/delete_expired_data.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/machine_learning/delete_expired_data.rb
@@ -42,7 +42,7 @@ module Elasticsearch
                        "_ml/_delete_expired_data/#{Elasticsearch::API::Utils.__listify(_job_id)}"
                      else
                        "_ml/_delete_expired_data"
-            end
+                     end
             params = Elasticsearch::API::Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
 
             body = arguments[:body]
@@ -56,8 +56,8 @@ module Elasticsearch
             :requests_per_second,
             :timeout
           ].freeze)
+        end
       end
-    end
     end
   end
 end

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/machine_learning/delete_filter.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/machine_learning/delete_filter.rb
@@ -43,8 +43,8 @@ module Elasticsearch
             body = nil
             perform_request(method, path, params, body, headers).body
           end
+        end
       end
-    end
     end
   end
 end

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/machine_learning/delete_forecast.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/machine_learning/delete_forecast.rb
@@ -46,7 +46,7 @@ module Elasticsearch
                        "_ml/anomaly_detectors/#{Elasticsearch::API::Utils.__listify(_job_id)}/_forecast/#{Elasticsearch::API::Utils.__listify(_forecast_id)}"
                      else
                        "_ml/anomaly_detectors/#{Elasticsearch::API::Utils.__listify(_job_id)}/_forecast"
-  end
+                     end
             params = Elasticsearch::API::Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
 
             body = nil
@@ -60,8 +60,8 @@ module Elasticsearch
             :allow_no_forecasts,
             :timeout
           ].freeze)
+        end
       end
-    end
     end
   end
 end

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/machine_learning/delete_job.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/machine_learning/delete_job.rb
@@ -53,8 +53,8 @@ module Elasticsearch
             :force,
             :wait_for_completion
           ].freeze)
+        end
       end
-    end
     end
   end
 end

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/machine_learning/delete_model_snapshot.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/machine_learning/delete_model_snapshot.rb
@@ -47,8 +47,8 @@ module Elasticsearch
             body = nil
             perform_request(method, path, params, body, headers).body
           end
+        end
       end
-    end
     end
   end
 end

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/machine_learning/delete_trained_model.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/machine_learning/delete_trained_model.rb
@@ -43,8 +43,8 @@ module Elasticsearch
             body = nil
             perform_request(method, path, params, body, headers).body
           end
+        end
       end
-    end
     end
   end
 end

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/machine_learning/estimate_model_memory.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/machine_learning/estimate_model_memory.rb
@@ -41,8 +41,8 @@ module Elasticsearch
             body = arguments[:body]
             perform_request(method, path, params, body, headers).body
           end
+        end
       end
-    end
     end
   end
 end

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/machine_learning/evaluate_data_frame.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/machine_learning/evaluate_data_frame.rb
@@ -41,8 +41,8 @@ module Elasticsearch
             body = arguments[:body]
             perform_request(method, path, params, body, headers).body
           end
+        end
       end
-    end
     end
   end
 end

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/machine_learning/explain_data_frame_analytics.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/machine_learning/explain_data_frame_analytics.rb
@@ -35,19 +35,24 @@ module Elasticsearch
 
             _id = arguments.delete(:id)
 
-            method = Elasticsearch::API::HTTP_GET
-            path   = if _id
-                       "_ml/data_frame/analytics/#{Elasticsearch::API::Utils.__listify(_id)}/_explain"
+            method = if arguments[:body]
+                       Elasticsearch::API::HTTP_POST
                      else
-                       "_ml/data_frame/analytics/_explain"
-            end
+                       Elasticsearch::API::HTTP_GET
+                     end
+
+            path = if _id
+                     "_ml/data_frame/analytics/#{Elasticsearch::API::Utils.__listify(_id)}/_explain"
+                   else
+                     "_ml/data_frame/analytics/_explain"
+                   end
             params = {}
 
             body = arguments[:body]
             perform_request(method, path, params, body, headers).body
           end
+        end
       end
-    end
     end
   end
 end

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/machine_learning/find_file_structure.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/machine_learning/find_file_structure.rb
@@ -77,8 +77,8 @@ module Elasticsearch
             :timestamp_format,
             :explain
           ].freeze)
+        end
       end
-    end
     end
   end
 end

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/machine_learning/flush_job.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/machine_learning/flush_job.rb
@@ -60,8 +60,8 @@ module Elasticsearch
             :advance_time,
             :skip_time
           ].freeze)
+        end
       end
-    end
     end
   end
 end

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/machine_learning/forecast.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/machine_learning/forecast.rb
@@ -55,8 +55,8 @@ module Elasticsearch
             :expires_in,
             :max_model_memory
           ].freeze)
+        end
       end
-    end
     end
   end
 end

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/machine_learning/get_buckets.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/machine_learning/get_buckets.rb
@@ -49,12 +49,17 @@ module Elasticsearch
 
             _timestamp = arguments.delete(:timestamp)
 
-            method = Elasticsearch::API::HTTP_GET
-            path   = if _job_id && _timestamp
-                       "_ml/anomaly_detectors/#{Elasticsearch::API::Utils.__listify(_job_id)}/results/buckets/#{Elasticsearch::API::Utils.__listify(_timestamp)}"
+            method = if arguments[:body]
+                       Elasticsearch::API::HTTP_POST
                      else
-                       "_ml/anomaly_detectors/#{Elasticsearch::API::Utils.__listify(_job_id)}/results/buckets"
-  end
+                       Elasticsearch::API::HTTP_GET
+                     end
+
+            path = if _job_id && _timestamp
+                     "_ml/anomaly_detectors/#{Elasticsearch::API::Utils.__listify(_job_id)}/results/buckets/#{Elasticsearch::API::Utils.__listify(_timestamp)}"
+                   else
+                     "_ml/anomaly_detectors/#{Elasticsearch::API::Utils.__listify(_job_id)}/results/buckets"
+                   end
             params = Elasticsearch::API::Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
 
             body = arguments[:body]
@@ -75,8 +80,8 @@ module Elasticsearch
             :sort,
             :desc
           ].freeze)
+        end
       end
-    end
     end
   end
 end

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/machine_learning/get_calendar_events.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/machine_learning/get_calendar_events.rb
@@ -59,8 +59,8 @@ module Elasticsearch
             :from,
             :size
           ].freeze)
+        end
       end
-    end
     end
   end
 end

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/machine_learning/get_calendars.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/machine_learning/get_calendars.rb
@@ -37,12 +37,17 @@ module Elasticsearch
 
             _calendar_id = arguments.delete(:calendar_id)
 
-            method = Elasticsearch::API::HTTP_GET
-            path   = if _calendar_id
-                       "_ml/calendars/#{Elasticsearch::API::Utils.__listify(_calendar_id)}"
+            method = if arguments[:body]
+                       Elasticsearch::API::HTTP_POST
                      else
-                       "_ml/calendars"
-            end
+                       Elasticsearch::API::HTTP_GET
+                     end
+
+            path = if _calendar_id
+                     "_ml/calendars/#{Elasticsearch::API::Utils.__listify(_calendar_id)}"
+                   else
+                     "_ml/calendars"
+                   end
             params = Elasticsearch::API::Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
 
             body = arguments[:body]
@@ -56,8 +61,8 @@ module Elasticsearch
             :from,
             :size
           ].freeze)
+        end
       end
-    end
     end
   end
 end

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/machine_learning/get_categories.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/machine_learning/get_categories.rb
@@ -43,12 +43,17 @@ module Elasticsearch
 
             _category_id = arguments.delete(:category_id)
 
-            method = Elasticsearch::API::HTTP_GET
-            path   = if _job_id && _category_id
-                       "_ml/anomaly_detectors/#{Elasticsearch::API::Utils.__listify(_job_id)}/results/categories/#{Elasticsearch::API::Utils.__listify(_category_id)}"
+            method = if arguments[:body]
+                       Elasticsearch::API::HTTP_POST
                      else
-                       "_ml/anomaly_detectors/#{Elasticsearch::API::Utils.__listify(_job_id)}/results/categories"
-  end
+                       Elasticsearch::API::HTTP_GET
+                     end
+
+            path = if _job_id && _category_id
+                     "_ml/anomaly_detectors/#{Elasticsearch::API::Utils.__listify(_job_id)}/results/categories/#{Elasticsearch::API::Utils.__listify(_category_id)}"
+                   else
+                     "_ml/anomaly_detectors/#{Elasticsearch::API::Utils.__listify(_job_id)}/results/categories"
+                   end
             params = Elasticsearch::API::Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
 
             body = arguments[:body]
@@ -63,8 +68,8 @@ module Elasticsearch
             :size,
             :partition_field_value
           ].freeze)
+        end
       end
-    end
     end
   end
 end

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/machine_learning/get_data_frame_analytics.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/machine_learning/get_data_frame_analytics.rb
@@ -42,7 +42,7 @@ module Elasticsearch
                        "_ml/data_frame/analytics/#{Elasticsearch::API::Utils.__listify(_id)}"
                      else
                        "_ml/data_frame/analytics"
-            end
+                     end
             params = Elasticsearch::API::Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
 
             body = nil
@@ -57,8 +57,8 @@ module Elasticsearch
             :from,
             :size
           ].freeze)
+        end
       end
-    end
     end
   end
 end

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/machine_learning/get_data_frame_analytics_stats.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/machine_learning/get_data_frame_analytics_stats.rb
@@ -42,7 +42,7 @@ module Elasticsearch
                        "_ml/data_frame/analytics/#{Elasticsearch::API::Utils.__listify(_id)}/_stats"
                      else
                        "_ml/data_frame/analytics/_stats"
-            end
+                     end
             params = Elasticsearch::API::Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
 
             body = nil
@@ -57,8 +57,8 @@ module Elasticsearch
             :from,
             :size
           ].freeze)
+        end
       end
-    end
     end
   end
 end

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/machine_learning/get_datafeed_stats.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/machine_learning/get_datafeed_stats.rb
@@ -40,7 +40,7 @@ module Elasticsearch
                        "_ml/datafeeds/#{Elasticsearch::API::Utils.__listify(_datafeed_id)}/_stats"
                      else
                        "_ml/datafeeds/_stats"
-            end
+                     end
             params = Elasticsearch::API::Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
 
             body = nil
@@ -53,8 +53,8 @@ module Elasticsearch
           ParamsRegistry.register(:get_datafeed_stats, [
             :allow_no_datafeeds
           ].freeze)
+        end
       end
-    end
     end
   end
 end

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/machine_learning/get_datafeeds.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/machine_learning/get_datafeeds.rb
@@ -40,7 +40,7 @@ module Elasticsearch
                        "_ml/datafeeds/#{Elasticsearch::API::Utils.__listify(_datafeed_id)}"
                      else
                        "_ml/datafeeds"
-            end
+                     end
             params = Elasticsearch::API::Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
 
             body = nil
@@ -53,8 +53,8 @@ module Elasticsearch
           ParamsRegistry.register(:get_datafeeds, [
             :allow_no_datafeeds
           ].freeze)
+        end
       end
-    end
     end
   end
 end

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/machine_learning/get_filters.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/machine_learning/get_filters.rb
@@ -41,7 +41,7 @@ module Elasticsearch
                        "_ml/filters/#{Elasticsearch::API::Utils.__listify(_filter_id)}"
                      else
                        "_ml/filters"
-            end
+                     end
             params = Elasticsearch::API::Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
 
             body = nil
@@ -55,8 +55,8 @@ module Elasticsearch
             :from,
             :size
           ].freeze)
+        end
       end
-    end
     end
   end
 end

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/machine_learning/get_influencers.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/machine_learning/get_influencers.rb
@@ -45,8 +45,13 @@ module Elasticsearch
 
             _job_id = arguments.delete(:job_id)
 
-            method = Elasticsearch::API::HTTP_GET
-            path   = "_ml/anomaly_detectors/#{Elasticsearch::API::Utils.__listify(_job_id)}/results/influencers"
+            method = if arguments[:body]
+                       Elasticsearch::API::HTTP_POST
+                     else
+                       Elasticsearch::API::HTTP_GET
+                     end
+
+            path = "_ml/anomaly_detectors/#{Elasticsearch::API::Utils.__listify(_job_id)}/results/influencers"
             params = Elasticsearch::API::Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
 
             body = arguments[:body]
@@ -66,8 +71,8 @@ module Elasticsearch
             :sort,
             :desc
           ].freeze)
+        end
       end
-    end
     end
   end
 end

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/machine_learning/get_job_stats.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/machine_learning/get_job_stats.rb
@@ -40,7 +40,7 @@ module Elasticsearch
                        "_ml/anomaly_detectors/#{Elasticsearch::API::Utils.__listify(_job_id)}/_stats"
                      else
                        "_ml/anomaly_detectors/_stats"
-            end
+                     end
             params = Elasticsearch::API::Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
 
             body = nil
@@ -53,8 +53,8 @@ module Elasticsearch
           ParamsRegistry.register(:get_job_stats, [
             :allow_no_jobs
           ].freeze)
+        end
       end
-    end
     end
   end
 end

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/machine_learning/get_jobs.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/machine_learning/get_jobs.rb
@@ -40,7 +40,7 @@ module Elasticsearch
                        "_ml/anomaly_detectors/#{Elasticsearch::API::Utils.__listify(_job_id)}"
                      else
                        "_ml/anomaly_detectors"
-            end
+                     end
             params = Elasticsearch::API::Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
 
             body = nil
@@ -53,8 +53,8 @@ module Elasticsearch
           ParamsRegistry.register(:get_jobs, [
             :allow_no_jobs
           ].freeze)
+        end
       end
-    end
     end
   end
 end

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/machine_learning/get_model_snapshots.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/machine_learning/get_model_snapshots.rb
@@ -46,12 +46,17 @@ module Elasticsearch
 
             _snapshot_id = arguments.delete(:snapshot_id)
 
-            method = Elasticsearch::API::HTTP_GET
-            path   = if _job_id && _snapshot_id
-                       "_ml/anomaly_detectors/#{Elasticsearch::API::Utils.__listify(_job_id)}/model_snapshots/#{Elasticsearch::API::Utils.__listify(_snapshot_id)}"
+            method = if arguments[:body]
+                       Elasticsearch::API::HTTP_POST
                      else
-                       "_ml/anomaly_detectors/#{Elasticsearch::API::Utils.__listify(_job_id)}/model_snapshots"
-  end
+                       Elasticsearch::API::HTTP_GET
+                     end
+
+            path = if _job_id && _snapshot_id
+                     "_ml/anomaly_detectors/#{Elasticsearch::API::Utils.__listify(_job_id)}/model_snapshots/#{Elasticsearch::API::Utils.__listify(_snapshot_id)}"
+                   else
+                     "_ml/anomaly_detectors/#{Elasticsearch::API::Utils.__listify(_job_id)}/model_snapshots"
+                   end
             params = Elasticsearch::API::Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
 
             body = arguments[:body]
@@ -69,8 +74,8 @@ module Elasticsearch
             :sort,
             :desc
           ].freeze)
+        end
       end
-    end
     end
   end
 end

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/machine_learning/get_overall_buckets.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/machine_learning/get_overall_buckets.rb
@@ -44,8 +44,13 @@ module Elasticsearch
 
             _job_id = arguments.delete(:job_id)
 
-            method = Elasticsearch::API::HTTP_GET
-            path   = "_ml/anomaly_detectors/#{Elasticsearch::API::Utils.__listify(_job_id)}/results/overall_buckets"
+            method = if arguments[:body]
+                       Elasticsearch::API::HTTP_POST
+                     else
+                       Elasticsearch::API::HTTP_GET
+                     end
+
+            path = "_ml/anomaly_detectors/#{Elasticsearch::API::Utils.__listify(_job_id)}/results/overall_buckets"
             params = Elasticsearch::API::Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
 
             body = arguments[:body]
@@ -64,8 +69,8 @@ module Elasticsearch
             :end,
             :allow_no_jobs
           ].freeze)
+        end
       end
-    end
     end
   end
 end

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/machine_learning/get_records.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/machine_learning/get_records.rb
@@ -45,8 +45,13 @@ module Elasticsearch
 
             _job_id = arguments.delete(:job_id)
 
-            method = Elasticsearch::API::HTTP_GET
-            path   = "_ml/anomaly_detectors/#{Elasticsearch::API::Utils.__listify(_job_id)}/results/records"
+            method = if arguments[:body]
+                       Elasticsearch::API::HTTP_POST
+                     else
+                       Elasticsearch::API::HTTP_GET
+                     end
+
+            path = "_ml/anomaly_detectors/#{Elasticsearch::API::Utils.__listify(_job_id)}/results/records"
             params = Elasticsearch::API::Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
 
             body = arguments[:body]
@@ -66,8 +71,8 @@ module Elasticsearch
             :sort,
             :desc
           ].freeze)
+        end
       end
-    end
     end
   end
 end

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/machine_learning/get_trained_models.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/machine_learning/get_trained_models.rb
@@ -46,7 +46,7 @@ module Elasticsearch
                        "_ml/inference/#{Elasticsearch::API::Utils.__listify(_model_id)}"
                      else
                        "_ml/inference"
-            end
+                     end
             params = Elasticsearch::API::Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
 
             body = nil
@@ -65,8 +65,8 @@ module Elasticsearch
             :tags,
             :for_export
           ].freeze)
+        end
       end
-    end
     end
   end
 end

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/machine_learning/get_trained_models_stats.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/machine_learning/get_trained_models_stats.rb
@@ -42,7 +42,7 @@ module Elasticsearch
                        "_ml/inference/#{Elasticsearch::API::Utils.__listify(_model_id)}/_stats"
                      else
                        "_ml/inference/_stats"
-            end
+                     end
             params = Elasticsearch::API::Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
 
             body = nil
@@ -57,8 +57,8 @@ module Elasticsearch
             :from,
             :size
           ].freeze)
+        end
       end
-    end
     end
   end
 end

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/machine_learning/info.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/machine_learning/info.rb
@@ -38,8 +38,8 @@ module Elasticsearch
             body = nil
             perform_request(method, path, params, body, headers).body
           end
+        end
       end
-    end
     end
   end
 end

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/machine_learning/open_job.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/machine_learning/open_job.rb
@@ -43,8 +43,8 @@ module Elasticsearch
             body = nil
             perform_request(method, path, params, body, headers).body
           end
+        end
       end
-    end
     end
   end
 end

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/machine_learning/post_calendar_events.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/machine_learning/post_calendar_events.rb
@@ -45,8 +45,8 @@ module Elasticsearch
             body = arguments[:body]
             perform_request(method, path, params, body, headers).body
           end
+        end
       end
-    end
     end
   end
 end

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/machine_learning/post_data.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/machine_learning/post_data.rb
@@ -55,8 +55,8 @@ module Elasticsearch
             :reset_start,
             :reset_end
           ].freeze)
+        end
       end
-    end
     end
   end
 end

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/machine_learning/preview_datafeed.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/machine_learning/preview_datafeed.rb
@@ -43,8 +43,8 @@ module Elasticsearch
             body = nil
             perform_request(method, path, params, body, headers).body
           end
+        end
       end
-    end
     end
   end
 end

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/machine_learning/put_calendar.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/machine_learning/put_calendar.rb
@@ -44,8 +44,8 @@ module Elasticsearch
             body = arguments[:body]
             perform_request(method, path, params, body, headers).body
           end
+        end
       end
-    end
     end
   end
 end

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/machine_learning/put_calendar_job.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/machine_learning/put_calendar_job.rb
@@ -47,8 +47,8 @@ module Elasticsearch
             body = nil
             perform_request(method, path, params, body, headers).body
           end
+        end
       end
-    end
     end
   end
 end

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/machine_learning/put_data_frame_analytics.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/machine_learning/put_data_frame_analytics.rb
@@ -45,8 +45,8 @@ module Elasticsearch
             body = arguments[:body]
             perform_request(method, path, params, body, headers).body
           end
+        end
       end
-    end
     end
   end
 end

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/machine_learning/put_datafeed.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/machine_learning/put_datafeed.rb
@@ -61,8 +61,8 @@ module Elasticsearch
             :ignore_throttled,
             :expand_wildcards
           ].freeze)
+        end
       end
-    end
     end
   end
 end

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/machine_learning/put_filter.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/machine_learning/put_filter.rb
@@ -45,8 +45,8 @@ module Elasticsearch
             body = arguments[:body]
             perform_request(method, path, params, body, headers).body
           end
+        end
       end
-    end
     end
   end
 end

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/machine_learning/put_job.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/machine_learning/put_job.rb
@@ -45,8 +45,8 @@ module Elasticsearch
             body = arguments[:body]
             perform_request(method, path, params, body, headers).body
           end
+        end
       end
-    end
     end
   end
 end

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/machine_learning/put_trained_model.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/machine_learning/put_trained_model.rb
@@ -45,8 +45,8 @@ module Elasticsearch
             body = arguments[:body]
             perform_request(method, path, params, body, headers).body
           end
+        end
       end
-    end
     end
   end
 end

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/machine_learning/revert_model_snapshot.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/machine_learning/revert_model_snapshot.rb
@@ -56,8 +56,8 @@ module Elasticsearch
           ParamsRegistry.register(:revert_model_snapshot, [
             :delete_intervening_results
           ].freeze)
+        end
       end
-    end
     end
   end
 end

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/machine_learning/set_upgrade_mode.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/machine_learning/set_upgrade_mode.rb
@@ -48,8 +48,8 @@ module Elasticsearch
             :enabled,
             :timeout
           ].freeze)
+        end
       end
-    end
     end
   end
 end

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/machine_learning/start_data_frame_analytics.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/machine_learning/start_data_frame_analytics.rb
@@ -52,8 +52,8 @@ module Elasticsearch
           ParamsRegistry.register(:start_data_frame_analytics, [
             :timeout
           ].freeze)
+        end
       end
-    end
     end
   end
 end

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/machine_learning/start_datafeed.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/machine_learning/start_datafeed.rb
@@ -56,8 +56,8 @@ module Elasticsearch
             :end,
             :timeout
           ].freeze)
+        end
       end
-    end
     end
   end
 end

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/machine_learning/stop_data_frame_analytics.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/machine_learning/stop_data_frame_analytics.rb
@@ -56,8 +56,8 @@ module Elasticsearch
             :force,
             :timeout
           ].freeze)
+        end
       end
-    end
     end
   end
 end

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/machine_learning/stop_datafeed.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/machine_learning/stop_datafeed.rb
@@ -55,8 +55,8 @@ module Elasticsearch
             :force,
             :timeout
           ].freeze)
+        end
       end
-    end
     end
   end
 end

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/machine_learning/update_datafeed.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/machine_learning/update_datafeed.rb
@@ -61,8 +61,8 @@ module Elasticsearch
             :ignore_throttled,
             :expand_wildcards
           ].freeze)
+        end
       end
-    end
     end
   end
 end

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/machine_learning/update_filter.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/machine_learning/update_filter.rb
@@ -45,8 +45,8 @@ module Elasticsearch
             body = arguments[:body]
             perform_request(method, path, params, body, headers).body
           end
+        end
       end
-    end
     end
   end
 end

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/machine_learning/update_job.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/machine_learning/update_job.rb
@@ -45,8 +45,8 @@ module Elasticsearch
             body = arguments[:body]
             perform_request(method, path, params, body, headers).body
           end
+        end
       end
-    end
     end
   end
 end

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/machine_learning/update_model_snapshot.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/machine_learning/update_model_snapshot.rb
@@ -49,8 +49,8 @@ module Elasticsearch
             body = arguments[:body]
             perform_request(method, path, params, body, headers).body
           end
+        end
       end
-    end
     end
   end
 end

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/machine_learning/validate.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/machine_learning/validate.rb
@@ -41,8 +41,8 @@ module Elasticsearch
             body = arguments[:body]
             perform_request(method, path, params, body, headers).body
           end
+        end
       end
-    end
     end
   end
 end

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/machine_learning/validate_detector.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/machine_learning/validate_detector.rb
@@ -41,8 +41,8 @@ module Elasticsearch
             body = arguments[:body]
             perform_request(method, path, params, body, headers).body
           end
+        end
       end
-    end
     end
   end
 end

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/migration/deprecations.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/migration/deprecations.rb
@@ -39,14 +39,14 @@ module Elasticsearch
                        "#{Elasticsearch::API::Utils.__listify(_index)}/_migration/deprecations"
                      else
                        "_migration/deprecations"
-            end
+                     end
             params = {}
 
             body = nil
             perform_request(method, path, params, body, headers).body
           end
+        end
       end
-    end
     end
   end
 end

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/monitoring/bulk.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/monitoring/bulk.rb
@@ -51,7 +51,7 @@ module Elasticsearch
                        "_monitoring/#{Elasticsearch::API::Utils.__listify(_type)}/bulk"
                      else
                        "_monitoring/bulk"
-  end
+                     end
             params = Elasticsearch::API::Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
 
             body = arguments[:body]
@@ -59,7 +59,7 @@ module Elasticsearch
               payload = Elasticsearch::API::Utils.__bulkify(body)
             else
               payload = body
-          end
+            end
 
             headers.merge!("Content-Type" => "application/x-ndjson")
             perform_request(method, path, params, payload, headers).body
@@ -73,8 +73,8 @@ module Elasticsearch
             :system_api_version,
             :interval
           ].freeze)
+        end
       end
-    end
     end
   end
 end

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/rollup/delete_job.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/rollup/delete_job.rb
@@ -43,8 +43,8 @@ module Elasticsearch
             body = nil
             perform_request(method, path, params, body, headers).body
           end
+        end
       end
-    end
     end
   end
 end

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/rollup/get_jobs.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/rollup/get_jobs.rb
@@ -39,14 +39,14 @@ module Elasticsearch
                        "_rollup/job/#{Elasticsearch::API::Utils.__listify(_id)}"
                      else
                        "_rollup/job"
-            end
+                     end
             params = {}
 
             body = nil
             perform_request(method, path, params, body, headers).body
           end
+        end
       end
-    end
     end
   end
 end

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/rollup/get_rollup_caps.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/rollup/get_rollup_caps.rb
@@ -39,14 +39,14 @@ module Elasticsearch
                        "_rollup/data/#{Elasticsearch::API::Utils.__listify(_id)}"
                      else
                        "_rollup/data"
-            end
+                     end
             params = {}
 
             body = nil
             perform_request(method, path, params, body, headers).body
           end
+        end
       end
-    end
     end
   end
 end

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/rollup/get_rollup_index_caps.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/rollup/get_rollup_index_caps.rb
@@ -43,8 +43,8 @@ module Elasticsearch
             body = nil
             perform_request(method, path, params, body, headers).body
           end
+        end
       end
-    end
     end
   end
 end

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/rollup/put_job.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/rollup/put_job.rb
@@ -45,8 +45,8 @@ module Elasticsearch
             body = arguments[:body]
             perform_request(method, path, params, body, headers).body
           end
+        end
       end
-    end
     end
   end
 end

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/rollup/rollup_search.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/rollup/rollup_search.rb
@@ -48,12 +48,17 @@ module Elasticsearch
 
             _type = arguments.delete(:type)
 
-            method = Elasticsearch::API::HTTP_GET
-            path   = if _index && _type
-                       "#{Elasticsearch::API::Utils.__listify(_index)}/#{Elasticsearch::API::Utils.__listify(_type)}/_rollup_search"
+            method = if arguments[:body]
+                       Elasticsearch::API::HTTP_POST
                      else
-                       "#{Elasticsearch::API::Utils.__listify(_index)}/_rollup_search"
-  end
+                       Elasticsearch::API::HTTP_GET
+                     end
+
+            path = if _index && _type
+                     "#{Elasticsearch::API::Utils.__listify(_index)}/#{Elasticsearch::API::Utils.__listify(_type)}/_rollup_search"
+                   else
+                     "#{Elasticsearch::API::Utils.__listify(_index)}/_rollup_search"
+                   end
             params = Elasticsearch::API::Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
 
             body = arguments[:body]
@@ -67,8 +72,8 @@ module Elasticsearch
             :typed_keys,
             :rest_total_hits_as_int
           ].freeze)
+        end
       end
-    end
     end
   end
 end

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/rollup/start_job.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/rollup/start_job.rb
@@ -43,8 +43,8 @@ module Elasticsearch
             body = nil
             perform_request(method, path, params, body, headers).body
           end
+        end
       end
-    end
     end
   end
 end

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/rollup/stop_job.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/rollup/stop_job.rb
@@ -53,8 +53,8 @@ module Elasticsearch
             :wait_for_completion,
             :timeout
           ].freeze)
+        end
       end
-    end
     end
   end
 end

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/searchable_snapshots/clear_cache.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/searchable_snapshots/clear_cache.rb
@@ -45,7 +45,7 @@ module Elasticsearch
                        "#{Elasticsearch::API::Utils.__listify(_index)}/_searchable_snapshots/cache/clear"
                      else
                        "_searchable_snapshots/cache/clear"
-            end
+                     end
             params = Elasticsearch::API::Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
 
             body = nil
@@ -61,8 +61,8 @@ module Elasticsearch
             :expand_wildcards,
             :index
           ].freeze)
+        end
       end
-    end
     end
   end
 end

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/searchable_snapshots/mount.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/searchable_snapshots/mount.rb
@@ -59,8 +59,8 @@ module Elasticsearch
             :master_timeout,
             :wait_for_completion
           ].freeze)
+        end
       end
-    end
     end
   end
 end

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/searchable_snapshots/repository_stats.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/searchable_snapshots/repository_stats.rb
@@ -43,8 +43,8 @@ module Elasticsearch
             body = nil
             perform_request(method, path, params, body, headers).body
           end
+        end
       end
-    end
     end
   end
 end

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/searchable_snapshots/stats.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/searchable_snapshots/stats.rb
@@ -39,14 +39,14 @@ module Elasticsearch
                        "#{Elasticsearch::API::Utils.__listify(_index)}/_searchable_snapshots/stats"
                      else
                        "_searchable_snapshots/stats"
-            end
+                     end
             params = {}
 
             body = nil
             perform_request(method, path, params, body, headers).body
           end
+        end
       end
-    end
     end
   end
 end

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/security/authenticate.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/security/authenticate.rb
@@ -38,8 +38,8 @@ module Elasticsearch
             body = nil
             perform_request(method, path, params, body, headers).body
           end
+        end
       end
-    end
     end
   end
 end

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/security/change_password.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/security/change_password.rb
@@ -45,7 +45,7 @@ module Elasticsearch
                        "_security/user/#{Elasticsearch::API::Utils.__listify(_username)}/_password"
                      else
                        "_security/user/_password"
-  end
+                     end
             params = Elasticsearch::API::Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
 
             body = arguments[:body]
@@ -58,8 +58,8 @@ module Elasticsearch
           ParamsRegistry.register(:change_password, [
             :refresh
           ].freeze)
+        end
       end
-    end
     end
   end
 end

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/security/clear_cached_realms.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/security/clear_cached_realms.rb
@@ -51,8 +51,8 @@ module Elasticsearch
           ParamsRegistry.register(:clear_cached_realms, [
             :usernames
           ].freeze)
+        end
       end
-    end
     end
   end
 end

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/security/clear_cached_roles.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/security/clear_cached_roles.rb
@@ -43,8 +43,8 @@ module Elasticsearch
             body = nil
             perform_request(method, path, params, body, headers).body
           end
+        end
       end
-    end
     end
   end
 end

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/security/create_api_key.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/security/create_api_key.rb
@@ -51,8 +51,8 @@ module Elasticsearch
           ParamsRegistry.register(:create_api_key, [
             :refresh
           ].freeze)
+        end
       end
-    end
     end
   end
 end

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/security/delete_privileges.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/security/delete_privileges.rb
@@ -57,8 +57,8 @@ module Elasticsearch
           ParamsRegistry.register(:delete_privileges, [
             :refresh
           ].freeze)
+        end
       end
-    end
     end
   end
 end

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/security/delete_role.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/security/delete_role.rb
@@ -53,8 +53,8 @@ module Elasticsearch
           ParamsRegistry.register(:delete_role, [
             :refresh
           ].freeze)
+        end
       end
-    end
     end
   end
 end

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/security/delete_role_mapping.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/security/delete_role_mapping.rb
@@ -53,8 +53,8 @@ module Elasticsearch
           ParamsRegistry.register(:delete_role_mapping, [
             :refresh
           ].freeze)
+        end
       end
-    end
     end
   end
 end

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/security/delete_user.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/security/delete_user.rb
@@ -53,8 +53,8 @@ module Elasticsearch
           ParamsRegistry.register(:delete_user, [
             :refresh
           ].freeze)
+        end
       end
-    end
     end
   end
 end

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/security/disable_user.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/security/disable_user.rb
@@ -53,8 +53,8 @@ module Elasticsearch
           ParamsRegistry.register(:disable_user, [
             :refresh
           ].freeze)
+        end
       end
-    end
     end
   end
 end

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/security/enable_user.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/security/enable_user.rb
@@ -53,8 +53,8 @@ module Elasticsearch
           ParamsRegistry.register(:enable_user, [
             :refresh
           ].freeze)
+        end
       end
-    end
     end
   end
 end

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/security/get_api_key.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/security/get_api_key.rb
@@ -54,8 +54,8 @@ module Elasticsearch
             :realm_name,
             :owner
           ].freeze)
+        end
       end
-    end
     end
   end
 end

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/security/get_builtin_privileges.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/security/get_builtin_privileges.rb
@@ -38,8 +38,8 @@ module Elasticsearch
             body = nil
             perform_request(method, path, params, body, headers).body
           end
+        end
       end
-    end
     end
   end
 end

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/security/get_privileges.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/security/get_privileges.rb
@@ -44,14 +44,14 @@ module Elasticsearch
                        "_security/privilege/#{Elasticsearch::API::Utils.__listify(_application)}"
                      else
                        "_security/privilege"
-            end
+                     end
             params = {}
 
             body = nil
             perform_request(method, path, params, body, headers).body
           end
+        end
       end
-    end
     end
   end
 end

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/security/get_role.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/security/get_role.rb
@@ -39,7 +39,7 @@ module Elasticsearch
                        "_security/role/#{Elasticsearch::API::Utils.__listify(_name)}"
                      else
                        "_security/role"
-            end
+                     end
             params = {}
 
             body = nil
@@ -49,8 +49,8 @@ module Elasticsearch
               perform_request(method, path, params, body, headers).body
             end
           end
+        end
       end
-    end
     end
   end
 end

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/security/get_role_mapping.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/security/get_role_mapping.rb
@@ -39,14 +39,14 @@ module Elasticsearch
                        "_security/role_mapping/#{Elasticsearch::API::Utils.__listify(_name)}"
                      else
                        "_security/role_mapping"
-            end
+                     end
             params = {}
 
             body = nil
             perform_request(method, path, params, body, headers).body
           end
+        end
       end
-    end
     end
   end
 end

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/security/get_token.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/security/get_token.rb
@@ -41,8 +41,8 @@ module Elasticsearch
             body = arguments[:body]
             perform_request(method, path, params, body, headers).body
           end
+        end
       end
-    end
     end
   end
 end

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/security/get_user.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/security/get_user.rb
@@ -39,7 +39,7 @@ module Elasticsearch
                        "_security/user/#{Elasticsearch::API::Utils.__listify(_username)}"
                      else
                        "_security/user"
-            end
+                     end
             params = {}
 
             body = nil
@@ -49,8 +49,8 @@ module Elasticsearch
               perform_request(method, path, params, body, headers).body
             end
           end
+        end
       end
-    end
     end
   end
 end

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/security/get_user_privileges.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/security/get_user_privileges.rb
@@ -38,8 +38,8 @@ module Elasticsearch
             body = nil
             perform_request(method, path, params, body, headers).body
           end
+        end
       end
-    end
     end
   end
 end

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/security/has_privileges.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/security/has_privileges.rb
@@ -37,19 +37,24 @@ module Elasticsearch
 
             _user = arguments.delete(:user)
 
-            method = Elasticsearch::API::HTTP_GET
-            path   = if _user
-                       "_security/user/#{Elasticsearch::API::Utils.__listify(_user)}/_has_privileges"
+            method = if arguments[:body]
+                       Elasticsearch::API::HTTP_POST
                      else
-                       "_security/user/_has_privileges"
-  end
+                       Elasticsearch::API::HTTP_GET
+                     end
+
+            path = if _user
+                     "_security/user/#{Elasticsearch::API::Utils.__listify(_user)}/_has_privileges"
+                   else
+                     "_security/user/_has_privileges"
+                   end
             params = {}
 
             body = arguments[:body]
             perform_request(method, path, params, body, headers).body
           end
+        end
       end
-    end
     end
   end
 end

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/security/invalidate_api_key.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/security/invalidate_api_key.rb
@@ -41,8 +41,8 @@ module Elasticsearch
             body = arguments[:body]
             perform_request(method, path, params, body, headers).body
           end
+        end
       end
-    end
     end
   end
 end

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/security/invalidate_token.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/security/invalidate_token.rb
@@ -41,8 +41,8 @@ module Elasticsearch
             body = arguments[:body]
             perform_request(method, path, params, body, headers).body
           end
+        end
       end
-    end
     end
   end
 end

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/security/put_privileges.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/security/put_privileges.rb
@@ -51,8 +51,8 @@ module Elasticsearch
           ParamsRegistry.register(:put_privileges, [
             :refresh
           ].freeze)
+        end
       end
-    end
     end
   end
 end

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/security/put_role.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/security/put_role.rb
@@ -55,8 +55,8 @@ module Elasticsearch
           ParamsRegistry.register(:put_role, [
             :refresh
           ].freeze)
+        end
       end
-    end
     end
   end
 end

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/security/put_role_mapping.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/security/put_role_mapping.rb
@@ -55,8 +55,8 @@ module Elasticsearch
           ParamsRegistry.register(:put_role_mapping, [
             :refresh
           ].freeze)
+        end
       end
-    end
     end
   end
 end

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/security/put_user.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/security/put_user.rb
@@ -55,8 +55,8 @@ module Elasticsearch
           ParamsRegistry.register(:put_user, [
             :refresh
           ].freeze)
+        end
       end
-    end
     end
   end
 end

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/snapshot_lifecycle_management/delete_lifecycle.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/snapshot_lifecycle_management/delete_lifecycle.rb
@@ -43,8 +43,8 @@ module Elasticsearch
             body = nil
             perform_request(method, path, params, body, headers).body
           end
+        end
       end
-    end
     end
   end
 end

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/snapshot_lifecycle_management/execute_lifecycle.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/snapshot_lifecycle_management/execute_lifecycle.rb
@@ -43,8 +43,8 @@ module Elasticsearch
             body = nil
             perform_request(method, path, params, body, headers).body
           end
+        end
       end
-    end
     end
   end
 end

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/snapshot_lifecycle_management/execute_retention.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/snapshot_lifecycle_management/execute_retention.rb
@@ -38,8 +38,8 @@ module Elasticsearch
             body = nil
             perform_request(method, path, params, body, headers).body
           end
+        end
       end
-    end
     end
   end
 end

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/snapshot_lifecycle_management/get_lifecycle.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/snapshot_lifecycle_management/get_lifecycle.rb
@@ -39,14 +39,14 @@ module Elasticsearch
                        "_slm/policy/#{Elasticsearch::API::Utils.__listify(_policy_id)}"
                      else
                        "_slm/policy"
-            end
+                     end
             params = {}
 
             body = nil
             perform_request(method, path, params, body, headers).body
           end
+        end
       end
-    end
     end
   end
 end

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/snapshot_lifecycle_management/get_stats.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/snapshot_lifecycle_management/get_stats.rb
@@ -38,8 +38,8 @@ module Elasticsearch
             body = nil
             perform_request(method, path, params, body, headers).body
           end
+        end
       end
-    end
     end
   end
 end

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/snapshot_lifecycle_management/get_status.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/snapshot_lifecycle_management/get_status.rb
@@ -38,8 +38,8 @@ module Elasticsearch
             body = nil
             perform_request(method, path, params, body, headers).body
           end
+        end
       end
-    end
     end
   end
 end

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/snapshot_lifecycle_management/put_lifecycle.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/snapshot_lifecycle_management/put_lifecycle.rb
@@ -44,8 +44,8 @@ module Elasticsearch
             body = arguments[:body]
             perform_request(method, path, params, body, headers).body
           end
+        end
       end
-    end
     end
   end
 end

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/snapshot_lifecycle_management/start.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/snapshot_lifecycle_management/start.rb
@@ -38,8 +38,8 @@ module Elasticsearch
             body = nil
             perform_request(method, path, params, body, headers).body
           end
+        end
       end
-    end
     end
   end
 end

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/snapshot_lifecycle_management/stop.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/snapshot_lifecycle_management/stop.rb
@@ -38,8 +38,8 @@ module Elasticsearch
             body = nil
             perform_request(method, path, params, body, headers).body
           end
+        end
       end
-    end
     end
   end
 end

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/sql/clear_cursor.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/sql/clear_cursor.rb
@@ -41,8 +41,8 @@ module Elasticsearch
             body = arguments[:body]
             perform_request(method, path, params, body, headers).body
           end
+        end
       end
-    end
     end
   end
 end

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/sql/query.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/sql/query.rb
@@ -49,8 +49,8 @@ module Elasticsearch
           ParamsRegistry.register(:query, [
             :format
           ].freeze)
+        end
       end
-    end
     end
   end
 end

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/sql/translate.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/sql/translate.rb
@@ -41,8 +41,8 @@ module Elasticsearch
             body = arguments[:body]
             perform_request(method, path, params, body, headers).body
           end
+        end
       end
-    end
     end
   end
 end

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/ssl/certificates.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/ssl/certificates.rb
@@ -38,8 +38,8 @@ module Elasticsearch
             body = nil
             perform_request(method, path, params, body, headers).body
           end
+        end
       end
-    end
     end
   end
 end

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/transform/delete_transform.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/transform/delete_transform.rb
@@ -51,8 +51,8 @@ module Elasticsearch
           ParamsRegistry.register(:delete_transform, [
             :force
           ].freeze)
+        end
       end
-    end
     end
   end
 end

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/transform/get_transform.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/transform/get_transform.rb
@@ -42,7 +42,7 @@ module Elasticsearch
                        "_transform/#{Elasticsearch::API::Utils.__listify(_transform_id)}"
                      else
                        "_transform"
-            end
+                     end
             params = Elasticsearch::API::Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
 
             body = nil
@@ -57,8 +57,8 @@ module Elasticsearch
             :size,
             :allow_no_match
           ].freeze)
+        end
       end
-    end
     end
   end
 end

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/transform/get_transform_stats.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/transform/get_transform_stats.rb
@@ -55,8 +55,8 @@ module Elasticsearch
             :size,
             :allow_no_match
           ].freeze)
+        end
       end
-    end
     end
   end
 end

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/transform/preview_transform.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/transform/preview_transform.rb
@@ -41,8 +41,8 @@ module Elasticsearch
             body = arguments[:body]
             perform_request(method, path, params, body, headers).body
           end
+        end
       end
-    end
     end
   end
 end

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/transform/put_transform.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/transform/put_transform.rb
@@ -53,8 +53,8 @@ module Elasticsearch
           ParamsRegistry.register(:put_transform, [
             :defer_validation
           ].freeze)
+        end
       end
-    end
     end
   end
 end

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/transform/start_transform.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/transform/start_transform.rb
@@ -51,8 +51,8 @@ module Elasticsearch
           ParamsRegistry.register(:start_transform, [
             :timeout
           ].freeze)
+        end
       end
-    end
     end
   end
 end

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/transform/stop_transform.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/transform/stop_transform.rb
@@ -59,8 +59,8 @@ module Elasticsearch
             :allow_no_match,
             :wait_for_checkpoint
           ].freeze)
+        end
       end
-    end
     end
   end
 end

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/transform/update_transform.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/transform/update_transform.rb
@@ -53,8 +53,8 @@ module Elasticsearch
           ParamsRegistry.register(:update_transform, [
             :defer_validation
           ].freeze)
+        end
       end
-    end
     end
   end
 end

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/usage.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/usage.rb
@@ -45,7 +45,7 @@ module Elasticsearch
         ParamsRegistry.register(:usage, [
           :master_timeout
         ].freeze)
-  end
       end
-end
+    end
+  end
 end

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/watcher/ack_watch.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/watcher/ack_watch.rb
@@ -44,14 +44,14 @@ module Elasticsearch
                        "_watcher/watch/#{Elasticsearch::API::Utils.__listify(_watch_id)}/_ack/#{Elasticsearch::API::Utils.__listify(_action_id)}"
                      else
                        "_watcher/watch/#{Elasticsearch::API::Utils.__listify(_watch_id)}/_ack"
-  end
+                     end
             params = {}
 
             body = nil
             perform_request(method, path, params, body, headers).body
           end
+        end
       end
-    end
     end
   end
 end

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/watcher/activate_watch.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/watcher/activate_watch.rb
@@ -43,8 +43,8 @@ module Elasticsearch
             body = nil
             perform_request(method, path, params, body, headers).body
           end
+        end
       end
-    end
     end
   end
 end

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/watcher/deactivate_watch.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/watcher/deactivate_watch.rb
@@ -43,8 +43,8 @@ module Elasticsearch
             body = nil
             perform_request(method, path, params, body, headers).body
           end
+        end
       end
-    end
     end
   end
 end

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/watcher/delete_watch.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/watcher/delete_watch.rb
@@ -47,8 +47,8 @@ module Elasticsearch
               perform_request(method, path, params, body, headers).body
             end
           end
+        end
       end
-    end
     end
   end
 end

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/watcher/execute_watch.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/watcher/execute_watch.rb
@@ -41,7 +41,7 @@ module Elasticsearch
                        "_watcher/watch/#{Elasticsearch::API::Utils.__listify(_id)}/_execute"
                      else
                        "_watcher/watch/_execute"
-            end
+                     end
             params = Elasticsearch::API::Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
 
             body = arguments[:body]
@@ -54,8 +54,8 @@ module Elasticsearch
           ParamsRegistry.register(:execute_watch, [
             :debug
           ].freeze)
+        end
       end
-    end
     end
   end
 end

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/watcher/get_watch.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/watcher/get_watch.rb
@@ -43,8 +43,8 @@ module Elasticsearch
             body = nil
             perform_request(method, path, params, body, headers).body
           end
+        end
       end
-    end
     end
   end
 end

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/watcher/put_watch.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/watcher/put_watch.rb
@@ -58,8 +58,8 @@ module Elasticsearch
             :if_seq_no,
             :if_primary_term
           ].freeze)
+        end
       end
-    end
     end
   end
 end

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/watcher/start.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/watcher/start.rb
@@ -38,8 +38,8 @@ module Elasticsearch
             body = nil
             perform_request(method, path, params, body, headers).body
           end
+        end
       end
-    end
     end
   end
 end

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/watcher/stats.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/watcher/stats.rb
@@ -45,7 +45,7 @@ module Elasticsearch
                        "_watcher/stats/#{Elasticsearch::API::Utils.__listify(_metric)}"
                      else
                        "_watcher/stats"
-            end
+                     end
             params = Elasticsearch::API::Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
 
             body = nil
@@ -59,8 +59,8 @@ module Elasticsearch
             :metric,
             :emit_stacktraces
           ].freeze)
+        end
       end
-    end
     end
   end
 end

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/watcher/stop.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/watcher/stop.rb
@@ -38,8 +38,8 @@ module Elasticsearch
             body = nil
             perform_request(method, path, params, body, headers).body
           end
+        end
       end
-    end
     end
   end
 end

--- a/elasticsearch-xpack/test/unit/security/has_privileges_test.rb
+++ b/elasticsearch-xpack/test/unit/security/has_privileges_test.rb
@@ -26,7 +26,7 @@ module Elasticsearch
 
         should "perform correct request" do
           subject.expects(:perform_request).with do |method, url, params, body|
-            assert_equal 'GET', method
+            assert_equal 'POST', method
             assert_equal '_security/user/_has_privileges', url
             assert_equal Hash.new, params
             assert_equal({ cluster: [], index: [], application: [] }, body)
@@ -38,7 +38,7 @@ module Elasticsearch
 
         should "check privileges for a specific user" do
           subject.expects(:perform_request).with do |method, url, params, body|
-            assert_equal 'GET', method
+            assert_equal 'POST', method
             assert_equal '_security/user/foo/_has_privileges', url
             assert_equal Hash.new, params
             assert_equal({ cluster: [], index: [], application: [] }, body)


### PR DESCRIPTION
This Pull Request adds logic to the API generator so that when the http methods in the spec are `GET` and `POST`, it will use one or the other depending on the presence of a body in the request.