### PR TITLE
Updates to X-Pack

### DIFF
--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/cat/ml_datafeeds.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/cat/ml_datafeeds.rb
@@ -23,7 +23,8 @@ module Elasticsearch
           # Gets configuration and usage information about datafeeds.
           #
           # @option arguments [String] :datafeed_id The ID of the datafeeds stats to fetch
-          # @option arguments [Boolean] :allow_no_datafeeds Whether to ignore if a wildcard expression matches no datafeeds. (This includes `_all` string or when no datafeeds have been specified)
+          # @option arguments [Boolean] :allow_no_match Whether to ignore if a wildcard expression matches no datafeeds. (This includes `_all` string or when no datafeeds have been specified)
+          # @option arguments [Boolean] :allow_no_datafeeds Whether to ignore if a wildcard expression matches no datafeeds. (This includes `_all` string or when no datafeeds have been specified) *Deprecated*
           # @option arguments [String] :format a short version of the Accept header, e.g. json, yaml
           # @option arguments [List] :h Comma-separated list of column names to display
           # @option arguments [Boolean] :help Return help information
@@ -57,6 +58,7 @@ module Elasticsearch
           #
           # @since 6.2.0
           ParamsRegistry.register(:ml_datafeeds, [
+            :allow_no_match,
             :allow_no_datafeeds,
             :format,
             :h,

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/cat/ml_jobs.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/cat/ml_jobs.rb
@@ -23,7 +23,8 @@ module Elasticsearch
           # Gets configuration and usage information about anomaly detection jobs.
           #
           # @option arguments [String] :job_id The ID of the jobs stats to fetch
-          # @option arguments [Boolean] :allow_no_jobs Whether to ignore if a wildcard expression matches no jobs. (This includes `_all` string or when no jobs have been specified)
+          # @option arguments [Boolean] :allow_no_match Whether to ignore if a wildcard expression matches no jobs. (This includes `_all` string or when no jobs have been specified)
+          # @option arguments [Boolean] :allow_no_jobs Whether to ignore if a wildcard expression matches no jobs. (This includes `_all` string or when no jobs have been specified) *Deprecated*
           # @option arguments [String] :bytes The unit in which to display byte values (options: b, k, kb, m, mb, g, gb, t, tb, p, pb)
           # @option arguments [String] :format a short version of the Accept header, e.g. json, yaml
           # @option arguments [List] :h Comma-separated list of column names to display
@@ -58,6 +59,7 @@ module Elasticsearch
           #
           # @since 6.2.0
           ParamsRegistry.register(:ml_jobs, [
+            :allow_no_match,
             :allow_no_jobs,
             :bytes,
             :format,

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/close_point_in_time.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/close_point_in_time.rb
@@ -1,0 +1,44 @@
+# Licensed to Elasticsearch B.V. under one or more contributor
+# license agreements. See the NOTICE file distributed with
+# this work for additional information regarding copyright
+# ownership. Elasticsearch B.V. licenses this file to you under
+# the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+module Elasticsearch
+  module XPack
+    module API
+      module Actions
+        # Close a point in time
+        #
+        # @option arguments [Hash] :headers Custom HTTP headers
+        # @option arguments [Hash] :body a point-in-time id to close
+        #
+        # @see https://www.elastic.co/guide/en/elasticsearch/reference/7.x/point-in-time.html
+        #
+        def close_point_in_time(arguments = {})
+          headers = arguments.delete(:headers) || {}
+
+          arguments = arguments.clone
+
+          method = Elasticsearch::API::HTTP_DELETE
+          path   = "_pit"
+          params = {}
+
+          body = arguments[:body]
+          perform_request(method, path, params, body, headers).body
+        end
+      end
+    end
+  end
+end

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/machine_learning/close_job.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/machine_learning/close_job.rb
@@ -23,7 +23,8 @@ module Elasticsearch
           # Closes one or more anomaly detection jobs. A job can be opened and closed multiple times throughout its lifecycle.
           #
           # @option arguments [String] :job_id The name of the job to close
-          # @option arguments [Boolean] :allow_no_jobs Whether to ignore if a wildcard expression matches no jobs. (This includes `_all` string or when no jobs have been specified)
+          # @option arguments [Boolean] :allow_no_match Whether to ignore if a wildcard expression matches no jobs. (This includes `_all` string or when no jobs have been specified)
+          # @option arguments [Boolean] :allow_no_jobs Whether to ignore if a wildcard expression matches no jobs. (This includes `_all` string or when no jobs have been specified) *Deprecated*
           # @option arguments [Boolean] :force True if the job should be forcefully closed
           # @option arguments [Time] :timeout Controls the time to wait until a job has closed. Default to 30 minutes
           # @option arguments [Hash] :headers Custom HTTP headers
@@ -52,6 +53,7 @@ module Elasticsearch
           #
           # @since 6.2.0
           ParamsRegistry.register(:close_job, [
+            :allow_no_match,
             :allow_no_jobs,
             :force,
             :timeout

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/machine_learning/get_datafeed_stats.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/machine_learning/get_datafeed_stats.rb
@@ -23,7 +23,8 @@ module Elasticsearch
           # Retrieves usage information for datafeeds.
           #
           # @option arguments [String] :datafeed_id The ID of the datafeeds stats to fetch
-          # @option arguments [Boolean] :allow_no_datafeeds Whether to ignore if a wildcard expression matches no datafeeds. (This includes `_all` string or when no datafeeds have been specified)
+          # @option arguments [Boolean] :allow_no_match Whether to ignore if a wildcard expression matches no datafeeds. (This includes `_all` string or when no datafeeds have been specified)
+          # @option arguments [Boolean] :allow_no_datafeeds Whether to ignore if a wildcard expression matches no datafeeds. (This includes `_all` string or when no datafeeds have been specified) *Deprecated*
           # @option arguments [Hash] :headers Custom HTTP headers
           #
           # @see https://www.elastic.co/guide/en/elasticsearch/reference/7.x/ml-get-datafeed-stats.html
@@ -51,6 +52,7 @@ module Elasticsearch
           #
           # @since 6.2.0
           ParamsRegistry.register(:get_datafeed_stats, [
+            :allow_no_match,
             :allow_no_datafeeds
           ].freeze)
         end

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/machine_learning/get_datafeeds.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/machine_learning/get_datafeeds.rb
@@ -23,7 +23,8 @@ module Elasticsearch
           # Retrieves configuration information for datafeeds.
           #
           # @option arguments [String] :datafeed_id The ID of the datafeeds to fetch
-          # @option arguments [Boolean] :allow_no_datafeeds Whether to ignore if a wildcard expression matches no datafeeds. (This includes `_all` string or when no datafeeds have been specified)
+          # @option arguments [Boolean] :allow_no_match Whether to ignore if a wildcard expression matches no datafeeds. (This includes `_all` string or when no datafeeds have been specified)
+          # @option arguments [Boolean] :allow_no_datafeeds Whether to ignore if a wildcard expression matches no datafeeds. (This includes `_all` string or when no datafeeds have been specified) *Deprecated*
           # @option arguments [Hash] :headers Custom HTTP headers
           #
           # @see https://www.elastic.co/guide/en/elasticsearch/reference/7.x/ml-get-datafeed.html
@@ -51,6 +52,7 @@ module Elasticsearch
           #
           # @since 6.2.0
           ParamsRegistry.register(:get_datafeeds, [
+            :allow_no_match,
             :allow_no_datafeeds
           ].freeze)
         end

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/machine_learning/get_job_stats.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/machine_learning/get_job_stats.rb
@@ -23,7 +23,8 @@ module Elasticsearch
           # Retrieves usage information for anomaly detection jobs.
           #
           # @option arguments [String] :job_id The ID of the jobs stats to fetch
-          # @option arguments [Boolean] :allow_no_jobs Whether to ignore if a wildcard expression matches no jobs. (This includes `_all` string or when no jobs have been specified)
+          # @option arguments [Boolean] :allow_no_match Whether to ignore if a wildcard expression matches no jobs. (This includes `_all` string or when no jobs have been specified)
+          # @option arguments [Boolean] :allow_no_jobs Whether to ignore if a wildcard expression matches no jobs. (This includes `_all` string or when no jobs have been specified) *Deprecated*
           # @option arguments [Hash] :headers Custom HTTP headers
           #
           # @see https://www.elastic.co/guide/en/elasticsearch/reference/7.x/ml-get-job-stats.html
@@ -51,6 +52,7 @@ module Elasticsearch
           #
           # @since 6.2.0
           ParamsRegistry.register(:get_job_stats, [
+            :allow_no_match,
             :allow_no_jobs
           ].freeze)
         end

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/machine_learning/get_jobs.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/machine_learning/get_jobs.rb
@@ -23,7 +23,8 @@ module Elasticsearch
           # Retrieves configuration information for anomaly detection jobs.
           #
           # @option arguments [String] :job_id The ID of the jobs to fetch
-          # @option arguments [Boolean] :allow_no_jobs Whether to ignore if a wildcard expression matches no jobs. (This includes `_all` string or when no jobs have been specified)
+          # @option arguments [Boolean] :allow_no_match Whether to ignore if a wildcard expression matches no jobs. (This includes `_all` string or when no jobs have been specified)
+          # @option arguments [Boolean] :allow_no_jobs Whether to ignore if a wildcard expression matches no jobs. (This includes `_all` string or when no jobs have been specified) *Deprecated*
           # @option arguments [Hash] :headers Custom HTTP headers
           #
           # @see https://www.elastic.co/guide/en/elasticsearch/reference/7.x/ml-get-job.html
@@ -51,6 +52,7 @@ module Elasticsearch
           #
           # @since 6.2.0
           ParamsRegistry.register(:get_jobs, [
+            :allow_no_match,
             :allow_no_jobs
           ].freeze)
         end

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/machine_learning/get_overall_buckets.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/machine_learning/get_overall_buckets.rb
@@ -29,7 +29,8 @@ module Elasticsearch
           # @option arguments [Boolean] :exclude_interim If true overall buckets that include interim buckets will be excluded
           # @option arguments [String] :start Returns overall buckets with timestamps after this time
           # @option arguments [String] :end Returns overall buckets with timestamps earlier than this time
-          # @option arguments [Boolean] :allow_no_jobs Whether to ignore if a wildcard expression matches no jobs. (This includes `_all` string or when no jobs have been specified)
+          # @option arguments [Boolean] :allow_no_match Whether to ignore if a wildcard expression matches no jobs. (This includes `_all` string or when no jobs have been specified)
+          # @option arguments [Boolean] :allow_no_jobs Whether to ignore if a wildcard expression matches no jobs. (This includes `_all` string or when no jobs have been specified) *Deprecated*
           # @option arguments [Hash] :headers Custom HTTP headers
           # @option arguments [Hash] :body Overall bucket selection details if not provided in URI
           #
@@ -67,6 +68,7 @@ module Elasticsearch
             :exclude_interim,
             :start,
             :end,
+            :allow_no_match,
             :allow_no_jobs
           ].freeze)
         end

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/machine_learning/get_trained_models.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/machine_learning/get_trained_models.rb
@@ -28,7 +28,7 @@ module Elasticsearch
           #
           # @option arguments [String] :model_id The ID of the trained models to fetch
           # @option arguments [Boolean] :allow_no_match Whether to ignore if a wildcard expression matches no trained models. (This includes `_all` string or when no trained models have been specified)
-          # @option arguments [Boolean] :include_model_definition Should the full model definition be included in the results. These definitions can be large. So be cautious when including them. Defaults to false.
+          # @option arguments [String] :include A comma-separate list of fields to optionally include. Valid options are 'definition' and 'total_feature_importance'. Default is none.
           # @option arguments [Boolean] :decompress_definition Should the model definition be decompressed into valid JSON or returned in a custom compressed format. Defaults to true.
           # @option arguments [Int] :from skips a number of trained models
           # @option arguments [Int] :size specifies a max number of trained models to get
@@ -62,7 +62,7 @@ module Elasticsearch
           # @since 6.2.0
           ParamsRegistry.register(:get_trained_models, [
             :allow_no_match,
-            :include_model_definition,
+            :include,
             :decompress_definition,
             :from,
             :size,

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/machine_learning/stop_datafeed.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/machine_learning/stop_datafeed.rb
@@ -23,10 +23,12 @@ module Elasticsearch
           # Stops one or more datafeeds.
           #
           # @option arguments [String] :datafeed_id The ID of the datafeed to stop
-          # @option arguments [Boolean] :allow_no_datafeeds Whether to ignore if a wildcard expression matches no datafeeds. (This includes `_all` string or when no datafeeds have been specified)
+          # @option arguments [Boolean] :allow_no_match Whether to ignore if a wildcard expression matches no datafeeds. (This includes `_all` string or when no datafeeds have been specified)
+          # @option arguments [Boolean] :allow_no_datafeeds Whether to ignore if a wildcard expression matches no datafeeds. (This includes `_all` string or when no datafeeds have been specified) *Deprecated*
           # @option arguments [Boolean] :force True if the datafeed should be forcefully stopped.
           # @option arguments [Time] :timeout Controls the time to wait until a datafeed has stopped. Default to 20 seconds
           # @option arguments [Hash] :headers Custom HTTP headers
+          # @option arguments [Hash] :body The URL params optionally sent in the body
           #
           # @see https://www.elastic.co/guide/en/elasticsearch/reference/7.x/ml-stop-datafeed.html
           #
@@ -43,7 +45,7 @@ module Elasticsearch
             path   = "_ml/datafeeds/#{Elasticsearch::API::Utils.__listify(_datafeed_id)}/_stop"
             params = Elasticsearch::API::Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
 
-            body = nil
+            body = arguments[:body]
             perform_request(method, path, params, body, headers).body
           end
 
@@ -51,6 +53,7 @@ module Elasticsearch
           #
           # @since 6.2.0
           ParamsRegistry.register(:stop_datafeed, [
+            :allow_no_match,
             :allow_no_datafeeds,
             :force,
             :timeout

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/open_point_in_time.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/open_point_in_time.rb
@@ -1,0 +1,66 @@
+# Licensed to Elasticsearch B.V. under one or more contributor
+# license agreements. See the NOTICE file distributed with
+# this work for additional information regarding copyright
+# ownership. Elasticsearch B.V. licenses this file to you under
+# the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+module Elasticsearch
+  module XPack
+    module API
+      module Actions
+        # Open a point in time that can be used in subsequent searches
+        #
+        # @option arguments [List] :index A comma-separated list of index names to open point in time; use `_all` or empty string to perform the operation on all indices
+        # @option arguments [String] :preference Specify the node or shard the operation should be performed on (default: random)
+        # @option arguments [String] :routing Specific routing value
+        # @option arguments [Boolean] :ignore_unavailable Whether specified concrete indices should be ignored when unavailable (missing or closed)
+        # @option arguments [String] :expand_wildcards Whether to expand wildcard expression to concrete indices that are open, closed or both. (options: open, closed, hidden, none, all)
+        # @option arguments [String] :keep_alive Specific the time to live for the point in time
+        # @option arguments [Hash] :headers Custom HTTP headers
+        #
+        # @see https://www.elastic.co/guide/en/elasticsearch/reference/7.x/point-in-time.html
+        #
+        def open_point_in_time(arguments = {})
+          headers = arguments.delete(:headers) || {}
+
+          arguments = arguments.clone
+
+          _index = arguments.delete(:index)
+
+          method = Elasticsearch::API::HTTP_POST
+          path   = if _index
+                     "#{Elasticsearch::API::Utils.__listify(_index)}/_pit"
+                   else
+                     "_pit"
+                   end
+          params = Elasticsearch::API::Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
+
+          body = nil
+          perform_request(method, path, params, body, headers).body
+        end
+
+        # Register this action with its valid params when the module is loaded.
+        #
+        # @since 6.2.0
+        ParamsRegistry.register(:open_point_in_time, [
+          :preference,
+          :routing,
+          :ignore_unavailable,
+          :expand_wildcards,
+          :keep_alive
+        ].freeze)
+      end
+    end
+  end
+end

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/searchable_snapshots/clear_cache.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/searchable_snapshots/clear_cache.rb
@@ -33,7 +33,7 @@ module Elasticsearch
           # @option arguments [List] :index A comma-separated list of index name to limit the operation
           # @option arguments [Hash] :headers Custom HTTP headers
           #
-          # @see https://www.elastic.co/guide/en/elasticsearch/reference/7.x/searchable-snapshots-api-clear-cache.html
+          # @see https://www.elastic.co/guide/en/elasticsearch/reference/7.x/searchable-snapshots-apis.html
           #
           def clear_cache(arguments = {})
             headers = arguments.delete(:headers) || {}

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/searchable_snapshots/repository_stats.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/searchable_snapshots/repository_stats.rb
@@ -20,7 +20,7 @@ module Elasticsearch
     module API
       module SearchableSnapshots
         module Actions
-          # Retrieve usage statistics about a snapshot repository.
+          # DEPRECATED: This API is replaced by the Repositories Metering API.
           # This functionality is Experimental and may be changed or removed
           # completely in a future release. Elastic will take a best effort approach
           # to fix any issues, but experimental features are not subject to the
@@ -29,7 +29,7 @@ module Elasticsearch
           # @option arguments [String] :repository The repository for which to get the stats for
           # @option arguments [Hash] :headers Custom HTTP headers
           #
-          # @see https://www.elastic.co/guide/en/elasticsearch/reference/7.x/searchable-snapshots-repository-stats.html
+          # @see https://www.elastic.co/guide/en/elasticsearch/reference/7.x/searchable-snapshots-apis.html
           #
           def repository_stats(arguments = {})
             raise ArgumentError, "Required argument 'repository' missing" unless arguments[:repository]

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/searchable_snapshots/stats.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/searchable_snapshots/stats.rb
@@ -29,7 +29,7 @@ module Elasticsearch
           # @option arguments [List] :index A comma-separated list of index names
           # @option arguments [Hash] :headers Custom HTTP headers
           #
-          # @see https://www.elastic.co/guide/en/elasticsearch/reference/7.x/searchable-snapshots-api-stats.html
+          # @see https://www.elastic.co/guide/en/elasticsearch/reference/7.x/searchable-snapshots-apis.html
           #
           def stats(arguments = {})
             headers = arguments.delete(:headers) || {}


### PR DESCRIPTION
- Adds allow_no_match parameter to:
  - cat/ml_datafeeds
  - cat/ml_jobs
  - machine_learning/close_job
  - machine_learning/get_datafeed_stats
  - machine_learning/get_datafeeds
  - machine_learning/get_job_stats
  - machine_learning/get_jobs
  - machine_learning/get_overall_buckets
  - machine_learning/stop_datafeed,
- Renames include_model_definition to include in ml.get_trained_models, searchable_snapshots/clear_cache
- Adds body to machine_learning/stop_datafeed
- New: Adds close_point_in_time, open_point_in_time