### PR TITLE
Generator method

### DIFF
--- a/elasticsearch-api/lib/elasticsearch/api/actions/ingest/simulate.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/ingest/simulate.rb
@@ -37,17 +37,12 @@ module Elasticsearch
 
           _id = arguments.delete(:id)
 
-          method = if arguments[:body]
-                     Elasticsearch::API::HTTP_POST
+          method = Elasticsearch::API::HTTP_POST
+          path   = if _id
+                     "_ingest/pipeline/#{Utils.__listify(_id)}/_simulate"
                    else
-                     Elasticsearch::API::HTTP_GET
+                     "_ingest/pipeline/_simulate"
                    end
-
-          path = if _id
-                   "_ingest/pipeline/#{Utils.__listify(_id)}/_simulate"
-                 else
-                   "_ingest/pipeline/_simulate"
-                 end
           params = Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
 
           body = arguments[:body]

--- a/elasticsearch-api/lib/elasticsearch/api/actions/mget.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/mget.rb
@@ -51,19 +51,14 @@ module Elasticsearch
 
         _type = arguments.delete(:type)
 
-        method = if arguments[:body]
-                   Elasticsearch::API::HTTP_POST
+        method = Elasticsearch::API::HTTP_POST
+        path   = if _index && _type
+                   "#{Utils.__listify(_index)}/#{Utils.__listify(_type)}/_mget"
+                 elsif _index
+                   "#{Utils.__listify(_index)}/_mget"
                  else
-                   Elasticsearch::API::HTTP_GET
+                   "_mget"
                  end
-
-        path = if _index && _type
-                 "#{Utils.__listify(_index)}/#{Utils.__listify(_type)}/_mget"
-               elsif _index
-                 "#{Utils.__listify(_index)}/_mget"
-               else
-                 "_mget"
-               end
         params = Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
 
         body = arguments[:body]

--- a/elasticsearch-api/lib/elasticsearch/api/actions/msearch.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/msearch.rb
@@ -52,19 +52,14 @@ module Elasticsearch
 
         _type = arguments.delete(:type)
 
-        method = if arguments[:body]
-                   Elasticsearch::API::HTTP_POST
+        method = Elasticsearch::API::HTTP_POST
+        path   = if _index && _type
+                   "#{Utils.__listify(_index)}/#{Utils.__listify(_type)}/_msearch"
+                 elsif _index
+                   "#{Utils.__listify(_index)}/_msearch"
                  else
-                   Elasticsearch::API::HTTP_GET
+                   "_msearch"
                  end
-
-        path = if _index && _type
-                 "#{Utils.__listify(_index)}/#{Utils.__listify(_type)}/_msearch"
-               elsif _index
-                 "#{Utils.__listify(_index)}/_msearch"
-               else
-                 "_msearch"
-               end
         params = Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
 
         body = arguments[:body]

--- a/elasticsearch-api/lib/elasticsearch/api/actions/msearch_template.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/msearch_template.rb
@@ -50,19 +50,14 @@ module Elasticsearch
 
         _type = arguments.delete(:type)
 
-        method = if arguments[:body]
-                   Elasticsearch::API::HTTP_POST
+        method = Elasticsearch::API::HTTP_POST
+        path   = if _index && _type
+                   "#{Utils.__listify(_index)}/#{Utils.__listify(_type)}/_msearch/template"
+                 elsif _index
+                   "#{Utils.__listify(_index)}/_msearch/template"
                  else
-                   Elasticsearch::API::HTTP_GET
+                   "_msearch/template"
                  end
-
-        path = if _index && _type
-                 "#{Utils.__listify(_index)}/#{Utils.__listify(_type)}/_msearch/template"
-               elsif _index
-                 "#{Utils.__listify(_index)}/_msearch/template"
-               else
-                 "_msearch/template"
-               end
         params = Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
 
         body = arguments[:body]

--- a/elasticsearch-api/lib/elasticsearch/api/actions/rank_eval.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/rank_eval.rb
@@ -43,17 +43,12 @@ module Elasticsearch
 
         _index = arguments.delete(:index)
 
-        method = if arguments[:body]
-                   Elasticsearch::API::HTTP_POST
+        method = Elasticsearch::API::HTTP_POST
+        path   = if _index
+                   "#{Utils.__listify(_index)}/_rank_eval"
                  else
-                   Elasticsearch::API::HTTP_GET
+                   "_rank_eval"
                  end
-
-        path = if _index
-                 "#{Utils.__listify(_index)}/_rank_eval"
-               else
-                 "_rank_eval"
-               end
         params = Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
 
         body = arguments[:body]

--- a/elasticsearch-api/lib/elasticsearch/api/actions/search_template.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/search_template.rb
@@ -60,19 +60,14 @@ module Elasticsearch
 
         _type = arguments.delete(:type)
 
-        method = if arguments[:body]
-                   Elasticsearch::API::HTTP_POST
+        method = Elasticsearch::API::HTTP_POST
+        path   = if _index && _type
+                   "#{Utils.__listify(_index)}/#{Utils.__listify(_type)}/_search/template"
+                 elsif _index
+                   "#{Utils.__listify(_index)}/_search/template"
                  else
-                   Elasticsearch::API::HTTP_GET
+                   "_search/template"
                  end
-
-        path = if _index && _type
-                 "#{Utils.__listify(_index)}/#{Utils.__listify(_type)}/_search/template"
-               elsif _index
-                 "#{Utils.__listify(_index)}/_search/template"
-               else
-                 "_search/template"
-               end
         params = Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
 
         body = arguments[:body]

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/eql/search.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/eql/search.rb
@@ -42,13 +42,8 @@ module Elasticsearch
 
             _index = arguments.delete(:index)
 
-            method = if arguments[:body]
-                       Elasticsearch::API::HTTP_POST
-                     else
-                       Elasticsearch::API::HTTP_GET
-                     end
-
-            path = "#{Elasticsearch::API::Utils.__listify(_index)}/_eql/search"
+            method = Elasticsearch::API::HTTP_POST
+            path   = "#{Elasticsearch::API::Utils.__listify(_index)}/_eql/search"
             params = Elasticsearch::API::Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
 
             body = arguments[:body]

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/rollup/rollup_search.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/rollup/rollup_search.rb
@@ -48,17 +48,12 @@ module Elasticsearch
 
             _type = arguments.delete(:type)
 
-            method = if arguments[:body]
-                       Elasticsearch::API::HTTP_POST
+            method = Elasticsearch::API::HTTP_POST
+            path   = if _index && _type
+                       "#{Elasticsearch::API::Utils.__listify(_index)}/#{Elasticsearch::API::Utils.__listify(_type)}/_rollup_search"
                      else
-                       Elasticsearch::API::HTTP_GET
+                       "#{Elasticsearch::API::Utils.__listify(_index)}/_rollup_search"
                      end
-
-            path = if _index && _type
-                     "#{Elasticsearch::API::Utils.__listify(_index)}/#{Elasticsearch::API::Utils.__listify(_type)}/_rollup_search"
-                   else
-                     "#{Elasticsearch::API::Utils.__listify(_index)}/_rollup_search"
-                   end
             params = Elasticsearch::API::Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
 
             body = arguments[:body]

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/security/has_privileges.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/security/has_privileges.rb
@@ -37,17 +37,12 @@ module Elasticsearch
 
             _user = arguments.delete(:user)
 
-            method = if arguments[:body]
-                       Elasticsearch::API::HTTP_POST
+            method = Elasticsearch::API::HTTP_POST
+            path   = if _user
+                       "_security/user/#{Elasticsearch::API::Utils.__listify(_user)}/_has_privileges"
                      else
-                       Elasticsearch::API::HTTP_GET
+                       "_security/user/_has_privileges"
                      end
-
-            path = if _user
-                     "_security/user/#{Elasticsearch::API::Utils.__listify(_user)}/_has_privileges"
-                   else
-                     "_security/user/_has_privileges"
-                   end
             params = {}
 
             body = arguments[:body]


### PR DESCRIPTION
This Pull Request simplifies the generated API code. When a body is required for an endpoint and the allowed HTTP methods are `GET` and `POST`, always use `POST` for consistency. The `GET` part of the if was never used if there was a body anyway.