### PR TITLE
Refactor test runner

### DIFF
--- a/api-spec-testing/rspec_matchers.rb
+++ b/api-spec-testing/rspec_matchers.rb
@@ -227,8 +227,12 @@ RSpec::Matchers.define :match_response do |pairs, test|
   def compare_string(expected, actual_value, test, response)
     # When you must match a regex. For example:
     #   match: {task: '/.+:\d+/'}
-    if expected[0] == "/" && expected[-1] == "/"
-      /#{expected.tr("/", "")}/ =~ actual_value
+    if expected[0] == '/' && expected[-1] == '/'
+      parsed = expected
+      expected.scan(/\$\{([a-z_0-9]+)\}/) do |match|
+        parsed = parsed.gsub(/\$\{?#{match.first}\}?/, test.cached_values[match.first])
+      end
+      /#{parsed.tr("/", "")}/ =~ actual_value
     elsif !!(expected.match?(/[0-9]{1}\.[0-9]+E[0-9]+/))
       # When the value in the yaml test is a big number, the format is
       # different from what Ruby uses, so we transform  X.XXXXEXX to X.XXXXXe+XX

--- a/api-spec-testing/test_file/action.rb
+++ b/api-spec-testing/test_file/action.rb
@@ -109,9 +109,12 @@ module Elasticsearch
                   args[key] = value.collect { |v| prepare_arguments(v, test) }
                 when String
                   # Find the cached values where the variable name is contained in the arguments.
-                  if cached_value = test.cached_values.find { |k, v| value =~ /\$\{?#{k}\}?/ }
-                    # The arguments may contain the variable in the form ${variable} or $variable
-                    args[key] = value.gsub(/\$\{?#{cached_value[0]}\}?/, cached_value[1].to_s)
+                  if(cached_values = test.cached_values.keys.select { |k| value =~ /\$\{?#{k}\}?/ })
+                    cached_values.each do |cached|
+                      # The arguments may contain the variable in the form ${variable} or $variable
+                      value.gsub!(/\$\{?#{cached}\}?/, test.cached_values[cached].to_s)
+                    end
+                    args[key] = value
                   end
                 when Time
                   # The YAML parser reads in dates as Time objects, reconvert to a format Elasticsearch accepts

--- a/api-spec-testing/test_file/task_group.rb
+++ b/api-spec-testing/test_file/task_group.rb
@@ -16,13 +16,9 @@
 # under the License.
 
 module Elasticsearch
-
   module RestAPIYAMLTests
-
     class TestFile
-
       class Test
-
         # Representation of a block of actions consisting of some 'do' actions and their verifications.
         #
         # For example, this is a task group:
@@ -36,7 +32,6 @@ module Elasticsearch
         #
         # @since 6.2.0
         class TaskGroup
-
           attr_reader :exception
           attr_reader :response
           attr_reader :test
@@ -321,7 +316,6 @@ module Elasticsearch
           def set_variable(action)
             variables_to_set.each do |set_definition|
               set_definition['set'].each do |response_key, variable_name|
-
                 nested_key_chain = response_key.split('.').map do |key|
                   (key =~ /\A[-+]?[0-9]+\z/) ? key.to_i: key
                 end

--- a/elasticsearch-xpack/spec/xpack/rest_api_yaml_spec.rb
+++ b/elasticsearch-xpack/spec/xpack/rest_api_yaml_spec.rb
@@ -87,7 +87,6 @@ describe 'XPack Rest API YAML tests' do
 
                 # 'match' is in the task group definition
                 if task_group.has_match_clauses?
-
                   task_group.match_clauses.each do |match|
                     it "has the expected value (#{match['match'].values.join(',')}) in the response field (#{match['match'].keys.join(',')})" do
                       expect(task_group.response).to match_response(match['match'], test)


### PR DESCRIPTION
An error was triggered from the YAML test runner in the X-Pack test [`api_key/10_basic.yml`](https://github.com/elastic/elasticsearch/blob/master/x-pack/plugin/src/test/resources/rest-api-spec/test/api_key/10_basic.yml) file. The issue had 2 parts:

- the runner was not setting the variables for `api_key_id_2` and `api_key_id_3` and this was fixed in https://github.com/elastic/elasticsearch-ruby/commit/23046afcf9c74d11ccdcd02b0e6f3c849a2d4049.
- When the tests were run, the variables in this request body:
```
"ids": [ "${api_key_id_1}", "${api_key_id_2}", "${api_key_id_3}" ]
```
Was not being parsed and the newly set values for `api_key_id_2` and `api_key_id_3` were not being used. This was fixed in https://github.com/elastic/elasticsearch-ruby/commit/75eaa420b9d4377511937d15bde3f7d1f4d37163.