### PR TITLE
[API] Generator: Add comment about stability to documentation

### DIFF
--- a/elasticsearch-api/utils/thor/generate_source.rb
+++ b/elasticsearch-api/utils/thor/generate_source.rb
@@ -234,6 +234,32 @@ module Elasticsearch
         "# @option arguments [#{tipo}] :#{name} #{description} #{required} #{deprecated} #{options}\n"
       end
 
+      def stability_doc_helper(stability)
+        return if stability == 'stable'
+
+        if stability == 'experimental'
+          <<~MSG
+            # This functionality is Experimental and may be changed or removed
+            # completely in a future release. Elastic will take a best effort approach
+            # to fix any issues, but experimental features are not subject to the
+            # support SLA of official GA features.
+          MSG
+        elsif stability == 'beta'
+          <<~MSG
+            # This functionality is in Beta and is subject to change. The design and
+            # code is less mature than official GA features and is being provided
+            # as-is with no warranties. Beta features are not subject to the support
+            # SLA of official GA features.
+          MSG
+        else
+          <<~MSG
+            # This functionality is subject to potential breaking changes within a
+            # minor version, meaning that your referencing code may break when this
+            # library is upgraded.
+          MSG
+        end
+      end
+
       def generate_tests
         copy_file 'templates/test_helper.rb', @output.join('test').join('test_helper.rb')
 

--- a/elasticsearch-api/utils/thor/templates/_documentation_top.erb
+++ b/elasticsearch-api/utils/thor/templates/_documentation_top.erb
@@ -3,6 +3,7 @@
 <%- else %>
   <%= '  '*(@namespace_depth+3) %># TODO: Description
 <%- end %>
+<%= stability_doc_helper(@spec['stability']) -%>
 <%= '  '*(@namespace_depth+3) %>#
 <%- unless @parts.nil? || @parts.empty? %><%# URL parts -%>
   <%- @parts.each do |name, info| -%>


### PR DESCRIPTION
This PR adds a notice about non stable APIs to the documentation, based on [.NET's](https://github.com/elastic/elasticsearch-net/blob/7cd1c2414a35d8a5d7304351c7aed4ca2d1bf7d6/src/ApiGenerator/Views/LowLevel/Client/Methods/MethodDocs.cshtml#L15-L30) code.

Example output:
```ruby
      module Autoscaling
        module Actions
          # Retrieves an autoscaling policy.
          # This functionality is Experimental and may be changed or removed
          # completely in a future release. Elastic will take a best effort approach
          # to fix any issues, but experimental features are not subject to the
          # support SLA of official GA features.
          #
          # @option arguments [String] :name the name of the autoscaling policy
          # @option arguments [Hash] :headers Custom HTTP headers
          #
          # @see https://www.elastic.co/guide/en/elasticsearch/reference/8.0/autoscaling-get-autoscaling-policy.html
          #
          def get_autoscaling_policy(arguments = {})
```

This needs to be backported to `7.x`, `7.9` and `7.8` and code needs to be regenerated to be included on the 7.8.1 release.