### PR TITLE
[DOCS] Update APM example with latest elastic-apm release information

### DIFF
--- a/docs/examples/apm/README.md
+++ b/docs/examples/apm/README.md
@@ -1,8 +1,8 @@
 # Observability Example
 
-This example provides a `docker-compose` file based on the [Quick start development environment](https://www.elastic.co/guide/en/apm/get-started/current/quick-start-overview.html) for APM. It gets the default distributions of Elasticsearch, Kibana and APM Server up and running in Docker.
+The Elasticsearch Ruby client integrates seamlessly with Elastic APM via the [Elastic APM Agent](https://github.com/elastic/apm-agent-ruby). This directory includes an example Sinatra App which interacts with Elasticsearch and is configured with APM via the apm agent.
 
-The docker-compose file also includes a basic Sinatra App and a script to ping the web app with different endpoints.
+A `docker-compose` file based on the [Quick start development environment](https://www.elastic.co/guide/en/apm/get-started/current/quick-start-overview.html) for APM is provided. It gets the default distributions of Elasticsearch, Kibana and APM Server up and running in Docker. The docker-compose file also runs the basic Sinatra App and a script to ping the web app with different endpoints.
 
 Run `docker-compose up` on the root folder of this example and you'll get everything set up. Follow the steps on the full documentation [at elastic.co](https://www.elastic.co/guide/en/apm/get-started/current/quick-start-overview.html) to get APM set up in your Kibana instance.
 
@@ -24,9 +24,11 @@ Use your web browser or `curl` against http://localhost:9292/ to check that ever
 
 The docker-compose file will also run a `pinger` script. This script will make requests irregularly to the web app to simulate proper traffic and fill your APM Dashboard with data, even errors. You can comment the pinger container from `docker-compose.yml` if you want to have all the services running and test the different endpoints (or add your own) by yourself.
 
-# Screenshot
+Once you have some requests to Elasticsearch via the Sinatra app, you can see them in your APM dashboard:
 
 ![Kibana APM Dashboard](screenshot.jpg)
+
+If you're using `elastic-apm` v3.8.0 or up, you can set `capture_elasticsearch_queries` to `true` in `config/elastic_apm.yml` to also capture the body from requests in Elasticsearch.
 
 # Routes in the example Sinatra app
 

--- a/docs/examples/apm/config/elastic_apm.yml
+++ b/docs/examples/apm/config/elastic_apm.yml
@@ -8,3 +8,6 @@ service_name: 'ruby-client-apm'
 # Set custom APM Server URL (default: http://localhost:8200)
 # In this example, we're using the URL from the docker-compose apm-server instance
 server_url: 'http://apm-server:8200'
+
+# Capture request body in Elasticsearch queries
+capture_elasticsearch_queries: true

--- a/elasticsearch-transport/README.md
+++ b/elasticsearch-transport/README.md
@@ -83,6 +83,7 @@ Full documentation is available at <http://rubydoc.info/gems/elasticsearch-trans
 * [Connect using an Elastic Cloud ID](#connect-using-an-elastic-cloud-id)
 * [Authentication](#authentication)
 * [Logging](#logging)
+* [APM integration](#apm-integration)
 * [Custom HTTP Headers](#custom-http-headers)
 * [Identifying running tasks with X-Opaque-Id](#identifying-running-tasks-with-x-opaque-id)
 * [Setting Timeouts](#setting-timeouts)
@@ -248,6 +249,9 @@ log.level = :info
 
 client = Elasticsearch::Client.new logger: log
 ```
+### APM integration
+
+This client integrates seamlessly with Elastic APM via the [Elastic APM Agent](https://github.com/elastic/apm-agent-ruby). It will automatically capture client requests if you are using the agent on your code. If you're using `elastic-apm` v3.8.0 or up, you can set `capture_elasticsearch_queries` to `true` in `config/elastic_apm.yml` to also capture the body from requests in Elasticsearch. See [here](https://github.com/elastic/elasticsearch-ruby/tree/master/docs/examples/apm) for an example.
 
 ### Custom HTTP Headers
 


### PR DESCRIPTION
Elastic APM Agent [v3.8.0](https://github.com/elastic/apm-agent-ruby/releases/tag/v3.8.0) was released last week, so the `capture_elasticsearch_queries` config option is now available to see the request bodies in APM.