### PR TITLE
[API] Adds Rubocop file to Generator so end is aligned correctly

### DIFF
--- a/elasticsearch-api/utils/thor/.rubocop.yml
+++ b/elasticsearch-api/utils/thor/.rubocop.yml
@@ -1,0 +1,2 @@
+Lint/EndAlignment:
+  AutoCorrect: true

--- a/elasticsearch-api/utils/thor/generate_source.rb
+++ b/elasticsearch-api/utils/thor/generate_source.rb
@@ -260,7 +260,7 @@ module Elasticsearch
       end
 
       def run_rubocop(api)
-        system("rubocop --format autogenconf -x #{FilesHelper::output_dir(api)}")
+        system("rubocop -c ./thor/.rubocop.yml --format autogenconf -x #{FilesHelper::output_dir(api)}")
       end
     end
   end


### PR DESCRIPTION
This adds a rubocop configuration file, so the `end` keywords are aligned correctly when we run Rubocop on the generated files. For now the only configuration included is setting `Lint/EndAlignment` to `Autocorrect: True`.