### PR TITLE
[XPACK] usage can be called from client without xpack namespace

### DIFF
--- a/elasticsearch-xpack/lib/elasticsearch/xpack.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack.rb
@@ -46,7 +46,15 @@ Elasticsearch::API::COMMON_PARAMS.push :job_id, :datafeed_id, :filter_id, :snaps
 module Elasticsearch
   module Transport
     class Client
-      TOP_LEVEL_METHODS = [:open_point_in_time, :close_point_in_time].freeze
+      # When a method is called on the client, if it's one of the xpack root
+      # namespace methods, send them to the xpack client.
+      # E.g.: client.xpack.usage => client.usage
+      # Excluding `info` since OSS and XPACK both have info endpoints.
+      TOP_LEVEL_METHODS = [
+        :open_point_in_time,
+        :close_point_in_time,
+        :usage
+      ].freeze
 
       def method_missing(method, *args, &block)
         return xpack.send(method, *args, &block) if TOP_LEVEL_METHODS.include?(method)

--- a/elasticsearch-xpack/test/test_helper.rb
+++ b/elasticsearch-xpack/test/test_helper.rb
@@ -26,8 +26,8 @@ require 'mocha/minitest'
 
 require 'ansi'
 
-require 'elasticsearch/xpack'
 require 'elasticsearch/transport'
+require 'elasticsearch/xpack'
 
 Minitest::Reporters.use! Minitest::Reporters::SpecReporter.new
 
@@ -58,7 +58,7 @@ module Elasticsearch
       end
 
       # Top level methods:
-      [:open_point_in_time, :close_point_in_time].each do |method|
+      Elasticsearch::Transport::Client::TOP_LEVEL_METHODS.each do |method|
         define_method method do |*args|
           xpack.send(method, *args)
         end

--- a/elasticsearch-xpack/test/unit/info_test.rb
+++ b/elasticsearch-xpack/test/unit/info_test.rb
@@ -20,7 +20,6 @@ require 'test_helper'
 module Elasticsearch
   module Test
     class XPackInfoTest < Minitest::Test
-
       context "XPack: Info" do
         subject { FakeClient.new }
 
@@ -35,9 +34,7 @@ module Elasticsearch
 
           subject.xpack.info
         end
-
       end
-
     end
   end
 end

--- a/elasticsearch-xpack/test/unit/usage_test.rb
+++ b/elasticsearch-xpack/test/unit/usage_test.rb
@@ -20,24 +20,33 @@ require 'test_helper'
 module Elasticsearch
   module Test
     class XPackUsageTest < Minitest::Test
-
-      context "XPack: Usage" do
+      context 'XPack: Usage' do
         subject { FakeClient.new }
 
-        should "perform correct request" do
+        should 'perform correct request' do
           subject.expects(:perform_request).with do |method, url, params, body|
-            assert_equal 'GET', method
-            assert_equal '_xpack/usage', url
-            assert_equal Hash.new, params
-            assert_nil   body
+            assert_equal('GET', method)
+            assert_equal('_xpack/usage', url)
+            assert_equal({}, params)
+            assert_nil(body)
             true
           end.returns(FakeResponse.new)
 
           subject.xpack.usage
         end
 
-      end
+        should 'perform correct request without using xpack namespace' do
+          subject.expects(:perform_request).with do |method, url, params, body|
+            assert_equal('GET', method)
+            assert_equal('_xpack/usage', url)
+            assert_equal({}, params)
+            assert_nil(body)
+            true
+          end.returns(FakeResponse.new)
 
+          subject.usage
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
Makes `usage` available from the client without having to use the xpack namespace:
```ruby
client.xpack.usage => client.usage
```
Fixes test_helper to use `TOP_LEVEL_METHODS` from the Client.