### PR TITLE
Retry docs

### DIFF
--- a/elasticsearch-transport/README.md
+++ b/elasticsearch-transport/README.md
@@ -326,8 +326,7 @@ on a different host:
 Elasticsearch::Client.new hosts: ['localhost:9200', 'localhost:9201'], retry_on_failure: true
 ```
 
-You can specify how many times should the client retry the request before it raises an exception
-(the default is 3 times):
+By default, the client will retry the request 3 times. You can specify how many times to retry before it raises an exception by passing a number to `retry_on_failure`:
 
 ```ruby
 Elasticsearch::Client.new hosts: ['localhost:9200', 'localhost:9201'], retry_on_failure: 5
@@ -337,6 +336,12 @@ You can also use `retry_on_status` to retry when specific status codes are retur
 
 ```ruby
 Elasticsearch::Client.new hosts: ['localhost:9200', 'localhost:9201'], retry_on_status: [502, 503]
+```
+
+These two parameters can also be used together:
+
+```ruby
+Elasticsearch::Client.new hosts: ['localhost:9200', 'localhost:9201'], retry_on_status: [502, 503], retry_on_failure: 10
 ```
 
 ### Reloading Hosts

--- a/elasticsearch-transport/spec/elasticsearch/transport/base_spec.rb
+++ b/elasticsearch-transport/spec/elasticsearch/transport/base_spec.rb
@@ -18,11 +18,8 @@
 require 'spec_helper'
 
 describe Elasticsearch::Transport::Transport::Base do
-
   context 'when a host is printed in a logged message' do
-
     shared_examples_for 'a redacted string' do
-
       let(:client) do
         Elasticsearch::Transport::Client.new(arguments)
       end
@@ -47,32 +44,35 @@ describe Elasticsearch::Transport::Transport::Base do
     end
 
     context 'when the user and password are provided as separate arguments' do
-
       let(:arguments) do
-        { hosts: 'fake',
+        {
+          hosts: 'fake',
           logger: logger,
           password: 'secret_password',
-          user: 'test' }
+          user: 'test'
+        }
       end
 
       it_behaves_like 'a redacted string'
     end
 
     context 'when the user and password are provided in the string URI' do
-
       let(:arguments) do
-        { hosts: 'http://test:secret_password@fake',
-          logger: logger }
+        {
+          hosts: 'http://test:secret_password@fake',
+          logger: logger
+        }
       end
 
       it_behaves_like 'a redacted string'
     end
 
     context 'when the user and password are provided in the URI object' do
-
       let(:arguments) do
-        { hosts: URI.parse('http://test:secret_password@fake'),
-          logger: logger }
+        {
+          hosts: URI.parse('http://test:secret_password@fake'),
+          logger: logger
+        }
       end
 
       it_behaves_like 'a redacted string'
@@ -80,36 +80,32 @@ describe Elasticsearch::Transport::Transport::Base do
   end
 
   context 'when reload_on_failure is true and and hosts are unreachable' do
-
     let(:client) do
       Elasticsearch::Transport::Client.new(arguments)
     end
 
     let(:arguments) do
       {
-          hosts: ['http://unavailable:9200', 'http://unavailable:9201'],
-          reload_on_failure: true,
-          sniffer_timeout: 5
+        hosts: ['http://unavailable:9200', 'http://unavailable:9201'],
+        reload_on_failure: true,
+        sniffer_timeout: 5
       }
     end
 
     it 'raises an exception' do
-      expect {
-        client.info
-      }.to raise_exception(Faraday::ConnectionFailed)
+      expect { client.info }.to raise_exception(Faraday::ConnectionFailed)
     end
   end
 
   context 'when the client has `retry_on_failure` set to an integer' do
-
     let(:client) do
       Elasticsearch::Transport::Client.new(arguments)
     end
 
     let(:arguments) do
       {
-          hosts: ['http://unavailable:9200', 'http://unavailable:9201'],
-          retry_on_failure: 2
+        hosts: ['http://unavailable:9200', 'http://unavailable:9201'],
+        retry_on_failure: 2
       }
     end
 
@@ -214,40 +210,35 @@ describe Elasticsearch::Transport::Transport::Base do
   end
 
   context 'when the client has no `retry_on_failure` set' do
-
     let(:client) do
       Elasticsearch::Transport::Client.new(arguments)
     end
 
     let(:arguments) do
-      {
-          hosts: ['http://unavailable:9200', 'http://unavailable:9201'],
-      }
+      { hosts: ['http://unavailable:9200', 'http://unavailable:9201'] }
     end
 
     context 'when `perform_request` is called without a `retry_on_failure` option value' do
-
       before do
         expect(client.transport).to receive(:get_connection).exactly(1).times.and_call_original
       end
 
       it 'does not retry' do
-        expect {
+        expect do
           client.transport.perform_request('GET', '/info')
-        }.to raise_exception(Faraday::ConnectionFailed)
+        end.to raise_exception(Faraday::ConnectionFailed)
       end
     end
 
     context 'when `perform_request` is called with a `retry_on_failure` option value' do
-
       before do
         expect(client.transport).to receive(:get_connection).exactly(6).times.and_call_original
       end
 
       it 'uses the option `retry_on_failure` value' do
-        expect {
+        expect do
           client.transport.perform_request('GET', '/info', {}, nil, nil, retry_on_failure: 5)
-        }.to raise_exception(Faraday::ConnectionFailed)
+        end.to raise_exception(Faraday::ConnectionFailed)
       end
     end
   end

--- a/elasticsearch-transport/spec/elasticsearch/transport/base_spec.rb
+++ b/elasticsearch-transport/spec/elasticsearch/transport/base_spec.rb
@@ -121,15 +121,34 @@ describe Elasticsearch::Transport::Transport::Base do
       end
     end
 
+    context 'when `perform_request` is called with a `retry_on_status` option value' do
+      before do
+        expect(client.transport).to receive(:__raise_transport_error).exactly(6).times.and_call_original
+      end
+
+      let(:arguments) do
+        {
+          hosts: ['http://localhost:9250'],
+          retry_on_status: ['404']
+        }
+      end
+
+      it 'retries on 404 status the specified number of max_retries' do
+        expect do
+          client.transport.perform_request('GET', 'myindex/mydoc/1?routing=FOOBARBAZ', {}, nil, nil, retry_on_failure: 5)
+        end.to raise_exception(Elasticsearch::Transport::Transport::Errors::NotFound)
+      end
+    end
+
     context 'when `perform_request` is called with a `retry_on_failure` option value' do
       before do
         expect(client.transport).to receive(:get_connection).exactly(6).times.and_call_original
       end
 
       it 'uses the option `retry_on_failure` value' do
-        expect {
+        expect do
           client.transport.perform_request('GET', '/info', {}, nil, nil, retry_on_failure: 5)
-        }.to raise_exception(Faraday::ConnectionFailed)
+        end.to raise_exception(Faraday::ConnectionFailed)
       end
     end
   end


### PR DESCRIPTION
Based on #878, it wasn't clear enough that the client supports using `retry_on_failure` and `retry_on_status` together. So I added a few words and a test to attempt to make it more clear.