### PR TITLE
fix: Fix adding nested aggregations imperatively

### DIFF
--- a/elasticsearch-dsl/lib/elasticsearch/dsl/search/base_aggregation_component.rb
+++ b/elasticsearch-dsl/lib/elasticsearch/dsl/search/base_aggregation_component.rb
@@ -53,7 +53,12 @@ module Elasticsearch
           #
           def aggregation(*args, &block)
             @aggregations ||= AggregationsCollection.new
-            @aggregations.update args.first => Aggregation.new(*args, &block)
+            if block
+              @aggregations.update args.first => Aggregation.new(*args, &block)
+            else
+              name = args.shift
+              @aggregations.update name => args.shift
+            end
             self
           end
 

--- a/elasticsearch-dsl/test/unit/search_base_aggregation_component_test.rb
+++ b/elasticsearch-dsl/test/unit/search_base_aggregation_component_test.rb
@@ -52,6 +52,19 @@ module Elasticsearch
 
           assert_equal 'foo', subject.to_hash[:aggregations][:inner][:dummy][:field]
         end
+
+        should "add a nested aggregation using imperatively" do
+          subject.aggregation(
+            :inner,
+            ::Elasticsearch::DSL::Search::Aggregations::Dummy.new(field: 'foo')
+          )
+
+          assert ! subject.aggregations.empty?, "#{subject.aggregations.inspect} is empty"
+
+          assert_equal( {:dummy=>{:field=>"foo"}}, subject.aggregations[:inner].to_hash )
+
+          assert_equal 'foo', subject.to_hash[:aggregations][:inner][:dummy][:field]
+        end
       end
     end
   end


### PR DESCRIPTION
Hello :wave: This is related to `elasticsearch-dsl`, the following does not seem to work
```ruby
terms = Elasticsearch::DSL::Search::Aggregations::Terms.new(field: 'foo')
average = Elasticsearch::DSL::Search::Aggregations::Avg.new(field: 'bar')
terms.aggregation(:average, average)
terms.to_hash
```
expected output would be
```ruby
{:terms=>{:field=>"foo"}, :aggregations=>{:average=>{:avg=>{:field=>"bar"}}}}
```
actual output
```ruby
{:terms=>{:field=>"foo"}}
```
This PR fixes this issue, If a block is not passed use the passed aggregation, this is similar to [Search#aggregation](https://github.com/elastic/elasticsearch-ruby/blob/master/elasticsearch-dsl/lib/elasticsearch/dsl/search.rb#L138). If something is incorrect or missing please let me know :see_no_evil: 