### PR TITLE
[DOCS] Adds discrete attribute to the section titles

### DIFF
--- a/docs/client.asciidoc
+++ b/docs/client.asciidoc
@@ -8,6 +8,8 @@ Full documentation is hosted at https://github.com/elastic/elasticsearch-ruby[Gi
 and http://rubydoc.info/gems/elasticsearch[RubyDoc]
 -- this documentation provides only an overview of features.
 
+
+[discrete]
 === Elasticsearch and Ruby Version Compatibility
 
 The Elasticsearch client is compatible with Ruby 1.9 and higher.
@@ -27,6 +29,8 @@ just use a release matching major version of Elasticsearch.
 | master        | → | master
 |===
 
+
+[discrete]
 === Installation
 
 Install the Ruby gem for the latest Elasticsearch version:
@@ -57,6 +61,8 @@ gem install elasticsearch -v 6.0.0
 gem 'elasticsearch', '~> 6.0'
 ------------------------------------
 
+
+[discrete]
 === Example Usage
 
 [source,ruby]
@@ -75,6 +81,7 @@ client.search index: 'my-index', body: { query: { match: { title: 'test' } } }
 ------------------------------------
 
 
+[discrete]
 === Features at a Glance
 
 * Pluggable logging and tracing
@@ -87,6 +94,7 @@ client.search index: 'my-index', body: { query: { match: { title: 'test' } } }
 * 100% REST API coverage
 
 
+[discrete]
 === Transport and API
 
 The `elasticsearch` gem combines two separate Rubygems:
@@ -106,6 +114,7 @@ Keep in mind, that for optimal performance, you should use an HTTP library which
 persistent ("keep-alive") HTTP connections.
 
 
+[discrete]
 === Extensions
 
 The https://github.com/elastic/elasticsearch-ruby/tree/master/elasticsearch-extensions[`elasticsearch-extensions`]

--- a/docs/model.asciidoc
+++ b/docs/model.asciidoc
@@ -7,6 +7,7 @@ provides integration with Ruby domain objects ("models"), commonly found e.g. in
 It uses the `elasticsearch` Rubygem as the client communicating with the Elasticsearch cluster.
 
 
+[discrete]
 === Features at a Glance
 
 * ActiveModel integration with adapters for ActiveRecord and Mongoid
@@ -18,6 +19,7 @@ It uses the `elasticsearch` Rubygem as the client communicating with the Elastic
 * Convenience methods for (re)creating the index, setting up mappings, indexing documents, ...
 
 
+[discrete]
 === Usage
 
 Add the library to your Gemfile:

--- a/docs/persistence.asciidoc
+++ b/docs/persistence.asciidoc
@@ -6,10 +6,14 @@ provides persistence layer for Ruby domain objects.
 
 It supports the repository design patterns. Versions before 6.0 also supported the _active record_ design pattern.
 
+
+[discrete]
 === Repository
 
 The `Elasticsearch::Persistence::Repository` module provides an implementation of the repository pattern and allows to save, delete, find and search objects stored in Elasticsearch, as well as configure mappings and settings for the index.
 
+
+[discrete]
 ==== Features At a Glance
 
 * Access to the Elasticsearch client
@@ -21,6 +25,8 @@ The `Elasticsearch::Persistence::Repository` module provides an implementation o
 * Providing access to the Elasticsearch response for search results (aggregations, total, ...)
 * Defining the methods for serialization and deserialization
 
+
+[discrete]
 ==== Usage
 
 Let's have a simple plain old Ruby object (PORO):

--- a/docs/rails.asciidoc
+++ b/docs/rails.asciidoc
@@ -4,12 +4,16 @@
 The `elasticsearch-rails` http://rubygems.org/gems/elasticsearch-rails[Rubygem]
 provides features suitable for Ruby on Rails applications.
 
+
+[discrete]
 === Features at a Glance
 
 * Rake tasks for importing data from application models
 * Integration with Rails' instrumentation framework
 * Templates for generating example Rails application
 
+
+[discrete]
 === Example applications
 
 You can generate a fully working example Ruby on Rails application with templates provides.

--- a/docs/release_notes/70.asciidoc
+++ b/docs/release_notes/70.asciidoc
@@ -6,6 +6,8 @@ This version contains the following changes:
 * Added `elastic_ruby_console` executable. It opens a console with the elasticsearch gems you have installed required.
 * Added macro benchmarking framework, available when developing. Use `rake -T` to view all available benchmarking tasks. 
 
+
+[discrete]
 ==== Client
 
 * Fixed failing integration test
@@ -44,6 +46,8 @@ This version contains the following changes:
 * Update handling of publish_address in _nodes/http response
 * Add another test for hostname/ipv6:port format
 
+
+[discrete]
 ==== API
 
 * Added the `wait_for_active_shards` parameter to the "Indices Open" API
@@ -129,6 +133,7 @@ This version contains the following changes:
 * Ensure that the :index param is supported for cat.segments
 * Ensure that the :name param is passed to the templates API
 
+[discrete]
 ==== DSL
 
 * Add inner_hits option support for has_parent query
@@ -153,6 +158,8 @@ This version contains the following changes:
 * Ensure that filters are registered when called on bool queries (#609)
 * Don't specify a type when creating mappings in tests
 
+
+[discrete]
 ==== X-Pack
 
 * Embedded the source code for the `elasticsearch-xpack` Rubygem

--- a/docs/release_notes/75.asciidoc
+++ b/docs/release_notes/75.asciidoc
@@ -6,6 +6,8 @@
 - Specs have been updated to address new/deprecated parameters.
 - Ruby versions tested: 2.3.8, 2.4.9, 2.5.7, 2.6.5 and 2.7.0 (new).
 
+
+[discrete]
 ==== API
 
 Endpoints that changed:
@@ -45,6 +47,8 @@ Endpoints that changed:
 - `termvectors`: `parent` parameter is gone.
 - `update`: `version` parameter is not supported anymore.
 
+
+[discrete]
 ==== X-Pack
 
 Some urls changed internally to remove `_xpack`, but it shouldn't affect the client's API.

--- a/docs/release_notes/76.asciidoc
+++ b/docs/release_notes/76.asciidoc
@@ -1,19 +1,27 @@
 [[release_notes_76]]
 === 7.6 Release notes
 
+
+[discrete]
 ==== Client
 
 * Support for Elasticsearch version 7.6.
 * Last release supporting Ruby 2.4. Ruby 2.4 has reached it's end of life and no more security updates will be provided, users are suggested to update to a newer version of Ruby.
 
+
+[discrete]
 ===== API Key Support
 
 The client now supports API Key Authentication, check "Authentication" on the https://github.com/elastic/elasticsearch-ruby/tree/7.x/elasticsearch-transport#authentication[transport README] for information on how to use it.
 
+
+[discrete]
 ===== X-Opaque-Id Support
 
 The client now supports identifying running tasks with X-Opaque-Id. Check https://github.com/elastic/elasticsearch-ruby/tree/7.x/elasticsearch-transport#identifying-running-tasks-with-x-opaque-id[transport README] for information on how to use X-Opaque-Id.
 
+
+[discrete]
 ===== Faraday migrated to 1.0
 
 We're now using version 1.0 of Faraday:
@@ -27,8 +35,12 @@ Reference: https://github.com/lostisland/faraday/blob/master/UPGRADING.md[Upgrad
 
 https://github.com/elastic/elasticsearch-ruby/pull/808[Pull Request]
 
+
+[discrete]
 ==== API
 
+
+[discrete]
 ===== API Changes:
 
 - `cat.indices`: argument `bytes` options were: `b,k,m,g` and are now `b,k,kb,m,mb,g,gb,t,tb,p,pb`.
@@ -38,17 +50,25 @@ https://github.com/elastic/elasticsearch-ruby/pull/808[Pull Request]
 - `rank_eval`: New parameter `search_type` - Search operation type (options: `query_then_fetch,dfs_query_then_fetch`).
 - `search_template`: New parameter `ccs_minimize_roundtrips` - Indicates whether network round-trips should be minimized as part of cross-cluster search requests execution.
 
+
+[discrete]
 ===== New API endpoints:
 
 - `get_script_context`
 - `get_script_languages`
 
+
+[discrete]
 ===== Warnings:
 
 Synced flush is deprecated and will be removed in 8.0.
 
+
+[discrete]
 ==== X-Pack
 
+
+[discrete]
 ===== New API endpoints:
 
 - `ml/delete_trained_model`
@@ -57,6 +77,8 @@ Synced flush is deprecated and will be removed in 8.0.
 - `ml/get_trained_models_stats`
 - `ml/put_trained_model`
 
+
+[discrete]
 ===== API changes:
 
 - `license/get`: Added parameter `accept_enterprise`.

--- a/docs/release_notes/77.asciidoc
+++ b/docs/release_notes/77.asciidoc
@@ -3,16 +3,24 @@
 
 This version drops support for Ruby 2.4 since it's reached it's end of life.
 
+
+[discrete]
 ==== Client
 
 - Support for Elasticsearch version `7.7`
 
+
+[discrete]
 ===== Custom Headers
 
 You can set custom HTTP headers on the client's initializer or pass them as a parameter to any API endpoint. https://github.com/elastic/elasticsearch-ruby/tree/7.x/elasticsearch-transport#custom-http-headers[More info and code examples].
 
+
+[discrete]
 ==== API
 
+
+[discrete]
 ===== API Changes
 
 - Clean: Removes up some deprecated endpoints: `abort_benchmark`, `benchmark`, `delete_by_rethrottle`, `nodes.shutdown`, `remote.info`.
@@ -22,6 +30,8 @@ You can set custom HTTP headers on the client's initializer or pass them as a pa
 - `update_by_query`: Parameter `slices` can now be set to `auto`.
 - `snapshot.cleanup_repository`: Parameter `body` is removed.
 
+
+[discrete]
 ===== New API Endpoints
 
 - `cluster.delete_component_template`
@@ -31,14 +41,20 @@ You can set custom HTTP headers on the client's initializer or pass them as a pa
 - `indices.delete_data_stream` (experimental)
 - `indices.get_data_stream` (experimental)
 
+
+[discrete]
 ==== X-Pack
 
+
+[discrete]
 ===== API Changes
 
 - `machine_learing.get_trained_models`: New parameter `tags`
 - `machine_learning.put_datafeed`, `machine_learning.update_datafeed`: Added parameters `ignore_unavailable`, `allow_no_indices`, `ignore_throttled`, `expand_wildcards`
 - `reload_secure_settings`: New parameter `body`, an object containing the password for the keystore.
 
+
+[discrete]
 ===== New API Endpoints
 
 - `async_search.delete`

--- a/docs/release_notes/78.asciidoc
+++ b/docs/release_notes/78.asciidoc
@@ -1,6 +1,8 @@
 [[release_notes_78]]
 === 7.8 Release notes
 
+
+[discrete]
 ==== Client
 
 - Support for Elasticsearch version `7.8`.
@@ -8,8 +10,12 @@
 - Typhoeus is supported again, version 1.4+ and has been added back to the docs.
 - Adds documentation and example for integrating with Elastic APM.
 
+
+[discrete]
 ==== API
 
+
+[discrete]
 ===== New API Endpoints
 
 - `abort_benchmark`
@@ -33,6 +39,8 @@ Experimental endpoints:
 - `indices.put_index_template`
 - `indices.simulate_index_template`
 
+
+[discrete]
 ===== API Changes
 
 - `cat/thread_pool`: `size` is deprecated.
@@ -42,8 +50,12 @@ Experimental endpoints:
 - `snapshot.delete_repository`: New parameter `repository`, name of the snapshot repository, wildcard (`*`) patterns are now supported.
 - `task.cancel`: new parameter `wait_for_completion` (boolean) Should the request block until the cancellation of the task and its descendant tasks is completed. Defaults to false.
 
+
+[discrete]
 ==== X-Pack
 
+
+[discrete]
 ===== New API Endpoints
 
 New namespace: `indices`
@@ -59,6 +71,8 @@ New namespace: `searchable_snapshots`
 - `repository_stats`
 - `stats`
 
+
+[discrete]
 ===== API Changes
 
 - `machine_learning.delete_expired_data` new param `body`: deleting expired data parameters.

--- a/docs/release_notes/781.asciidoc
+++ b/docs/release_notes/781.asciidoc
@@ -1,13 +1,19 @@
 [[release_notes_781]]
 === 7.8.1 Release notes
 
+
+[discrete]
 === Client
 
 - Support for Elasticsearch version `7.8.1`.
 - Bug fix: Fixed a bug on the API endpoints documentation for RubyDocs: there was an unnecessary empty new line in the documentation for parameters that have options. So the parameters before that empty newline were not being documented in RubyDocs.
 
+
+[discrete]
 === X-Pack
 
+
+[discrete]
 ==== API Changes
 
 - Update to `info` endpoint. New parameter `accept_enterprise` (boolean): If an enterprise license is installed, return the type and mode as 'enterprise' (default: false).

--- a/docs/release_notes/index.asciidoc
+++ b/docs/release_notes/index.asciidoc
@@ -1,6 +1,8 @@
 [[release_notes]]
 == Release Notes
 
+
+[discrete]
 === 7.x
 * <<release_notes_781, 7.8.1 Release Notes>>
 * <<release_notes_78, 7.8 Release Notes>>


### PR DESCRIPTION
## Overview

This PR adds the [discrete] attribute to the titles of the sections that don't need to be separated chunks in the book structure.
This change is required because of the changes in https://github.com/elastic/docs/pull/1942.