### PR TITLE
Test Runner: expand_wildcards on xpack indices clean up

### DIFF
--- a/api-spec-testing/test_file.rb
+++ b/api-spec-testing/test_file.rb
@@ -236,7 +236,7 @@ module Elasticsearch
         end
 
         def clear_indices_xpack(client)
-          indices = client.indices.get(index: '_all').keys.reject do |i|
+          indices = client.indices.get(index: '_all', expand_wildcards: 'all').keys.reject do |i|
             i.start_with?('.security') || i.start_with?('.watches') || i.start_with?('.ds-')
           end
           indices.each do |index|


### PR DESCRIPTION
There's a [flaky in master](https://clients-ci.elastic.co/view/Ruby/job/elastic+elasticsearch-ruby+master/887/ELASTICSEARCH_VERSION=8.0.0-SNAPSHOT,RUBY_TEST_VERSION=2.7.1,TEST_SUITE=xpack,label=linux/testReport/junit/spec.xpack/rest_api_yaml_spec/XPack_Rest_API_YAML_tests_data_stream_80_resolve_index_data_streams_yml_Resolve_index_with_hidden_and_closed_indices_has_the_expected_value__test_index1__in_the_response_field__indices_3_name_/) which I think could be related to indices cleanup.