### PR TITLE
Updates in X-Pack

### DIFF
--- a/api-spec-testing/README.md
+++ b/api-spec-testing/README.md
@@ -44,6 +44,10 @@ Task Groups are a representation of a block of actions consisting of 'do' action
 
 For each TaskGroup, it sees what's in the task group definition and runs an expectation test.
 
+## Action
+
+This file is where the action is executed, where we call the client with the method from the test and save the response which is then used in the task group.
+
 ## Rest YAML tests Helper
 
 `elasticsearch-(api|xpack)/spec/rest_yaml_tests_helper.rb`

--- a/api-spec-testing/rspec_matchers.rb
+++ b/api-spec-testing/rspec_matchers.rb
@@ -221,6 +221,11 @@ RSpec::Matchers.define :match_response do |pairs, test|
     #   match: {task: '/.+:\d+/'}
     if expected[0] == "/" && expected[-1] == "/"
       /#{expected.tr("/", "")}/ =~ actual_value
+    elsif !!(expected.match?(/[0-9]{1}\.[0-9]+E[0-9]+/))
+      # When the value in the yaml test is a big number, the format is
+      # different from what Ruby uses, so we transform  X.XXXXEXX to X.XXXXXe+XX
+      # to be able to compare the values
+      actual_value.to_s == expected.gsub('E', 'e+')
     elsif expected == ''
       actual_value == response
     else

--- a/api-spec-testing/rspec_matchers.rb
+++ b/api-spec-testing/rspec_matchers.rb
@@ -17,10 +17,8 @@
 
 # Match the `length` of a field.
 RSpec::Matchers.define :match_response_field_length do |expected_pairs, test|
-
   match do |response|
     expected_pairs.all? do |expected_key, expected_value|
-
       # ssl test returns results at '$body' key. See ssl/10_basic.yml
       expected_pairs = expected_pairs['$body'] if expected_pairs['$body']
 
@@ -43,7 +41,6 @@ end
 
 # Validate that a field is `true`.
 RSpec::Matchers.define :match_true_field do |field, test|
-
   match do |response|
     # Handle is_true: ''
     return !!response if field == ''
@@ -57,7 +54,6 @@ end
 
 # Validate that a field is `false`.
 RSpec::Matchers.define :match_false_field do |field, test|
-
   match do |response|
     # Handle is_false: ''
     return !response if field == ''
@@ -71,7 +67,6 @@ end
 
 # Validate that a field is `gte` than a given value.
 RSpec::Matchers.define :match_gte_field do |expected_pairs, test|
-
   match do |response|
     expected_pairs.all? do |expected_key, expected_value|
 
@@ -94,7 +89,6 @@ end
 
 # Validate that a field is `gt` than a given value.
 RSpec::Matchers.define :match_gt_field do |expected_pairs, test|
-
   match do |response|
     expected_pairs.all? do |expected_key, expected_value|
 
@@ -117,7 +111,6 @@ end
 
 # Validate that a field is `lte` than a given value.
 RSpec::Matchers.define :match_lte_field do |expected_pairs, test|
-
   match do |response|
     expected_pairs.all? do |expected_key, expected_value|
 
@@ -140,7 +133,6 @@ end
 
 # Validate that a field is `lt` than a given value.
 RSpec::Matchers.define :match_lt_field do |expected_pairs, test|
-
   match do |response|
     expected_pairs.all? do |expected_key, expected_value|
 
@@ -163,7 +155,6 @@ end
 
 # Match an arbitrary field of a response to a given value.
 RSpec::Matchers.define :match_response do |pairs, test|
-
   match do |response|
     pairs = sanitize_pairs(pairs)
     compare_pairs(pairs, response, test).empty?
@@ -258,7 +249,6 @@ end
 
 # Match that a request returned a given error.
 RSpec::Matchers.define :match_error do |expected_error|
-
   match do |actual_error|
     # Remove surrounding '/' in string representing Regex
     expected_error = expected_error.chomp("/")

--- a/api-spec-testing/test_file.rb
+++ b/api-spec-testing/test_file.rb
@@ -75,6 +75,7 @@ module Elasticsearch
       # @since 6.2.0
       def setup(client)
         return unless @setup
+
         actions = @setup['setup'].select { |action| action['do'] }.map { |action| Action.new(action['do']) }
         actions.each do |action|
           action.execute(client)
@@ -94,13 +95,13 @@ module Elasticsearch
       # @since 6.2.0
       def teardown(client)
         return unless @teardown
+
         actions = @teardown['teardown'].select { |action| action['do'] }.map { |action| Action.new(action['do']) }
         actions.each { |action| action.execute(client) }
         self
       end
 
       class << self
-
         # Prepare Elasticsearch for a single test file.
         # This method deletes indices, roles, datafeeds, etc.
         #

--- a/api-spec-testing/test_file/test.rb
+++ b/api-spec-testing/test_file/test.rb
@@ -16,18 +16,13 @@
 # under the License.
 
 module Elasticsearch
-
   module RestAPIYAMLTests
-
     class TestFile
-
       # Represents a single test in a test file. A single test can have many operations and validations.
       #
       # @since 6.2.0
       class Test
-
         class << self
-
           # Given a list of keys, find the value in a recursively nested document.
           #
           # @param [ Array<String> ] chain The list of nested document keys.
@@ -39,6 +34,7 @@ module Elasticsearch
           def find_value_in_document(chain, document)
             return document[chain] unless chain.is_a?(Array)
             return document[chain[0]] unless chain.size > 1
+
             # a number can be a string key in a Hash or indicate an element in a list
             if document.is_a?(Hash)
               find_value_in_document(chain[1..-1], document[chain[0].to_s]) if document[chain[0].to_s]

--- a/elasticsearch-xpack/Rakefile
+++ b/elasticsearch-xpack/Rakefile
@@ -16,10 +16,8 @@
 # under the License.
 
 require 'bundler/gem_tasks'
-
 require 'rake/testtask'
 require 'rspec/core/rake_task'
-
 
 task :default do
   exec "rake --tasks"
@@ -33,13 +31,12 @@ Rake::TestTask.new('test:unit') do |test|
 end
 
 namespace :test do
-
   RSpec::Core::RakeTask.new(:spec)
 
-  desc "Run rest api yaml tests"
-  Rake::TestTask.new(:rest_api)  do |test|
+  desc 'Run rest api yaml tests'
+  Rake::TestTask.new(:rest_api) do |test|
     `rm Gemfile.lock`
-    test.deps = [ :spec ]
+    test.deps = [:spec]
   end
 
   desc "Run integration tests"

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/close_point_in_time.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/close_point_in_time.rb
@@ -24,7 +24,7 @@ module Elasticsearch
         # @option arguments [Hash] :headers Custom HTTP headers
         # @option arguments [Hash] :body a point-in-time id to close
         #
-        # @see https://www.elastic.co/guide/en/elasticsearch/reference/7.x/point-in-time.html
+        # @see https://www.elastic.co/guide/en/elasticsearch/reference/7.x/point-in-time-api.html
         #
         def close_point_in_time(arguments = {})
           headers = arguments.delete(:headers) || {}

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/machine_learning/delete_trained_model.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/machine_learning/delete_trained_model.rb
@@ -29,7 +29,7 @@ module Elasticsearch
           # @option arguments [String] :model_id The ID of the trained model to delete
           # @option arguments [Hash] :headers Custom HTTP headers
           #
-          # @see https://www.elastic.co/guide/en/elasticsearch/reference/7.x/delete-inference.html
+          # @see https://www.elastic.co/guide/en/elasticsearch/reference/7.x/delete-trained-models.html
           #
           def delete_trained_model(arguments = {})
             raise ArgumentError, "Required argument 'model_id' missing" unless arguments[:model_id]
@@ -41,7 +41,7 @@ module Elasticsearch
             _model_id = arguments.delete(:model_id)
 
             method = Elasticsearch::API::HTTP_DELETE
-            path   = "_ml/inference/#{Elasticsearch::API::Utils.__listify(_model_id)}"
+            path   = "_ml/trained_models/#{Elasticsearch::API::Utils.__listify(_model_id)}"
             params = {}
 
             body = nil

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/machine_learning/get_trained_models.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/machine_learning/get_trained_models.rb
@@ -29,6 +29,7 @@ module Elasticsearch
           # @option arguments [String] :model_id The ID of the trained models to fetch
           # @option arguments [Boolean] :allow_no_match Whether to ignore if a wildcard expression matches no trained models. (This includes `_all` string or when no trained models have been specified)
           # @option arguments [String] :include A comma-separate list of fields to optionally include. Valid options are 'definition' and 'total_feature_importance'. Default is none.
+          # @option arguments [Boolean] :include_model_definition Should the full model definition be included in the results. These definitions can be large. So be cautious when including them. Defaults to false. *Deprecated*
           # @option arguments [Boolean] :decompress_definition Should the model definition be decompressed into valid JSON or returned in a custom compressed format. Defaults to true.
           # @option arguments [Int] :from skips a number of trained models
           # @option arguments [Int] :size specifies a max number of trained models to get
@@ -36,7 +37,7 @@ module Elasticsearch
           # @option arguments [Boolean] :for_export Omits fields that are illegal to set on model PUT
           # @option arguments [Hash] :headers Custom HTTP headers
           #
-          # @see https://www.elastic.co/guide/en/elasticsearch/reference/7.x/get-inference.html
+          # @see https://www.elastic.co/guide/en/elasticsearch/reference/7.x/get-trained-models.html
           #
           def get_trained_models(arguments = {})
             headers = arguments.delete(:headers) || {}
@@ -47,9 +48,9 @@ module Elasticsearch
 
             method = Elasticsearch::API::HTTP_GET
             path   = if _model_id
-                       "_ml/inference/#{Elasticsearch::API::Utils.__listify(_model_id)}"
+                       "_ml/trained_models/#{Elasticsearch::API::Utils.__listify(_model_id)}"
                      else
-                       "_ml/inference"
+                       "_ml/trained_models"
                      end
             params = Elasticsearch::API::Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
 
@@ -63,6 +64,7 @@ module Elasticsearch
           ParamsRegistry.register(:get_trained_models, [
             :allow_no_match,
             :include,
+            :include_model_definition,
             :decompress_definition,
             :from,
             :size,

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/machine_learning/get_trained_models_stats.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/machine_learning/get_trained_models_stats.rb
@@ -32,7 +32,7 @@ module Elasticsearch
           # @option arguments [Int] :size specifies a max number of trained models to get
           # @option arguments [Hash] :headers Custom HTTP headers
           #
-          # @see https://www.elastic.co/guide/en/elasticsearch/reference/7.x/get-inference-stats.html
+          # @see https://www.elastic.co/guide/en/elasticsearch/reference/7.x/get-trained-models-stats.html
           #
           def get_trained_models_stats(arguments = {})
             headers = arguments.delete(:headers) || {}
@@ -43,9 +43,9 @@ module Elasticsearch
 
             method = Elasticsearch::API::HTTP_GET
             path   = if _model_id
-                       "_ml/inference/#{Elasticsearch::API::Utils.__listify(_model_id)}/_stats"
+                       "_ml/trained_models/#{Elasticsearch::API::Utils.__listify(_model_id)}/_stats"
                      else
-                       "_ml/inference/_stats"
+                       "_ml/trained_models/_stats"
                      end
             params = Elasticsearch::API::Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
 

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/machine_learning/put_trained_model.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/machine_learning/put_trained_model.rb
@@ -30,7 +30,7 @@ module Elasticsearch
           # @option arguments [Hash] :headers Custom HTTP headers
           # @option arguments [Hash] :body The trained model configuration (*Required*)
           #
-          # @see https://www.elastic.co/guide/en/elasticsearch/reference/7.x/put-inference.html
+          # @see https://www.elastic.co/guide/en/elasticsearch/reference/7.x/put-trained-models.html
           #
           def put_trained_model(arguments = {})
             raise ArgumentError, "Required argument 'body' missing" unless arguments[:body]
@@ -43,7 +43,7 @@ module Elasticsearch
             _model_id = arguments.delete(:model_id)
 
             method = Elasticsearch::API::HTTP_PUT
-            path   = "_ml/inference/#{Elasticsearch::API::Utils.__listify(_model_id)}"
+            path   = "_ml/trained_models/#{Elasticsearch::API::Utils.__listify(_model_id)}"
             params = {}
 
             body = arguments[:body]

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/open_point_in_time.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/open_point_in_time.rb
@@ -29,7 +29,7 @@ module Elasticsearch
         # @option arguments [String] :keep_alive Specific the time to live for the point in time
         # @option arguments [Hash] :headers Custom HTTP headers
         #
-        # @see https://www.elastic.co/guide/en/elasticsearch/reference/7.x/point-in-time.html
+        # @see https://www.elastic.co/guide/en/elasticsearch/reference/7.x/point-in-time-api.html
         #
         def open_point_in_time(arguments = {})
           headers = arguments.delete(:headers) || {}

--- a/elasticsearch-xpack/spec/spec_helper.rb
+++ b/elasticsearch-xpack/spec/spec_helper.rb
@@ -28,7 +28,6 @@ require 'openssl'
 
 module HelperModule
   def self.included(context)
-
     context.let(:client_double) do
       Class.new { include Elasticsearch::XPack::API }.new.tap do |client|
         expect(client).to receive(:perform_request).with(*expected_args).and_return(response_double)

--- a/elasticsearch-xpack/spec/xpack/rest_api_yaml_spec.rb
+++ b/elasticsearch-xpack/spec/xpack/rest_api_yaml_spec.rb
@@ -19,9 +19,7 @@ require 'spec_helper'
 require 'rest_yaml_tests_helper'
 
 describe 'XPack Rest API YAML tests' do
-
   REST_API_YAML_FILES.each do |file|
-
     test_file = Elasticsearch::RestAPIYAMLTests::TestFile.new(file, REST_API_YAML_SKIP_FEATURES)
 
     context "#{file.gsub("#{YAML_FILES_DIRECTORY}/", '')}" do
@@ -67,21 +65,18 @@ describe 'XPack Rest API YAML tests' do
             end
 
             test.task_groups.each do |task_group|
-
               before do
                 task_group.run(client)
               end
 
               # 'catch' is in the task group definition
               if task_group.catch_exception?
-
                 it 'sends the request and throws the expected error' do
                   expect(task_group.exception).to match_error(task_group.expected_exception_message)
                 end
 
                 # 'match' on error description is in the task group definition
                 if task_group.has_match_clauses?
-
                   task_group.match_clauses.each do |match|
                     it 'contains the expected error in the request response' do
                       expect(task_group.exception.message).to match(Regexp.new(Regexp.escape(match['match'].values.first.to_s)))


### PR DESCRIPTION
- Updates X-Pack Machine Learning API
  - `ml.get_trained_models` adds `include_model_definition` parameter.
  - Internal API changes: endpoint change from `_ml/inference` to `_ml/trained_models`
    - ml.get_trained_models
    - ml.delete_trained_model
    - ml.get_trained_models_stats
    - ml.put_trained_models
- Updates rspec matchers in YAML test runners to be able to compare big numbers
- Minor whitespace fixes and update in YAML test runner README


