### PR TITLE
[CLIENT] Adds test for trailing $ sign in cloud_id

### DIFF
--- a/elasticsearch-transport/lib/elasticsearch/transport/client.rb
+++ b/elasticsearch-transport/lib/elasticsearch/transport/client.rb
@@ -191,13 +191,18 @@ module Elasticsearch
 
       def extract_cloud_creds(arguments)
         return unless arguments[:cloud_id]
+
         name = arguments[:cloud_id].split(':')[0]
         cloud_url, elasticsearch_instance = Base64.decode64(arguments[:cloud_id].gsub("#{name}:", '')).split('$')
-        [ { scheme: 'https',
+        [
+          {
+            scheme: 'https',
             user: arguments[:user],
             password: arguments[:password],
             host: "#{elasticsearch_instance}.#{cloud_url}",
-            port: arguments[:port] || DEFAULT_CLOUD_PORT } ]
+            port: arguments[:port] || DEFAULT_CLOUD_PORT
+          }
+        ]
       end
 
       # Normalizes and returns hosts configuration.

--- a/elasticsearch-transport/spec/elasticsearch/transport/client_spec.rb
+++ b/elasticsearch-transport/spec/elasticsearch/transport/client_spec.rb
@@ -328,7 +328,11 @@ describe Elasticsearch::Transport::Client do
   context 'when cloud credentials are provided' do
 
     let(:client) do
-      described_class.new(cloud_id: 'name:bG9jYWxob3N0JGFiY2QkZWZnaA==', user: 'elastic', password: 'changeme')
+      described_class.new(
+        cloud_id: 'name:bG9jYWxob3N0JGFiY2QkZWZnaA==',
+        user: 'elastic',
+        password: 'changeme'
+      )
     end
 
     let(:hosts) do
@@ -344,13 +348,20 @@ describe Elasticsearch::Transport::Client do
     end
 
     it 'creates the correct full url' do
-      expect(client.transport.__full_url(client.transport.hosts[0])).to eq('https://elastic:changeme@abcd.localhost:9243')
+      expect(
+        client.transport.__full_url(client.transport.hosts[0])
+      ).to eq('https://elastic:changeme@abcd.localhost:9243')
     end
 
     context 'when a port is specified' do
 
       let(:client) do
-        described_class.new(cloud_id: 'name:bG9jYWxob3N0JGFiY2QkZWZnaA==', user: 'elastic', password: 'changeme', port: 9200 )
+        described_class.new(
+          cloud_id: 'name:bG9jYWxob3N0JGFiY2QkZWZnaA==',
+          user: 'elastic',
+          password: 'changeme',
+          port: 9200
+        )
       end
 
       it 'sets the specified port along with the cloud credentials' do
@@ -369,7 +380,11 @@ describe Elasticsearch::Transport::Client do
     context 'when the cluster has alternate names' do
 
       let(:client) do
-        described_class.new(cloud_id: 'myCluster:bG9jYWxob3N0JGFiY2QkZWZnaA==', user: 'elasticfantastic', password: 'tobechanged')
+        described_class.new(
+          cloud_id: 'myCluster:bG9jYWxob3N0JGFiY2QkZWZnaA==',
+          user: 'elasticfantastic',
+          password: 'tobechanged'
+        )
       end
 
       let(:hosts) do
@@ -385,9 +400,38 @@ describe Elasticsearch::Transport::Client do
       end
 
       it 'creates the correct full url' do
-        expect(client.transport.__full_url(client.transport.hosts[0])).to eq('https://elasticfantastic:tobechanged@abcd.localhost:9243')
+        expect(
+          client.transport.__full_url(client.transport.hosts[0])
+        ).to eq('https://elasticfantastic:tobechanged@abcd.localhost:9243')
+      end
+    end
+
+    context 'when decoded cloud id has a trailing dollar sign' do
+      let(:client) do
+        described_class.new(
+          cloud_id: 'a_cluster:bG9jYWxob3N0JGFiY2Qk',
+          user: 'elasticfantastic',
+          password: 'changeme'
+        )
       end
 
+      let(:hosts) do
+        client.transport.hosts
+      end
+
+      it 'extracts the cloud credentials' do
+        expect(hosts[0][:host]).to eq('abcd.localhost')
+        expect(hosts[0][:protocol]).to eq('https')
+        expect(hosts[0][:user]).to eq('elasticfantastic')
+        expect(hosts[0][:password]).to eq('changeme')
+        expect(hosts[0][:port]).to eq(9243)
+      end
+
+      it 'creates the correct full url' do
+        expect(
+          client.transport.__full_url(client.transport.hosts[0])
+        ).to eq('https://elasticfantastic:changeme@abcd.localhost:9243')
+      end
     end
   end
 


### PR DESCRIPTION
Backports #1025