### PR TITLE
Generator doc fix

### DIFF
--- a/elasticsearch-api/lib/elasticsearch/api/actions/bulk.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/bulk.rb
@@ -25,7 +25,6 @@ module Elasticsearch
       # @option arguments [String] :wait_for_active_shards Sets the number of shard copies that must be active before proceeding with the bulk operation. Defaults to 1, meaning the primary shard only. Set to `all` for all shard copies, otherwise set to any non-negative value less than or equal to the total number of copies for the shard (number of replicas + 1)
       # @option arguments [String] :refresh If `true` then refresh the affected shards to make this operation visible to search, if `wait_for` then wait for a refresh to make this operation visible to search, if `false` (the default) then do nothing with refreshes.
       #   (options: true,false,wait_for)
-
       # @option arguments [String] :routing Specific routing value
       # @option arguments [Time] :timeout Explicit operation timeout
       # @option arguments [String] :type Default document type for items which don't provide one

--- a/elasticsearch-api/lib/elasticsearch/api/actions/cat/aliases.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/cat/aliases.rb
@@ -30,7 +30,6 @@ module Elasticsearch
         # @option arguments [Boolean] :v Verbose mode. Display column headers
         # @option arguments [String] :expand_wildcards Whether to expand wildcard expression to concrete indices that are open, closed or both.
         #   (options: open,closed,hidden,none,all)
-
         # @option arguments [Hash] :headers Custom HTTP headers
         #
         # @see https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-alias.html

--- a/elasticsearch-api/lib/elasticsearch/api/actions/cat/allocation.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/cat/allocation.rb
@@ -25,7 +25,6 @@ module Elasticsearch
         # @option arguments [String] :format a short version of the Accept header, e.g. json, yaml
         # @option arguments [String] :bytes The unit in which to display byte values
         #   (options: b,k,kb,m,mb,g,gb,t,tb,p,pb)
-
         # @option arguments [Boolean] :local Return local information, do not retrieve the state from master node (default: false)
         # @option arguments [Time] :master_timeout Explicit operation timeout for connection to master node
         # @option arguments [List] :h Comma-separated list of column names to display

--- a/elasticsearch-api/lib/elasticsearch/api/actions/cat/fielddata.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/cat/fielddata.rb
@@ -25,7 +25,6 @@ module Elasticsearch
         # @option arguments [String] :format a short version of the Accept header, e.g. json, yaml
         # @option arguments [String] :bytes The unit in which to display byte values
         #   (options: b,k,kb,m,mb,g,gb,t,tb,p,pb)
-
         # @option arguments [List] :h Comma-separated list of column names to display
         # @option arguments [Boolean] :help Return help information
         # @option arguments [List] :s Comma-separated list of column names or column aliases to sort by

--- a/elasticsearch-api/lib/elasticsearch/api/actions/cat/health.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/cat/health.rb
@@ -27,7 +27,6 @@ module Elasticsearch
         # @option arguments [List] :s Comma-separated list of column names or column aliases to sort by
         # @option arguments [String] :time The unit in which to display time values
         #   (options: d,h,m,s,ms,micros,nanos)
-
         # @option arguments [Boolean] :ts Set to false to disable timestamping
         # @option arguments [Boolean] :v Verbose mode. Display column headers
         # @option arguments [Hash] :headers Custom HTTP headers

--- a/elasticsearch-api/lib/elasticsearch/api/actions/cat/indices.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/cat/indices.rb
@@ -25,24 +25,20 @@ module Elasticsearch
         # @option arguments [String] :format a short version of the Accept header, e.g. json, yaml
         # @option arguments [String] :bytes The unit in which to display byte values
         #   (options: b,k,kb,m,mb,g,gb,t,tb,p,pb)
-
         # @option arguments [Boolean] :local Return local information, do not retrieve the state from master node (default: false)
         # @option arguments [Time] :master_timeout Explicit operation timeout for connection to master node
         # @option arguments [List] :h Comma-separated list of column names to display
         # @option arguments [String] :health A health status ("green", "yellow", or "red" to filter only indices matching the specified health status
         #   (options: green,yellow,red)
-
         # @option arguments [Boolean] :help Return help information
         # @option arguments [Boolean] :pri Set to true to return stats only for primary shards
         # @option arguments [List] :s Comma-separated list of column names or column aliases to sort by
         # @option arguments [String] :time The unit in which to display time values
         #   (options: d,h,m,s,ms,micros,nanos)
-
         # @option arguments [Boolean] :v Verbose mode. Display column headers
         # @option arguments [Boolean] :include_unloaded_segments If set to true segment stats will include stats for segments that are not currently loaded into memory
         # @option arguments [String] :expand_wildcards Whether to expand wildcard expression to concrete indices that are open, closed or both.
         #   (options: open,closed,hidden,none,all)
-
         # @option arguments [Hash] :headers Custom HTTP headers
         #
         # @see https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-indices.html

--- a/elasticsearch-api/lib/elasticsearch/api/actions/cat/nodes.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/cat/nodes.rb
@@ -23,7 +23,6 @@ module Elasticsearch
         #
         # @option arguments [String] :bytes The unit in which to display byte values
         #   (options: b,k,kb,m,mb,g,gb,t,tb,p,pb)
-
         # @option arguments [String] :format a short version of the Accept header, e.g. json, yaml
         # @option arguments [Boolean] :full_id Return the full node ID instead of the shortened version (default: false)
         # @option arguments [Time] :master_timeout Explicit operation timeout for connection to master node
@@ -32,7 +31,6 @@ module Elasticsearch
         # @option arguments [List] :s Comma-separated list of column names or column aliases to sort by
         # @option arguments [String] :time The unit in which to display time values
         #   (options: d,h,m,s,ms,micros,nanos)
-
         # @option arguments [Boolean] :v Verbose mode. Display column headers
         # @option arguments [Hash] :headers Custom HTTP headers
         #

--- a/elasticsearch-api/lib/elasticsearch/api/actions/cat/pending_tasks.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/cat/pending_tasks.rb
@@ -29,7 +29,6 @@ module Elasticsearch
         # @option arguments [List] :s Comma-separated list of column names or column aliases to sort by
         # @option arguments [String] :time The unit in which to display time values
         #   (options: d,h,m,s,ms,micros,nanos)
-
         # @option arguments [Boolean] :v Verbose mode. Display column headers
         # @option arguments [Hash] :headers Custom HTTP headers
         #

--- a/elasticsearch-api/lib/elasticsearch/api/actions/cat/recovery.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/cat/recovery.rb
@@ -26,7 +26,6 @@ module Elasticsearch
         # @option arguments [Boolean] :active_only If `true`, the response only includes ongoing shard recoveries
         # @option arguments [String] :bytes The unit in which to display byte values
         #   (options: b,k,kb,m,mb,g,gb,t,tb,p,pb)
-
         # @option arguments [Boolean] :detailed If `true`, the response includes detailed information about shard recoveries
         # @option arguments [List] :h Comma-separated list of column names to display
         # @option arguments [Boolean] :help Return help information
@@ -34,7 +33,6 @@ module Elasticsearch
         # @option arguments [List] :s Comma-separated list of column names or column aliases to sort by
         # @option arguments [String] :time The unit in which to display time values
         #   (options: d,h,m,s,ms,micros,nanos)
-
         # @option arguments [Boolean] :v Verbose mode. Display column headers
         # @option arguments [Hash] :headers Custom HTTP headers
         #

--- a/elasticsearch-api/lib/elasticsearch/api/actions/cat/segments.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/cat/segments.rb
@@ -25,7 +25,6 @@ module Elasticsearch
         # @option arguments [String] :format a short version of the Accept header, e.g. json, yaml
         # @option arguments [String] :bytes The unit in which to display byte values
         #   (options: b,k,kb,m,mb,g,gb,t,tb,p,pb)
-
         # @option arguments [List] :h Comma-separated list of column names to display
         # @option arguments [Boolean] :help Return help information
         # @option arguments [List] :s Comma-separated list of column names or column aliases to sort by

--- a/elasticsearch-api/lib/elasticsearch/api/actions/cat/shards.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/cat/shards.rb
@@ -25,7 +25,6 @@ module Elasticsearch
         # @option arguments [String] :format a short version of the Accept header, e.g. json, yaml
         # @option arguments [String] :bytes The unit in which to display byte values
         #   (options: b,k,kb,m,mb,g,gb,t,tb,p,pb)
-
         # @option arguments [Boolean] :local Return local information, do not retrieve the state from master node (default: false)
         # @option arguments [Time] :master_timeout Explicit operation timeout for connection to master node
         # @option arguments [List] :h Comma-separated list of column names to display
@@ -33,7 +32,6 @@ module Elasticsearch
         # @option arguments [List] :s Comma-separated list of column names or column aliases to sort by
         # @option arguments [String] :time The unit in which to display time values
         #   (options: d,h,m,s,ms,micros,nanos)
-
         # @option arguments [Boolean] :v Verbose mode. Display column headers
         # @option arguments [Hash] :headers Custom HTTP headers
         #

--- a/elasticsearch-api/lib/elasticsearch/api/actions/cat/snapshots.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/cat/snapshots.rb
@@ -30,7 +30,6 @@ module Elasticsearch
         # @option arguments [List] :s Comma-separated list of column names or column aliases to sort by
         # @option arguments [String] :time The unit in which to display time values
         #   (options: d,h,m,s,ms,micros,nanos)
-
         # @option arguments [Boolean] :v Verbose mode. Display column headers
         # @option arguments [Hash] :headers Custom HTTP headers
         #

--- a/elasticsearch-api/lib/elasticsearch/api/actions/cat/tasks.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/cat/tasks.rb
@@ -31,7 +31,6 @@ module Elasticsearch
         # @option arguments [List] :s Comma-separated list of column names or column aliases to sort by
         # @option arguments [String] :time The unit in which to display time values
         #   (options: d,h,m,s,ms,micros,nanos)
-
         # @option arguments [Boolean] :v Verbose mode. Display column headers
         # @option arguments [Hash] :headers Custom HTTP headers
         #

--- a/elasticsearch-api/lib/elasticsearch/api/actions/cat/thread_pool.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/cat/thread_pool.rb
@@ -26,7 +26,6 @@ module Elasticsearch
         # @option arguments [String] :format a short version of the Accept header, e.g. json, yaml
         # @option arguments [String] :time The unit in which to display time values
         #   (options: d,h,m,s,ms,micros,nanos)
-
         # @option arguments [Boolean] :local Return local information, do not retrieve the state from master node (default: false)
         # @option arguments [Time] :master_timeout Explicit operation timeout for connection to master node
         # @option arguments [List] :h Comma-separated list of column names to display

--- a/elasticsearch-api/lib/elasticsearch/api/actions/cluster/health.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/cluster/health.rb
@@ -24,10 +24,8 @@ module Elasticsearch
         # @option arguments [List] :index Limit the information returned to a specific index
         # @option arguments [String] :expand_wildcards Whether to expand wildcard expression to concrete indices that are open, closed or both.
         #   (options: open,closed,hidden,none,all)
-
         # @option arguments [String] :level Specify the level of detail for returned information
         #   (options: cluster,indices,shards)
-
         # @option arguments [Boolean] :local Return local information, do not retrieve the state from master node (default: false)
         # @option arguments [Time] :master_timeout Explicit operation timeout for connection to master node
         # @option arguments [Time] :timeout Explicit operation timeout
@@ -35,12 +33,10 @@ module Elasticsearch
         # @option arguments [String] :wait_for_nodes Wait until the specified number of nodes is available
         # @option arguments [String] :wait_for_events Wait until all currently queued events with the given priority are processed
         #   (options: immediate,urgent,high,normal,low,languid)
-
         # @option arguments [Boolean] :wait_for_no_relocating_shards Whether to wait until there are no relocating shards in the cluster
         # @option arguments [Boolean] :wait_for_no_initializing_shards Whether to wait until there are no initializing shards in the cluster
         # @option arguments [String] :wait_for_status Wait until cluster is in a specific state
         #   (options: green,yellow,red)
-
         # @option arguments [Hash] :headers Custom HTTP headers
         #
         # @see https://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-health.html

--- a/elasticsearch-api/lib/elasticsearch/api/actions/cluster/reroute.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/cluster/reroute.rb
@@ -26,7 +26,6 @@ module Elasticsearch
         # @option arguments [Boolean] :retry_failed Retries allocation of shards that are blocked due to too many subsequent allocation failures
         # @option arguments [List] :metric Limit the information returned to the specified metrics. Defaults to all but metadata
         #   (options: _all,blocks,metadata,nodes,routing_table,master_node,version)
-
         # @option arguments [Time] :master_timeout Explicit operation timeout for connection to master node
         # @option arguments [Time] :timeout Explicit operation timeout
         # @option arguments [Hash] :headers Custom HTTP headers

--- a/elasticsearch-api/lib/elasticsearch/api/actions/cluster/state.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/cluster/state.rb
@@ -23,7 +23,6 @@ module Elasticsearch
         #
         # @option arguments [List] :metric Limit the information returned to the specified metrics
         #   (options: _all,blocks,metadata,nodes,routing_table,routing_nodes,master_node,version)
-
         # @option arguments [List] :index A comma-separated list of index names; use `_all` or empty string to perform the operation on all indices
         # @option arguments [Boolean] :local Return local information, do not retrieve the state from master node (default: false)
         # @option arguments [Time] :master_timeout Specify timeout for connection to master
@@ -34,7 +33,6 @@ module Elasticsearch
         # @option arguments [Boolean] :allow_no_indices Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)
         # @option arguments [String] :expand_wildcards Whether to expand wildcard expression to concrete indices that are open, closed or both.
         #   (options: open,closed,hidden,none,all)
-
         # @option arguments [Hash] :headers Custom HTTP headers
         #
         # @see https://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-state.html

--- a/elasticsearch-api/lib/elasticsearch/api/actions/count.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/count.rb
@@ -26,7 +26,6 @@ module Elasticsearch
       # @option arguments [Boolean] :allow_no_indices Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)
       # @option arguments [String] :expand_wildcards Whether to expand wildcard expression to concrete indices that are open, closed or both.
       #   (options: open,closed,hidden,none,all)
-
       # @option arguments [Number] :min_score Include only documents with a specific `_score` value in the result
       # @option arguments [String] :preference Specify the node or shard the operation should be performed on (default: random)
       # @option arguments [List] :routing A comma-separated list of specific routing values
@@ -35,7 +34,6 @@ module Elasticsearch
       # @option arguments [Boolean] :analyze_wildcard Specify whether wildcard and prefix queries should be analyzed (default: false)
       # @option arguments [String] :default_operator The default operator for query string query (AND or OR)
       #   (options: AND,OR)
-
       # @option arguments [String] :df The field to use as default where no field prefix is given in the query string
       # @option arguments [Boolean] :lenient Specify whether format-based query failures (such as providing text to a numeric field) should be ignored
       # @option arguments [Number] :terminate_after The maximum count for each shard, upon reaching which the query execution will terminate early

--- a/elasticsearch-api/lib/elasticsearch/api/actions/create.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/create.rb
@@ -28,13 +28,11 @@ module Elasticsearch
       # @option arguments [String] :wait_for_active_shards Sets the number of shard copies that must be active before proceeding with the index operation. Defaults to 1, meaning the primary shard only. Set to `all` for all shard copies, otherwise set to any non-negative value less than or equal to the total number of copies for the shard (number of replicas + 1)
       # @option arguments [String] :refresh If `true` then refresh the affected shards to make this operation visible to search, if `wait_for` then wait for a refresh to make this operation visible to search, if `false` (the default) then do nothing with refreshes.
       #   (options: true,false,wait_for)
-
       # @option arguments [String] :routing Specific routing value
       # @option arguments [Time] :timeout Explicit operation timeout
       # @option arguments [Number] :version Explicit version number for concurrency control
       # @option arguments [String] :version_type Specific version type
       #   (options: internal,external,external_gte)
-
       # @option arguments [String] :pipeline The pipeline id to preprocess incoming documents with
       # @option arguments [Hash] :headers Custom HTTP headers
       # @option arguments [Hash] :body The document (*Required*)

--- a/elasticsearch-api/lib/elasticsearch/api/actions/delete.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/delete.rb
@@ -26,7 +26,6 @@ module Elasticsearch
       # @option arguments [String] :wait_for_active_shards Sets the number of shard copies that must be active before proceeding with the delete operation. Defaults to 1, meaning the primary shard only. Set to `all` for all shard copies, otherwise set to any non-negative value less than or equal to the total number of copies for the shard (number of replicas + 1)
       # @option arguments [String] :refresh If `true` then refresh the affected shards to make this operation visible to search, if `wait_for` then wait for a refresh to make this operation visible to search, if `false` (the default) then do nothing with refreshes.
       #   (options: true,false,wait_for)
-
       # @option arguments [String] :routing Specific routing value
       # @option arguments [Time] :timeout Explicit operation timeout
       # @option arguments [Number] :if_seq_no only perform the delete operation if the last operation that has changed the document has the specified sequence number
@@ -34,7 +33,6 @@ module Elasticsearch
       # @option arguments [Number] :version Explicit version number for concurrency control
       # @option arguments [String] :version_type Specific version type
       #   (options: internal,external,external_gte)
-
       # @option arguments [Hash] :headers Custom HTTP headers
       #
       # *Deprecation notice*:

--- a/elasticsearch-api/lib/elasticsearch/api/actions/delete_by_query.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/delete_by_query.rb
@@ -25,17 +25,14 @@ module Elasticsearch
       # @option arguments [Boolean] :analyze_wildcard Specify whether wildcard and prefix queries should be analyzed (default: false)
       # @option arguments [String] :default_operator The default operator for query string query (AND or OR)
       #   (options: AND,OR)
-
       # @option arguments [String] :df The field to use as default where no field prefix is given in the query string
       # @option arguments [Number] :from Starting offset (default: 0)
       # @option arguments [Boolean] :ignore_unavailable Whether specified concrete indices should be ignored when unavailable (missing or closed)
       # @option arguments [Boolean] :allow_no_indices Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)
       # @option arguments [String] :conflicts What to do when the delete by query hits version conflicts?
       #   (options: abort,proceed)
-
       # @option arguments [String] :expand_wildcards Whether to expand wildcard expression to concrete indices that are open, closed or both.
       #   (options: open,closed,hidden,none,all)
-
       # @option arguments [Boolean] :lenient Specify whether format-based query failures (such as providing text to a numeric field) should be ignored
       # @option arguments [String] :preference Specify the node or shard the operation should be performed on (default: random)
       # @option arguments [String] :q Query in the Lucene query string syntax
@@ -43,7 +40,6 @@ module Elasticsearch
       # @option arguments [Time] :scroll Specify how long a consistent view of the index should be maintained for scrolled search
       # @option arguments [String] :search_type Search operation type
       #   (options: query_then_fetch,dfs_query_then_fetch)
-
       # @option arguments [Time] :search_timeout Explicit timeout for each search request. Defaults to no timeout.
       # @option arguments [Number] :max_docs Maximum number of documents to process (default: all documents)
       # @option arguments [List] :sort A comma-separated list of <field>:<direction> pairs

--- a/elasticsearch-api/lib/elasticsearch/api/actions/exists.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/exists.rb
@@ -33,7 +33,6 @@ module Elasticsearch
       # @option arguments [Number] :version Explicit version number for concurrency control
       # @option arguments [String] :version_type Specific version type
       #   (options: internal,external,external_gte)
-
       # @option arguments [Hash] :headers Custom HTTP headers
       #
       # @see https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-get.html

--- a/elasticsearch-api/lib/elasticsearch/api/actions/exists_source.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/exists_source.rb
@@ -33,7 +33,6 @@ module Elasticsearch
       # @option arguments [Number] :version Explicit version number for concurrency control
       # @option arguments [String] :version_type Specific version type
       #   (options: internal,external,external_gte)
-
       # @option arguments [Hash] :headers Custom HTTP headers
       #
       # *Deprecation notice*:

--- a/elasticsearch-api/lib/elasticsearch/api/actions/explain.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/explain.rb
@@ -26,7 +26,6 @@ module Elasticsearch
       # @option arguments [String] :analyzer The analyzer for the query string query
       # @option arguments [String] :default_operator The default operator for query string query (AND or OR)
       #   (options: AND,OR)
-
       # @option arguments [String] :df The default field for query string query (default: _all)
       # @option arguments [List] :stored_fields A comma-separated list of stored fields to return in the response
       # @option arguments [Boolean] :lenient Specify whether format-based query failures (such as providing text to a numeric field) should be ignored

--- a/elasticsearch-api/lib/elasticsearch/api/actions/field_caps.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/field_caps.rb
@@ -26,7 +26,6 @@ module Elasticsearch
       # @option arguments [Boolean] :allow_no_indices Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)
       # @option arguments [String] :expand_wildcards Whether to expand wildcard expression to concrete indices that are open, closed or both.
       #   (options: open,closed,hidden,none,all)
-
       # @option arguments [Boolean] :include_unmapped Indicates whether unmapped fields should be included in the response.
       # @option arguments [Hash] :headers Custom HTTP headers
       # @option arguments [Hash] :body An index filter specified with the Query DSL

--- a/elasticsearch-api/lib/elasticsearch/api/actions/get.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/get.rb
@@ -33,7 +33,6 @@ module Elasticsearch
       # @option arguments [Number] :version Explicit version number for concurrency control
       # @option arguments [String] :version_type Specific version type
       #   (options: internal,external,external_gte)
-
       # @option arguments [Hash] :headers Custom HTTP headers
       #
       # @see https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-get.html

--- a/elasticsearch-api/lib/elasticsearch/api/actions/get_source.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/get_source.rb
@@ -32,7 +32,6 @@ module Elasticsearch
       # @option arguments [Number] :version Explicit version number for concurrency control
       # @option arguments [String] :version_type Specific version type
       #   (options: internal,external,external_gte)
-
       # @option arguments [Hash] :headers Custom HTTP headers
       #
       # @see https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-get.html

--- a/elasticsearch-api/lib/elasticsearch/api/actions/index.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/index.rb
@@ -25,16 +25,13 @@ module Elasticsearch
       # @option arguments [String] :wait_for_active_shards Sets the number of shard copies that must be active before proceeding with the index operation. Defaults to 1, meaning the primary shard only. Set to `all` for all shard copies, otherwise set to any non-negative value less than or equal to the total number of copies for the shard (number of replicas + 1)
       # @option arguments [String] :op_type Explicit operation type. Defaults to `index` for requests with an explicit document ID, and to `create`for requests without an explicit document ID
       #   (options: index,create)
-
       # @option arguments [String] :refresh If `true` then refresh the affected shards to make this operation visible to search, if `wait_for` then wait for a refresh to make this operation visible to search, if `false` (the default) then do nothing with refreshes.
       #   (options: true,false,wait_for)
-
       # @option arguments [String] :routing Specific routing value
       # @option arguments [Time] :timeout Explicit operation timeout
       # @option arguments [Number] :version Explicit version number for concurrency control
       # @option arguments [String] :version_type Specific version type
       #   (options: internal,external,external_gte)
-
       # @option arguments [Number] :if_seq_no only perform the index operation if the last operation that has changed the document has the specified sequence number
       # @option arguments [Number] :if_primary_term only perform the index operation if the last operation that has changed the document has the specified primary term
       # @option arguments [String] :pipeline The pipeline id to preprocess incoming documents with

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/add_block.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/add_block.rb
@@ -29,7 +29,6 @@ module Elasticsearch
         # @option arguments [Boolean] :allow_no_indices Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)
         # @option arguments [String] :expand_wildcards Whether to expand wildcard expression to concrete indices that are open, closed or both.
         #   (options: open,closed,hidden,none,all)
-
         # @option arguments [Hash] :headers Custom HTTP headers
         #
         # @see https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-blocks.html

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/clear_cache.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/clear_cache.rb
@@ -29,7 +29,6 @@ module Elasticsearch
         # @option arguments [Boolean] :allow_no_indices Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)
         # @option arguments [String] :expand_wildcards Whether to expand wildcard expression to concrete indices that are open, closed or both.
         #   (options: open,closed,hidden,none,all)
-
         # @option arguments [List] :index A comma-separated list of index name to limit the operation
         # @option arguments [Boolean] :request Clear request cache
         # @option arguments [Hash] :headers Custom HTTP headers

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/close.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/close.rb
@@ -28,7 +28,6 @@ module Elasticsearch
         # @option arguments [Boolean] :allow_no_indices Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)
         # @option arguments [String] :expand_wildcards Whether to expand wildcard expression to concrete indices that are open, closed or both.
         #   (options: open,closed,hidden,none,all)
-
         # @option arguments [String] :wait_for_active_shards Sets the number of active shards to wait for before the operation returns.
         # @option arguments [Hash] :headers Custom HTTP headers
         #

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/delete.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/delete.rb
@@ -28,7 +28,6 @@ module Elasticsearch
         # @option arguments [Boolean] :allow_no_indices Ignore if a wildcard expression resolves to no concrete indices (default: false)
         # @option arguments [String] :expand_wildcards Whether wildcard expressions should get expanded to open or closed indices (default: open)
         #   (options: open,closed,hidden,none,all)
-
         # @option arguments [Hash] :headers Custom HTTP headers
         #
         # @see https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-delete-index.html

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/exists.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/exists.rb
@@ -27,7 +27,6 @@ module Elasticsearch
         # @option arguments [Boolean] :allow_no_indices Ignore if a wildcard expression resolves to no concrete indices (default: false)
         # @option arguments [String] :expand_wildcards Whether wildcard expressions should get expanded to open or closed indices (default: open)
         #   (options: open,closed,hidden,none,all)
-
         # @option arguments [Boolean] :flat_settings Return settings in flat format (default: false)
         # @option arguments [Boolean] :include_defaults Whether to return all default setting for each of the indices.
         # @option arguments [Hash] :headers Custom HTTP headers

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/exists_alias.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/exists_alias.rb
@@ -27,7 +27,6 @@ module Elasticsearch
         # @option arguments [Boolean] :allow_no_indices Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)
         # @option arguments [String] :expand_wildcards Whether to expand wildcard expression to concrete indices that are open, closed or both.
         #   (options: open,closed,hidden,none,all)
-
         # @option arguments [Boolean] :local Return local information, do not retrieve the state from master node (default: false)
         # @option arguments [Hash] :headers Custom HTTP headers
         #

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/exists_type.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/exists_type.rb
@@ -27,7 +27,6 @@ module Elasticsearch
         # @option arguments [Boolean] :allow_no_indices Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)
         # @option arguments [String] :expand_wildcards Whether to expand wildcard expression to concrete indices that are open, closed or both.
         #   (options: open,closed,hidden,none,all)
-
         # @option arguments [Boolean] :local Return local information, do not retrieve the state from master node (default: false)
         # @option arguments [Hash] :headers Custom HTTP headers
         #

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/flush.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/flush.rb
@@ -28,7 +28,6 @@ module Elasticsearch
         # @option arguments [Boolean] :allow_no_indices Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)
         # @option arguments [String] :expand_wildcards Whether to expand wildcard expression to concrete indices that are open, closed or both.
         #   (options: open,closed,hidden,none,all)
-
         # @option arguments [Hash] :headers Custom HTTP headers
         #
         # @see https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-flush.html

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/forcemerge.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/forcemerge.rb
@@ -27,7 +27,6 @@ module Elasticsearch
         # @option arguments [Boolean] :allow_no_indices Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)
         # @option arguments [String] :expand_wildcards Whether to expand wildcard expression to concrete indices that are open, closed or both.
         #   (options: open,closed,hidden,none,all)
-
         # @option arguments [Number] :max_num_segments The number of segments the index should be merged into (default: dynamic)
         # @option arguments [Boolean] :only_expunge_deletes Specify whether the operation should only expunge deleted documents
         # @option arguments [Hash] :headers Custom HTTP headers

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/get.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/get.rb
@@ -27,7 +27,6 @@ module Elasticsearch
         # @option arguments [Boolean] :allow_no_indices Ignore if a wildcard expression resolves to no concrete indices (default: false)
         # @option arguments [String] :expand_wildcards Whether wildcard expressions should get expanded to open or closed indices (default: open)
         #   (options: open,closed,hidden,none,all)
-
         # @option arguments [Boolean] :flat_settings Return settings in flat format (default: false)
         # @option arguments [Boolean] :include_defaults Whether to return all default setting for each of the indices.
         # @option arguments [Time] :master_timeout Specify timeout for connection to master

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/get_alias.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/get_alias.rb
@@ -27,7 +27,6 @@ module Elasticsearch
         # @option arguments [Boolean] :allow_no_indices Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)
         # @option arguments [String] :expand_wildcards Whether to expand wildcard expression to concrete indices that are open, closed or both.
         #   (options: open,closed,hidden,none,all)
-
         # @option arguments [Boolean] :local Return local information, do not retrieve the state from master node (default: false)
         # @option arguments [Hash] :headers Custom HTTP headers
         #

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/get_field_mapping.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/get_field_mapping.rb
@@ -28,7 +28,6 @@ module Elasticsearch
         # @option arguments [Boolean] :allow_no_indices Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)
         # @option arguments [String] :expand_wildcards Whether to expand wildcard expression to concrete indices that are open, closed or both.
         #   (options: open,closed,hidden,none,all)
-
         # @option arguments [Boolean] :local Return local information, do not retrieve the state from master node (default: false)
         # @option arguments [Hash] :headers Custom HTTP headers
         #

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/get_mapping.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/get_mapping.rb
@@ -26,7 +26,6 @@ module Elasticsearch
         # @option arguments [Boolean] :allow_no_indices Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)
         # @option arguments [String] :expand_wildcards Whether to expand wildcard expression to concrete indices that are open, closed or both.
         #   (options: open,closed,hidden,none,all)
-
         # @option arguments [Time] :master_timeout Specify timeout for connection to master
         # @option arguments [Boolean] :local Return local information, do not retrieve the state from master node (default: false)   *Deprecated*
         # @option arguments [Hash] :headers Custom HTTP headers

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/get_settings.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/get_settings.rb
@@ -28,7 +28,6 @@ module Elasticsearch
         # @option arguments [Boolean] :allow_no_indices Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)
         # @option arguments [String] :expand_wildcards Whether to expand wildcard expression to concrete indices that are open, closed or both.
         #   (options: open,closed,hidden,none,all)
-
         # @option arguments [Boolean] :flat_settings Return settings in flat format (default: false)
         # @option arguments [Boolean] :local Return local information, do not retrieve the state from master node (default: false)
         # @option arguments [Boolean] :include_defaults Whether to return all default setting for each of the indices.

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/get_upgrade.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/get_upgrade.rb
@@ -26,7 +26,6 @@ module Elasticsearch
         # @option arguments [Boolean] :allow_no_indices Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)
         # @option arguments [String] :expand_wildcards Whether to expand wildcard expression to concrete indices that are open, closed or both.
         #   (options: open,closed,hidden,none,all)
-
         # @option arguments [Hash] :headers Custom HTTP headers
         #
         # *Deprecation notice*:

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/open.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/open.rb
@@ -28,7 +28,6 @@ module Elasticsearch
         # @option arguments [Boolean] :allow_no_indices Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)
         # @option arguments [String] :expand_wildcards Whether to expand wildcard expression to concrete indices that are open, closed or both.
         #   (options: open,closed,hidden,none,all)
-
         # @option arguments [String] :wait_for_active_shards Sets the number of active shards to wait for before the operation returns.
         # @option arguments [Hash] :headers Custom HTTP headers
         #

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/put_mapping.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/put_mapping.rb
@@ -28,7 +28,6 @@ module Elasticsearch
         # @option arguments [Boolean] :allow_no_indices Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)
         # @option arguments [String] :expand_wildcards Whether to expand wildcard expression to concrete indices that are open, closed or both.
         #   (options: open,closed,hidden,none,all)
-
         # @option arguments [Boolean] :write_index_only When true, applies mappings only to the write index of an alias or data stream
         # @option arguments [Hash] :headers Custom HTTP headers
         # @option arguments [Hash] :body The mapping definition (*Required*)

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/put_settings.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/put_settings.rb
@@ -29,7 +29,6 @@ module Elasticsearch
         # @option arguments [Boolean] :allow_no_indices Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)
         # @option arguments [String] :expand_wildcards Whether to expand wildcard expression to concrete indices that are open, closed or both.
         #   (options: open,closed,hidden,none,all)
-
         # @option arguments [Boolean] :flat_settings Return settings in flat format (default: false)
         # @option arguments [Hash] :headers Custom HTTP headers
         # @option arguments [Hash] :body The index settings to be updated (*Required*)

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/refresh.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/refresh.rb
@@ -26,7 +26,6 @@ module Elasticsearch
         # @option arguments [Boolean] :allow_no_indices Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)
         # @option arguments [String] :expand_wildcards Whether to expand wildcard expression to concrete indices that are open, closed or both.
         #   (options: open,closed,hidden,none,all)
-
         # @option arguments [Hash] :headers Custom HTTP headers
         #
         # @see https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-refresh.html

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/resolve_index.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/resolve_index.rb
@@ -24,7 +24,6 @@ module Elasticsearch
         # @option arguments [List] :name A comma-separated list of names or wildcard expressions
         # @option arguments [String] :expand_wildcards Whether wildcard expressions should get expanded to open or closed indices (default: open)
         #   (options: open,closed,hidden,none,all)
-
         # @option arguments [Hash] :headers Custom HTTP headers
         #
         # @see https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-resolve-index.html

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/segments.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/segments.rb
@@ -26,7 +26,6 @@ module Elasticsearch
         # @option arguments [Boolean] :allow_no_indices Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)
         # @option arguments [String] :expand_wildcards Whether to expand wildcard expression to concrete indices that are open, closed or both.
         #   (options: open,closed,hidden,none,all)
-
         # @option arguments [Boolean] :verbose Includes detailed memory usage by Lucene.
         # @option arguments [Hash] :headers Custom HTTP headers
         #

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/shard_stores.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/shard_stores.rb
@@ -24,12 +24,10 @@ module Elasticsearch
         # @option arguments [List] :index A comma-separated list of index names; use `_all` or empty string to perform the operation on all indices
         # @option arguments [List] :status A comma-separated list of statuses used to filter on shards to get store information for
         #   (options: green,yellow,red,all)
-
         # @option arguments [Boolean] :ignore_unavailable Whether specified concrete indices should be ignored when unavailable (missing or closed)
         # @option arguments [Boolean] :allow_no_indices Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)
         # @option arguments [String] :expand_wildcards Whether to expand wildcard expression to concrete indices that are open, closed or both.
         #   (options: open,closed,hidden,none,all)
-
         # @option arguments [Hash] :headers Custom HTTP headers
         #
         # @see https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-shards-stores.html

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/stats.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/stats.rb
@@ -23,7 +23,6 @@ module Elasticsearch
         #
         # @option arguments [List] :metric Limit the information returned the specific metrics.
         #   (options: _all,completion,docs,fielddata,query_cache,flush,get,indexing,merge,request_cache,refresh,search,segments,store,warmer,suggest,bulk)
-
         # @option arguments [List] :index A comma-separated list of index names; use `_all` or empty string to perform the operation on all indices
         # @option arguments [List] :completion_fields A comma-separated list of fields for `fielddata` and `suggest` index metric (supports wildcards)
         # @option arguments [List] :fielddata_fields A comma-separated list of fields for `fielddata` index metric (supports wildcards)
@@ -31,13 +30,11 @@ module Elasticsearch
         # @option arguments [List] :groups A comma-separated list of search groups for `search` index metric
         # @option arguments [String] :level Return stats aggregated at cluster, index or shard level
         #   (options: cluster,indices,shards)
-
         # @option arguments [List] :types A comma-separated list of document types for the `indexing` index metric
         # @option arguments [Boolean] :include_segment_file_sizes Whether to report the aggregated disk usage of each one of the Lucene index files (only applies if segment stats are requested)
         # @option arguments [Boolean] :include_unloaded_segments If set to true segment stats will include stats for segments that are not currently loaded into memory
         # @option arguments [String] :expand_wildcards Whether to expand wildcard expression to concrete indices that are open, closed or both.
         #   (options: open,closed,hidden,none,all)
-
         # @option arguments [Boolean] :forbid_closed_indices If set to false stats will also collected from closed indices if explicitly specified or if expand_wildcards expands to closed indices
         # @option arguments [Hash] :headers Custom HTTP headers
         #

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/upgrade.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/upgrade.rb
@@ -25,7 +25,6 @@ module Elasticsearch
         # @option arguments [Boolean] :allow_no_indices Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)
         # @option arguments [String] :expand_wildcards Whether to expand wildcard expression to concrete indices that are open, closed or both.
         #   (options: open,closed,hidden,none,all)
-
         # @option arguments [Boolean] :ignore_unavailable Whether specified concrete indices should be ignored when unavailable (missing or closed)
         # @option arguments [Boolean] :wait_for_completion Specify whether the request should block until the all segments are upgraded (default: false)
         # @option arguments [Boolean] :only_ancient_segments If true, only ancient (an older Lucene major release) segments will be upgraded

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/validate_query.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/validate_query.rb
@@ -28,13 +28,11 @@ module Elasticsearch
         # @option arguments [Boolean] :allow_no_indices Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)
         # @option arguments [String] :expand_wildcards Whether to expand wildcard expression to concrete indices that are open, closed or both.
         #   (options: open,closed,hidden,none,all)
-
         # @option arguments [String] :q Query in the Lucene query string syntax
         # @option arguments [String] :analyzer The analyzer to use for the query string
         # @option arguments [Boolean] :analyze_wildcard Specify whether wildcard and prefix queries should be analyzed (default: false)
         # @option arguments [String] :default_operator The default operator for query string query (AND or OR)
         #   (options: AND,OR)
-
         # @option arguments [String] :df The field to use as default where no field prefix is given in the query string
         # @option arguments [Boolean] :lenient Specify whether format-based query failures (such as providing text to a numeric field) should be ignored
         # @option arguments [Boolean] :rewrite Provide a more detailed explanation showing the actual Lucene query that will be executed.

--- a/elasticsearch-api/lib/elasticsearch/api/actions/msearch.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/msearch.rb
@@ -23,7 +23,6 @@ module Elasticsearch
       # @option arguments [List] :index A comma-separated list of index names to use as default
       # @option arguments [String] :search_type Search operation type
       #   (options: query_then_fetch,query_and_fetch,dfs_query_then_fetch,dfs_query_and_fetch)
-
       # @option arguments [Number] :max_concurrent_searches Controls the maximum number of concurrent searches the multi search api will execute
       # @option arguments [Boolean] :typed_keys Specify whether aggregation and suggester names should be prefixed by their respective types in the response
       # @option arguments [Number] :pre_filter_shard_size A threshold that enforces a pre-filter roundtrip to prefilter search shards based on query rewriting if the number of shards the search request expands to exceeds the threshold. This filter roundtrip can limit the number of shards significantly if for instance a shard can not match any documents based on its rewrite method ie. if date filters are mandatory to match but the shard bounds and the query are disjoint.

--- a/elasticsearch-api/lib/elasticsearch/api/actions/msearch_template.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/msearch_template.rb
@@ -23,7 +23,6 @@ module Elasticsearch
       # @option arguments [List] :index A comma-separated list of index names to use as default
       # @option arguments [String] :search_type Search operation type
       #   (options: query_then_fetch,query_and_fetch,dfs_query_then_fetch,dfs_query_and_fetch)
-
       # @option arguments [Boolean] :typed_keys Specify whether aggregation and suggester names should be prefixed by their respective types in the response
       # @option arguments [Number] :max_concurrent_searches Controls the maximum number of concurrent searches the multi search api will execute
       # @option arguments [Boolean] :rest_total_hits_as_int Indicates whether hits.total should be rendered as an integer or an object in the rest search response

--- a/elasticsearch-api/lib/elasticsearch/api/actions/mtermvectors.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/mtermvectors.rb
@@ -34,7 +34,6 @@ module Elasticsearch
       # @option arguments [Number] :version Explicit version number for concurrency control
       # @option arguments [String] :version_type Specific version type
       #   (options: internal,external,external_gte)
-
       # @option arguments [Hash] :headers Custom HTTP headers
       # @option arguments [Hash] :body Define ids, documents, parameters or a list of parameters per document here. You must at least provide a list of document ids. See documentation.
       #

--- a/elasticsearch-api/lib/elasticsearch/api/actions/nodes/hot_threads.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/nodes/hot_threads.rb
@@ -28,7 +28,6 @@ module Elasticsearch
         # @option arguments [Boolean] :ignore_idle_threads Don't show threads that are in known-idle places, such as waiting on a socket select or pulling from an empty task queue (default: true)
         # @option arguments [String] :type The type to sample (default: cpu)
         #   (options: cpu,wait,block)
-
         # @option arguments [Time] :timeout Explicit operation timeout
         # @option arguments [Hash] :headers Custom HTTP headers
         #

--- a/elasticsearch-api/lib/elasticsearch/api/actions/nodes/info.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/nodes/info.rb
@@ -24,7 +24,6 @@ module Elasticsearch
         # @option arguments [List] :node_id A comma-separated list of node IDs or names to limit the returned information; use `_local` to return information from the node you're connecting to, leave empty to get information from all nodes
         # @option arguments [List] :metric A comma-separated list of metrics you wish returned. Leave empty to return all.
         #   (options: settings,os,process,jvm,thread_pool,transport,http,plugins,ingest)
-
         # @option arguments [Boolean] :flat_settings Return settings in flat format (default: false)
         # @option arguments [Time] :timeout Explicit operation timeout
         # @option arguments [Hash] :headers Custom HTTP headers

--- a/elasticsearch-api/lib/elasticsearch/api/actions/nodes/stats.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/nodes/stats.rb
@@ -24,17 +24,14 @@ module Elasticsearch
         # @option arguments [List] :node_id A comma-separated list of node IDs or names to limit the returned information; use `_local` to return information from the node you're connecting to, leave empty to get information from all nodes
         # @option arguments [List] :metric Limit the information returned to the specified metrics
         #   (options: _all,breaker,fs,http,indices,jvm,os,process,thread_pool,transport,discovery,indexing_pressure)
-
         # @option arguments [List] :index_metric Limit the information returned for `indices` metric to the specific index metrics. Isn't used if `indices` (or `all`) metric isn't specified.
         #   (options: _all,completion,docs,fielddata,query_cache,flush,get,indexing,merge,request_cache,refresh,search,segments,store,warmer,suggest,bulk)
-
         # @option arguments [List] :completion_fields A comma-separated list of fields for `fielddata` and `suggest` index metric (supports wildcards)
         # @option arguments [List] :fielddata_fields A comma-separated list of fields for `fielddata` index metric (supports wildcards)
         # @option arguments [List] :fields A comma-separated list of fields for `fielddata` and `completion` index metric (supports wildcards)
         # @option arguments [Boolean] :groups A comma-separated list of search groups for `search` index metric
         # @option arguments [String] :level Return indices stats aggregated at index, node or shard level
         #   (options: indices,node,shards)
-
         # @option arguments [List] :types A comma-separated list of document types for the `indexing` index metric
         # @option arguments [Time] :timeout Explicit operation timeout
         # @option arguments [Boolean] :include_segment_file_sizes Whether to report the aggregated disk usage of each one of the Lucene index files (only applies if segment stats are requested)

--- a/elasticsearch-api/lib/elasticsearch/api/actions/nodes/usage.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/nodes/usage.rb
@@ -24,7 +24,6 @@ module Elasticsearch
         # @option arguments [List] :node_id A comma-separated list of node IDs or names to limit the returned information; use `_local` to return information from the node you're connecting to, leave empty to get information from all nodes
         # @option arguments [List] :metric Limit the information returned to the specified metrics
         #   (options: _all,rest_actions)
-
         # @option arguments [Time] :timeout Explicit operation timeout
         # @option arguments [Hash] :headers Custom HTTP headers
         #

--- a/elasticsearch-api/lib/elasticsearch/api/actions/rank_eval.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/rank_eval.rb
@@ -25,10 +25,8 @@ module Elasticsearch
       # @option arguments [Boolean] :allow_no_indices Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)
       # @option arguments [String] :expand_wildcards Whether to expand wildcard expression to concrete indices that are open, closed or both.
       #   (options: open,closed,hidden,none,all)
-
       # @option arguments [String] :search_type Search operation type
       #   (options: query_then_fetch,dfs_query_then_fetch)
-
       # @option arguments [Hash] :headers Custom HTTP headers
       # @option arguments [Hash] :body The ranking evaluation search definition, including search requests, document ratings and ranking metric definition. (*Required*)
       #

--- a/elasticsearch-api/lib/elasticsearch/api/actions/search.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/search.rb
@@ -26,7 +26,6 @@ module Elasticsearch
       # @option arguments [Boolean] :ccs_minimize_roundtrips Indicates whether network round-trips should be minimized as part of cross-cluster search requests execution
       # @option arguments [String] :default_operator The default operator for query string query (AND or OR)
       #   (options: AND,OR)
-
       # @option arguments [String] :df The field to use as default where no field prefix is given in the query string
       # @option arguments [Boolean] :explain Specify whether to return detailed information about score computation as part of a hit
       # @option arguments [List] :stored_fields A comma-separated list of stored fields to return as part of a hit
@@ -37,7 +36,6 @@ module Elasticsearch
       # @option arguments [Boolean] :allow_no_indices Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)
       # @option arguments [String] :expand_wildcards Whether to expand wildcard expression to concrete indices that are open, closed or both.
       #   (options: open,closed,hidden,none,all)
-
       # @option arguments [Boolean] :lenient Specify whether format-based query failures (such as providing text to a numeric field) should be ignored
       # @option arguments [String] :preference Specify the node or shard the operation should be performed on (default: random)
       # @option arguments [String] :q Query in the Lucene query string syntax
@@ -45,7 +43,6 @@ module Elasticsearch
       # @option arguments [Time] :scroll Specify how long a consistent view of the index should be maintained for scrolled search
       # @option arguments [String] :search_type Search operation type
       #   (options: query_then_fetch,dfs_query_then_fetch)
-
       # @option arguments [Number] :size Number of hits to return (default: 10)
       # @option arguments [List] :sort A comma-separated list of <field>:<direction> pairs
       # @option arguments [List] :_source True or false to return the _source field or not, or a list of fields to return
@@ -56,7 +53,6 @@ module Elasticsearch
       # @option arguments [String] :suggest_field Specify which field to use for suggestions
       # @option arguments [String] :suggest_mode Specify suggest mode
       #   (options: missing,popular,always)
-
       # @option arguments [Number] :suggest_size How many suggestions to return in response
       # @option arguments [String] :suggest_text The source text for which the suggestions should be returned
       # @option arguments [Time] :timeout Explicit operation timeout

--- a/elasticsearch-api/lib/elasticsearch/api/actions/search_shards.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/search_shards.rb
@@ -28,7 +28,6 @@ module Elasticsearch
       # @option arguments [Boolean] :allow_no_indices Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)
       # @option arguments [String] :expand_wildcards Whether to expand wildcard expression to concrete indices that are open, closed or both.
       #   (options: open,closed,hidden,none,all)
-
       # @option arguments [Hash] :headers Custom HTTP headers
       #
       # @see https://www.elastic.co/guide/en/elasticsearch/reference/master/search-shards.html

--- a/elasticsearch-api/lib/elasticsearch/api/actions/search_template.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/search_template.rb
@@ -26,13 +26,11 @@ module Elasticsearch
       # @option arguments [Boolean] :allow_no_indices Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)
       # @option arguments [String] :expand_wildcards Whether to expand wildcard expression to concrete indices that are open, closed or both.
       #   (options: open,closed,hidden,none,all)
-
       # @option arguments [String] :preference Specify the node or shard the operation should be performed on (default: random)
       # @option arguments [List] :routing A comma-separated list of specific routing values
       # @option arguments [Time] :scroll Specify how long a consistent view of the index should be maintained for scrolled search
       # @option arguments [String] :search_type Search operation type
       #   (options: query_then_fetch,query_and_fetch,dfs_query_then_fetch,dfs_query_and_fetch)
-
       # @option arguments [Boolean] :explain Specify whether to return detailed information about score computation as part of a hit
       # @option arguments [Boolean] :profile Specify whether to profile the query execution
       # @option arguments [Boolean] :typed_keys Specify whether aggregation and suggester names should be prefixed by their respective types in the response

--- a/elasticsearch-api/lib/elasticsearch/api/actions/tasks/list.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/tasks/list.rb
@@ -28,7 +28,6 @@ module Elasticsearch
         # @option arguments [Boolean] :wait_for_completion Wait for the matching tasks to complete (default: false)
         # @option arguments [String] :group_by Group tasks by nodes or parent/child relationships
         #   (options: nodes,parents,none)
-
         # @option arguments [Time] :timeout Explicit operation timeout
         # @option arguments [Hash] :headers Custom HTTP headers
         #

--- a/elasticsearch-api/lib/elasticsearch/api/actions/termvectors.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/termvectors.rb
@@ -34,7 +34,6 @@ module Elasticsearch
       # @option arguments [Number] :version Explicit version number for concurrency control
       # @option arguments [String] :version_type Specific version type
       #   (options: internal,external,external_gte)
-
       # @option arguments [Hash] :headers Custom HTTP headers
       # @option arguments [Hash] :body Define parameters and or supply a document to get termvectors for. See documentation.
       #

--- a/elasticsearch-api/lib/elasticsearch/api/actions/update.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/update.rb
@@ -30,7 +30,6 @@ module Elasticsearch
       # @option arguments [String] :lang The script language (default: painless)
       # @option arguments [String] :refresh If `true` then refresh the affected shards to make this operation visible to search, if `wait_for` then wait for a refresh to make this operation visible to search, if `false` (the default) then do nothing with refreshes.
       #   (options: true,false,wait_for)
-
       # @option arguments [Number] :retry_on_conflict Specify how many times should the operation be retried when a conflict occurs (default: 0)
       # @option arguments [String] :routing Specific routing value
       # @option arguments [Time] :timeout Explicit operation timeout

--- a/elasticsearch-api/lib/elasticsearch/api/actions/update_by_query.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/update_by_query.rb
@@ -26,17 +26,14 @@ module Elasticsearch
       # @option arguments [Boolean] :analyze_wildcard Specify whether wildcard and prefix queries should be analyzed (default: false)
       # @option arguments [String] :default_operator The default operator for query string query (AND or OR)
       #   (options: AND,OR)
-
       # @option arguments [String] :df The field to use as default where no field prefix is given in the query string
       # @option arguments [Number] :from Starting offset (default: 0)
       # @option arguments [Boolean] :ignore_unavailable Whether specified concrete indices should be ignored when unavailable (missing or closed)
       # @option arguments [Boolean] :allow_no_indices Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)
       # @option arguments [String] :conflicts What to do when the update by query hits version conflicts?
       #   (options: abort,proceed)
-
       # @option arguments [String] :expand_wildcards Whether to expand wildcard expression to concrete indices that are open, closed or both.
       #   (options: open,closed,hidden,none,all)
-
       # @option arguments [Boolean] :lenient Specify whether format-based query failures (such as providing text to a numeric field) should be ignored
       # @option arguments [String] :pipeline Ingest pipeline to set on index requests made by this action. (default: none)
       # @option arguments [String] :preference Specify the node or shard the operation should be performed on (default: random)
@@ -45,7 +42,6 @@ module Elasticsearch
       # @option arguments [Time] :scroll Specify how long a consistent view of the index should be maintained for scrolled search
       # @option arguments [String] :search_type Search operation type
       #   (options: query_then_fetch,dfs_query_then_fetch)
-
       # @option arguments [Time] :search_timeout Explicit timeout for each search request. Defaults to no timeout.
       # @option arguments [Number] :max_docs Maximum number of documents to process (default: all documents)
       # @option arguments [List] :sort A comma-separated list of <field>:<direction> pairs

--- a/elasticsearch-api/utils/thor/generate_source.rb
+++ b/elasticsearch-api/utils/thor/generate_source.rb
@@ -228,7 +228,7 @@ module Elasticsearch
         info['type'] = 'String' if info['type'] == 'enum' # Rename 'enums' to 'strings'
         tipo = info['type'] ? info['type'].capitalize : 'String'
         description = info['description'] ? info['description'].strip : '[TODO]'
-        options = info['options'] ? "\n    #   (options: #{info['options'].join(', '.strip)})\n" : ''
+        options = info['options'] ? "\n    #   (options: #{info['options'].join(', '.strip)})" : nil
         required = info['required'] ? ' (*Required*)' : ''
         deprecated = info['deprecated'] ? ' *Deprecated*' : ''
         "# @option arguments [#{tipo}] :#{name} #{description} #{required} #{deprecated} #{options}\n"

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/async_search/submit.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/async_search/submit.rb
@@ -32,7 +32,6 @@ module Elasticsearch
           # @option arguments [Boolean] :analyze_wildcard Specify whether wildcard and prefix queries should be analyzed (default: false)
           # @option arguments [String] :default_operator The default operator for query string query (AND or OR)
           #   (options: AND,OR)
-
           # @option arguments [String] :df The field to use as default where no field prefix is given in the query string
           # @option arguments [Boolean] :explain Specify whether to return detailed information about score computation as part of a hit
           # @option arguments [List] :stored_fields A comma-separated list of stored fields to return as part of a hit
@@ -43,14 +42,12 @@ module Elasticsearch
           # @option arguments [Boolean] :allow_no_indices Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)
           # @option arguments [String] :expand_wildcards Whether to expand wildcard expression to concrete indices that are open, closed or both.
           #   (options: open,closed,hidden,none,all)
-
           # @option arguments [Boolean] :lenient Specify whether format-based query failures (such as providing text to a numeric field) should be ignored
           # @option arguments [String] :preference Specify the node or shard the operation should be performed on (default: random)
           # @option arguments [String] :q Query in the Lucene query string syntax
           # @option arguments [List] :routing A comma-separated list of specific routing values
           # @option arguments [String] :search_type Search operation type
           #   (options: query_then_fetch,dfs_query_then_fetch)
-
           # @option arguments [Number] :size Number of hits to return (default: 10)
           # @option arguments [List] :sort A comma-separated list of <field>:<direction> pairs
           # @option arguments [List] :_source True or false to return the _source field or not, or a list of fields to return
@@ -61,7 +58,6 @@ module Elasticsearch
           # @option arguments [String] :suggest_field Specify which field to use for suggestions
           # @option arguments [String] :suggest_mode Specify suggest mode
           #   (options: missing,popular,always)
-
           # @option arguments [Number] :suggest_size How many suggestions to return in response
           # @option arguments [String] :suggest_text The source text for which the suggestions should be returned
           # @option arguments [Time] :timeout Explicit operation timeout

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/cat/ml_data_frame_analytics.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/cat/ml_data_frame_analytics.rb
@@ -26,14 +26,12 @@ module Elasticsearch
           # @option arguments [Boolean] :allow_no_match Whether to ignore if a wildcard expression matches no configs. (This includes `_all` string or when no configs have been specified)
           # @option arguments [String] :bytes The unit in which to display byte values
           #   (options: b,k,kb,m,mb,g,gb,t,tb,p,pb)
-
           # @option arguments [String] :format a short version of the Accept header, e.g. json, yaml
           # @option arguments [List] :h Comma-separated list of column names to display
           # @option arguments [Boolean] :help Return help information
           # @option arguments [List] :s Comma-separated list of column names or column aliases to sort by
           # @option arguments [String] :time The unit in which to display time values
           #   (options: d,h,m,s,ms,micros,nanos)
-
           # @option arguments [Boolean] :v Verbose mode. Display column headers
           # @option arguments [Hash] :headers Custom HTTP headers
           #

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/cat/ml_datafeeds.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/cat/ml_datafeeds.rb
@@ -30,7 +30,6 @@ module Elasticsearch
           # @option arguments [List] :s Comma-separated list of column names or column aliases to sort by
           # @option arguments [String] :time The unit in which to display time values
           #   (options: d,h,m,s,ms,micros,nanos)
-
           # @option arguments [Boolean] :v Verbose mode. Display column headers
           # @option arguments [Hash] :headers Custom HTTP headers
           #

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/cat/ml_jobs.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/cat/ml_jobs.rb
@@ -26,14 +26,12 @@ module Elasticsearch
           # @option arguments [Boolean] :allow_no_jobs Whether to ignore if a wildcard expression matches no jobs. (This includes `_all` string or when no jobs have been specified)
           # @option arguments [String] :bytes The unit in which to display byte values
           #   (options: b,k,kb,m,mb,g,gb,t,tb,p,pb)
-
           # @option arguments [String] :format a short version of the Accept header, e.g. json, yaml
           # @option arguments [List] :h Comma-separated list of column names to display
           # @option arguments [Boolean] :help Return help information
           # @option arguments [List] :s Comma-separated list of column names or column aliases to sort by
           # @option arguments [String] :time The unit in which to display time values
           #   (options: d,h,m,s,ms,micros,nanos)
-
           # @option arguments [Boolean] :v Verbose mode. Display column headers
           # @option arguments [Hash] :headers Custom HTTP headers
           #

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/cat/ml_trained_models.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/cat/ml_trained_models.rb
@@ -28,14 +28,12 @@ module Elasticsearch
           # @option arguments [Int] :size specifies a max number of trained models to get
           # @option arguments [String] :bytes The unit in which to display byte values
           #   (options: b,k,kb,m,mb,g,gb,t,tb,p,pb)
-
           # @option arguments [String] :format a short version of the Accept header, e.g. json, yaml
           # @option arguments [List] :h Comma-separated list of column names to display
           # @option arguments [Boolean] :help Return help information
           # @option arguments [List] :s Comma-separated list of column names or column aliases to sort by
           # @option arguments [String] :time The unit in which to display time values
           #   (options: d,h,m,s,ms,micros,nanos)
-
           # @option arguments [Boolean] :v Verbose mode. Display column headers
           # @option arguments [Hash] :headers Custom HTTP headers
           #

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/cat/transforms.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/cat/transforms.rb
@@ -32,7 +32,6 @@ module Elasticsearch
           # @option arguments [List] :s Comma-separated list of column names or column aliases to sort by
           # @option arguments [String] :time The unit in which to display time values
           #   (options: d,h,m,s,ms,micros,nanos)
-
           # @option arguments [Boolean] :v Verbose mode. Display column headers
           # @option arguments [Hash] :headers Custom HTTP headers
           #

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/indices/freeze.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/indices/freeze.rb
@@ -29,7 +29,6 @@ module Elasticsearch
           # @option arguments [Boolean] :allow_no_indices Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)
           # @option arguments [String] :expand_wildcards Whether to expand wildcard expression to concrete indices that are open, closed or both.
           #   (options: open,closed,hidden,none,all)
-
           # @option arguments [String] :wait_for_active_shards Sets the number of active shards to wait for before the operation returns.
           # @option arguments [Hash] :headers Custom HTTP headers
           #

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/indices/reload_search_analyzers.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/indices/reload_search_analyzers.rb
@@ -27,7 +27,6 @@ module Elasticsearch
           # @option arguments [Boolean] :allow_no_indices Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)
           # @option arguments [String] :expand_wildcards Whether to expand wildcard expression to concrete indices that are open, closed or both.
           #   (options: open,closed,hidden,none,all)
-
           # @option arguments [Hash] :headers Custom HTTP headers
           #
           # @see https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-reload-analyzers.html

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/indices/unfreeze.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/indices/unfreeze.rb
@@ -29,7 +29,6 @@ module Elasticsearch
           # @option arguments [Boolean] :allow_no_indices Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)
           # @option arguments [String] :expand_wildcards Whether to expand wildcard expression to concrete indices that are open, closed or both.
           #   (options: open,closed,hidden,none,all)
-
           # @option arguments [String] :wait_for_active_shards Sets the number of active shards to wait for before the operation returns.
           # @option arguments [Hash] :headers Custom HTTP headers
           #

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/machine_learning/find_file_structure.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/machine_learning/find_file_structure.rb
@@ -28,7 +28,6 @@ module Elasticsearch
           # @option arguments [String] :charset Optional parameter to specify the character set of the file
           # @option arguments [String] :format Optional parameter to specify the high level file format
           #   (options: ndjson,xml,delimited,semi_structured_text)
-
           # @option arguments [Boolean] :has_header_row Optional parameter to specify whether a delimited file includes the column names in its first row
           # @option arguments [List] :column_names Optional parameter containing a comma separated list of the column names for a delimited file
           # @option arguments [String] :delimiter Optional parameter to specify the delimiter character for a delimited file - must be a single character

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/machine_learning/put_datafeed.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/machine_learning/put_datafeed.rb
@@ -28,7 +28,6 @@ module Elasticsearch
           # @option arguments [Boolean] :ignore_throttled Ignore indices that are marked as throttled (default: true)
           # @option arguments [String] :expand_wildcards Whether source index expressions should get expanded to open or closed indices (default: open)
           #   (options: open,closed,hidden,none,all)
-
           # @option arguments [Hash] :headers Custom HTTP headers
           # @option arguments [Hash] :body The datafeed config (*Required*)
           #

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/machine_learning/update_datafeed.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/machine_learning/update_datafeed.rb
@@ -28,7 +28,6 @@ module Elasticsearch
           # @option arguments [Boolean] :ignore_throttled Ignore indices that are marked as throttled (default: true)
           # @option arguments [String] :expand_wildcards Whether source index expressions should get expanded to open or closed indices (default: open)
           #   (options: open,closed,hidden,none,all)
-
           # @option arguments [Hash] :headers Custom HTTP headers
           # @option arguments [Hash] :body The datafeed update settings (*Required*)
           #

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/searchable_snapshots/clear_cache.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/searchable_snapshots/clear_cache.rb
@@ -27,7 +27,6 @@ module Elasticsearch
           # @option arguments [Boolean] :allow_no_indices Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)
           # @option arguments [String] :expand_wildcards Whether to expand wildcard expression to concrete indices that are open, closed or both.
           #   (options: open,closed,none,all)
-
           # @option arguments [List] :index A comma-separated list of index name to limit the operation
           # @option arguments [Hash] :headers Custom HTTP headers
           #

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/security/change_password.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/security/change_password.rb
@@ -25,7 +25,6 @@ module Elasticsearch
           # @option arguments [String] :username The username of the user to change the password for
           # @option arguments [String] :refresh If `true` (the default) then refresh the affected shards to make this operation visible to search, if `wait_for` then wait for a refresh to make this operation visible to search, if `false` then do nothing with refreshes.
           #   (options: true,false,wait_for)
-
           # @option arguments [Hash] :headers Custom HTTP headers
           # @option arguments [Hash] :body the new password for the user (*Required*)
           #

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/security/create_api_key.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/security/create_api_key.rb
@@ -24,7 +24,6 @@ module Elasticsearch
           #
           # @option arguments [String] :refresh If `true` (the default) then refresh the affected shards to make this operation visible to search, if `wait_for` then wait for a refresh to make this operation visible to search, if `false` then do nothing with refreshes.
           #   (options: true,false,wait_for)
-
           # @option arguments [Hash] :headers Custom HTTP headers
           # @option arguments [Hash] :body The api key request to create an API key (*Required*)
           #

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/security/delete_privileges.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/security/delete_privileges.rb
@@ -26,7 +26,6 @@ module Elasticsearch
           # @option arguments [String] :name Privilege name
           # @option arguments [String] :refresh If `true` (the default) then refresh the affected shards to make this operation visible to search, if `wait_for` then wait for a refresh to make this operation visible to search, if `false` then do nothing with refreshes.
           #   (options: true,false,wait_for)
-
           # @option arguments [Hash] :headers Custom HTTP headers
           #
           # @see https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-delete-privilege.html

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/security/delete_role.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/security/delete_role.rb
@@ -25,7 +25,6 @@ module Elasticsearch
           # @option arguments [String] :name Role name
           # @option arguments [String] :refresh If `true` (the default) then refresh the affected shards to make this operation visible to search, if `wait_for` then wait for a refresh to make this operation visible to search, if `false` then do nothing with refreshes.
           #   (options: true,false,wait_for)
-
           # @option arguments [Hash] :headers Custom HTTP headers
           #
           # @see https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-delete-role.html

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/security/delete_role_mapping.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/security/delete_role_mapping.rb
@@ -25,7 +25,6 @@ module Elasticsearch
           # @option arguments [String] :name Role-mapping name
           # @option arguments [String] :refresh If `true` (the default) then refresh the affected shards to make this operation visible to search, if `wait_for` then wait for a refresh to make this operation visible to search, if `false` then do nothing with refreshes.
           #   (options: true,false,wait_for)
-
           # @option arguments [Hash] :headers Custom HTTP headers
           #
           # @see https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-delete-role-mapping.html

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/security/delete_user.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/security/delete_user.rb
@@ -25,7 +25,6 @@ module Elasticsearch
           # @option arguments [String] :username username
           # @option arguments [String] :refresh If `true` (the default) then refresh the affected shards to make this operation visible to search, if `wait_for` then wait for a refresh to make this operation visible to search, if `false` then do nothing with refreshes.
           #   (options: true,false,wait_for)
-
           # @option arguments [Hash] :headers Custom HTTP headers
           #
           # @see https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-delete-user.html

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/security/disable_user.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/security/disable_user.rb
@@ -25,7 +25,6 @@ module Elasticsearch
           # @option arguments [String] :username The username of the user to disable
           # @option arguments [String] :refresh If `true` (the default) then refresh the affected shards to make this operation visible to search, if `wait_for` then wait for a refresh to make this operation visible to search, if `false` then do nothing with refreshes.
           #   (options: true,false,wait_for)
-
           # @option arguments [Hash] :headers Custom HTTP headers
           #
           # @see https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-disable-user.html

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/security/enable_user.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/security/enable_user.rb
@@ -25,7 +25,6 @@ module Elasticsearch
           # @option arguments [String] :username The username of the user to enable
           # @option arguments [String] :refresh If `true` (the default) then refresh the affected shards to make this operation visible to search, if `wait_for` then wait for a refresh to make this operation visible to search, if `false` then do nothing with refreshes.
           #   (options: true,false,wait_for)
-
           # @option arguments [Hash] :headers Custom HTTP headers
           #
           # @see https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-enable-user.html

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/security/put_privileges.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/security/put_privileges.rb
@@ -24,7 +24,6 @@ module Elasticsearch
           #
           # @option arguments [String] :refresh If `true` (the default) then refresh the affected shards to make this operation visible to search, if `wait_for` then wait for a refresh to make this operation visible to search, if `false` then do nothing with refreshes.
           #   (options: true,false,wait_for)
-
           # @option arguments [Hash] :headers Custom HTTP headers
           # @option arguments [Hash] :body The privilege(s) to add (*Required*)
           #

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/security/put_role.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/security/put_role.rb
@@ -25,7 +25,6 @@ module Elasticsearch
           # @option arguments [String] :name Role name
           # @option arguments [String] :refresh If `true` (the default) then refresh the affected shards to make this operation visible to search, if `wait_for` then wait for a refresh to make this operation visible to search, if `false` then do nothing with refreshes.
           #   (options: true,false,wait_for)
-
           # @option arguments [Hash] :headers Custom HTTP headers
           # @option arguments [Hash] :body The role to add (*Required*)
           #

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/security/put_role_mapping.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/security/put_role_mapping.rb
@@ -25,7 +25,6 @@ module Elasticsearch
           # @option arguments [String] :name Role-mapping name
           # @option arguments [String] :refresh If `true` (the default) then refresh the affected shards to make this operation visible to search, if `wait_for` then wait for a refresh to make this operation visible to search, if `false` then do nothing with refreshes.
           #   (options: true,false,wait_for)
-
           # @option arguments [Hash] :headers Custom HTTP headers
           # @option arguments [Hash] :body The role mapping to add (*Required*)
           #

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/security/put_user.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/security/put_user.rb
@@ -25,7 +25,6 @@ module Elasticsearch
           # @option arguments [String] :username The username of the User
           # @option arguments [String] :refresh If `true` (the default) then refresh the affected shards to make this operation visible to search, if `wait_for` then wait for a refresh to make this operation visible to search, if `false` then do nothing with refreshes.
           #   (options: true,false,wait_for)
-
           # @option arguments [Hash] :headers Custom HTTP headers
           # @option arguments [Hash] :body The user to add (*Required*)
           #

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/watcher/stats.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/watcher/stats.rb
@@ -24,10 +24,8 @@ module Elasticsearch
           #
           # @option arguments [List] :metric Controls what additional stat metrics should be include in the response
           #   (options: _all,queued_watches,current_watches,pending_watches)
-
           # @option arguments [List] :metric Controls what additional stat metrics should be include in the response
           #   (options: _all,queued_watches,current_watches,pending_watches)
-
           # @option arguments [Boolean] :emit_stacktraces Emits stack traces of currently running watches
           # @option arguments [Hash] :headers Custom HTTP headers
           #


### PR DESCRIPTION
Bug discovered by Orhan Toy. In the generated code for the APIs, there is an unnecessary empty new line in the documentation for parameters that have options. So the parameters before that empty newline are not being documented in RubyDocs. This PR addresses the issue in the generator and regenerates the code for both OSS and X-Pack.

Will be backported to `7.x`, `7.8` (for 7.8.1 release) and `7.9`.