### PR TITLE
Update generator master

### DIFF
--- a/elasticsearch-api/lib/elasticsearch/api/actions/bulk.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/bulk.rb
@@ -26,7 +26,6 @@ module Elasticsearch
       # @option arguments [String] :refresh If `true` then refresh the affected shards to make this operation visible to search, if `wait_for` then wait for a refresh to make this operation visible to search, if `false` (the default) then do nothing with refreshes. (options: true, false, wait_for)
       # @option arguments [String] :routing Specific routing value
       # @option arguments [Time] :timeout Explicit operation timeout
-      # @option arguments [String] :type Default document type for items which don't provide one
       # @option arguments [List] :_source True or false to return the _source field or not, or default list of fields to return, can be overridden on each sub-request
       # @option arguments [List] :_source_excludes Default list of fields to exclude from the returned _source field, can be overridden on each sub-request
       # @option arguments [List] :_source_includes Default list of fields to extract and return from the _source field, can be overridden on each sub-request

--- a/elasticsearch-api/lib/elasticsearch/api/actions/cat/fielddata.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/cat/fielddata.rb
@@ -28,7 +28,6 @@ module Elasticsearch
         # @option arguments [Boolean] :help Return help information
         # @option arguments [List] :s Comma-separated list of column names or column aliases to sort by
         # @option arguments [Boolean] :v Verbose mode. Display column headers
-        # @option arguments [List] :fields A comma-separated list of fields to return in the output
         # @option arguments [Hash] :headers Custom HTTP headers
         #
         # @see https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-fielddata.html

--- a/elasticsearch-api/lib/elasticsearch/api/actions/cat/recovery.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/cat/recovery.rb
@@ -28,7 +28,6 @@ module Elasticsearch
         # @option arguments [Boolean] :detailed If `true`, the response includes detailed information about shard recoveries
         # @option arguments [List] :h Comma-separated list of column names to display
         # @option arguments [Boolean] :help Return help information
-        # @option arguments [List] :index Comma-separated list or wildcard expression of index names to limit the returned information
         # @option arguments [List] :s Comma-separated list of column names or column aliases to sort by
         # @option arguments [String] :time The unit in which to display time values (options: d, h, m, s, ms, micros, nanos)
         # @option arguments [Boolean] :v Verbose mode. Display column headers

--- a/elasticsearch-api/lib/elasticsearch/api/actions/clear_scroll.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/clear_scroll.rb
@@ -29,7 +29,7 @@ module Elasticsearch
       # Deprecated since version 7.0.0
       #
       #
-      # @see https://www.elastic.co/guide/en/elasticsearch/reference/master/search-request-body.html#_clear_scroll_api
+      # @see https://www.elastic.co/guide/en/elasticsearch/reference/current/clear-scroll-api.html
       #
       def clear_scroll(arguments = {})
         headers = arguments.delete(:headers) || {}

--- a/elasticsearch-api/lib/elasticsearch/api/actions/cluster/delete_component_template.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/cluster/delete_component_template.rb
@@ -20,6 +20,10 @@ module Elasticsearch
     module Cluster
       module Actions
         # Deletes a component template
+        # This functionality is Experimental and may be changed or removed
+        # completely in a future release. Elastic will take a best effort approach
+        # to fix any issues, but experimental features are not subject to the
+        # support SLA of official GA features.
         #
         # @option arguments [String] :name The name of the template
         # @option arguments [Time] :timeout Explicit operation timeout

--- a/elasticsearch-api/lib/elasticsearch/api/actions/cluster/exists_component_template.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/cluster/exists_component_template.rb
@@ -20,6 +20,10 @@ module Elasticsearch
     module Cluster
       module Actions
         # Returns information about whether a particular component template exist
+        # This functionality is Experimental and may be changed or removed
+        # completely in a future release. Elastic will take a best effort approach
+        # to fix any issues, but experimental features are not subject to the
+        # support SLA of official GA features.
         #
         # @option arguments [String] :name The name of the template
         # @option arguments [Time] :master_timeout Explicit operation timeout for connection to master node

--- a/elasticsearch-api/lib/elasticsearch/api/actions/cluster/get_component_template.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/cluster/get_component_template.rb
@@ -20,6 +20,10 @@ module Elasticsearch
     module Cluster
       module Actions
         # Returns one or more component templates
+        # This functionality is Experimental and may be changed or removed
+        # completely in a future release. Elastic will take a best effort approach
+        # to fix any issues, but experimental features are not subject to the
+        # support SLA of official GA features.
         #
         # @option arguments [List] :name The comma separated names of the component templates
         # @option arguments [Time] :master_timeout Explicit operation timeout for connection to master node

--- a/elasticsearch-api/lib/elasticsearch/api/actions/cluster/put_component_template.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/cluster/put_component_template.rb
@@ -20,6 +20,10 @@ module Elasticsearch
     module Cluster
       module Actions
         # Creates or updates a component template
+        # This functionality is Experimental and may be changed or removed
+        # completely in a future release. Elastic will take a best effort approach
+        # to fix any issues, but experimental features are not subject to the
+        # support SLA of official GA features.
         #
         # @option arguments [String] :name The name of the template
         # @option arguments [Boolean] :create Whether the index template should only be added if new or can also replace an existing one

--- a/elasticsearch-api/lib/elasticsearch/api/actions/get_script_context.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/get_script_context.rb
@@ -19,6 +19,10 @@ module Elasticsearch
   module API
     module Actions
       # Returns all script contexts.
+      # This functionality is Experimental and may be changed or removed
+      # completely in a future release. Elastic will take a best effort approach
+      # to fix any issues, but experimental features are not subject to the
+      # support SLA of official GA features.
       #
       # @option arguments [Hash] :headers Custom HTTP headers
       #

--- a/elasticsearch-api/lib/elasticsearch/api/actions/get_script_languages.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/get_script_languages.rb
@@ -19,6 +19,10 @@ module Elasticsearch
   module API
     module Actions
       # Returns available script types, languages and contexts
+      # This functionality is Experimental and may be changed or removed
+      # completely in a future release. Elastic will take a best effort approach
+      # to fix any issues, but experimental features are not subject to the
+      # support SLA of official GA features.
       #
       # @option arguments [Hash] :headers Custom HTTP headers
       #

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/add_block.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/add_block.rb
@@ -30,7 +30,7 @@ module Elasticsearch
         # @option arguments [String] :expand_wildcards Whether to expand wildcard expression to concrete indices that are open, closed or both. (options: open, closed, hidden, none, all)
         # @option arguments [Hash] :headers Custom HTTP headers
         #
-        # @see https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-blocks.html
+        # @see https://www.elastic.co/guide/en/elasticsearch/reference/master/index-modules-blocks.html
         #
         def add_block(arguments = {})
           raise ArgumentError, "Required argument 'index' missing" unless arguments[:index]

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/analyze.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/analyze.rb
@@ -22,7 +22,6 @@ module Elasticsearch
         # Performs the analysis process on a text and return the tokens breakdown of the text.
         #
         # @option arguments [String] :index The name of the index to scope the operation
-        # @option arguments [String] :index The name of the index to scope the operation
         # @option arguments [Hash] :headers Custom HTTP headers
         # @option arguments [Hash] :body Define analyzer/tokenizer parameters and the text on which the analysis should be performed
         #

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/clear_cache.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/clear_cache.rb
@@ -28,7 +28,6 @@ module Elasticsearch
         # @option arguments [Boolean] :ignore_unavailable Whether specified concrete indices should be ignored when unavailable (missing or closed)
         # @option arguments [Boolean] :allow_no_indices Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)
         # @option arguments [String] :expand_wildcards Whether to expand wildcard expression to concrete indices that are open, closed or both. (options: open, closed, hidden, none, all)
-        # @option arguments [List] :index A comma-separated list of index name to limit the operation
         # @option arguments [Boolean] :request Clear request cache
         # @option arguments [Hash] :headers Custom HTTP headers
         #

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/delete_index_template.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/delete_index_template.rb
@@ -20,6 +20,10 @@ module Elasticsearch
     module Indices
       module Actions
         # Deletes an index template.
+        # This functionality is Experimental and may be changed or removed
+        # completely in a future release. Elastic will take a best effort approach
+        # to fix any issues, but experimental features are not subject to the
+        # support SLA of official GA features.
         #
         # @option arguments [String] :name The name of the template
         # @option arguments [Time] :timeout Explicit operation timeout

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/exists_index_template.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/exists_index_template.rb
@@ -20,6 +20,10 @@ module Elasticsearch
     module Indices
       module Actions
         # Returns information about whether a particular index template exists.
+        # This functionality is Experimental and may be changed or removed
+        # completely in a future release. Elastic will take a best effort approach
+        # to fix any issues, but experimental features are not subject to the
+        # support SLA of official GA features.
         #
         # @option arguments [String] :name The name of the template
         # @option arguments [Boolean] :flat_settings Return settings in flat format (default: false)

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/get_index_template.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/get_index_template.rb
@@ -20,6 +20,10 @@ module Elasticsearch
     module Indices
       module Actions
         # Returns an index template.
+        # This functionality is Experimental and may be changed or removed
+        # completely in a future release. Elastic will take a best effort approach
+        # to fix any issues, but experimental features are not subject to the
+        # support SLA of official GA features.
         #
         # @option arguments [List] :name The comma separated names of the index templates
         # @option arguments [Boolean] :flat_settings Return settings in flat format (default: false)

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/put_index_template.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/put_index_template.rb
@@ -20,6 +20,10 @@ module Elasticsearch
     module Indices
       module Actions
         # Creates or updates an index template.
+        # This functionality is Experimental and may be changed or removed
+        # completely in a future release. Elastic will take a best effort approach
+        # to fix any issues, but experimental features are not subject to the
+        # support SLA of official GA features.
         #
         # @option arguments [String] :name The name of the template
         # @option arguments [Boolean] :create Whether the index template should only be added if new or can also replace an existing one

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/resolve_index.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/resolve_index.rb
@@ -20,12 +20,16 @@ module Elasticsearch
     module Indices
       module Actions
         # Returns information about any matching indices, aliases, and data streams
+        # This functionality is Experimental and may be changed or removed
+        # completely in a future release. Elastic will take a best effort approach
+        # to fix any issues, but experimental features are not subject to the
+        # support SLA of official GA features.
         #
         # @option arguments [List] :name A comma-separated list of names or wildcard expressions
         # @option arguments [String] :expand_wildcards Whether wildcard expressions should get expanded to open or closed indices (default: open) (options: open, closed, hidden, none, all)
         # @option arguments [Hash] :headers Custom HTTP headers
         #
-        # @see https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-resolve-index.html
+        # @see https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-resolve-index-api.html
         #
         def resolve_index(arguments = {})
           raise ArgumentError, "Required argument 'name' missing" unless arguments[:name]

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/simulate_index_template.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/simulate_index_template.rb
@@ -20,6 +20,10 @@ module Elasticsearch
     module Indices
       module Actions
         # Simulate matching the given index name against the index templates in the system
+        # This functionality is Experimental and may be changed or removed
+        # completely in a future release. Elastic will take a best effort approach
+        # to fix any issues, but experimental features are not subject to the
+        # support SLA of official GA features.
         #
         # @option arguments [String] :name The name of the index (it must be a concrete index name)
         # @option arguments [Boolean] :create Whether the index template we optionally defined in the body should only be dry-run added if new or can also replace an existing one

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/simulate_template.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/simulate_template.rb
@@ -20,6 +20,10 @@ module Elasticsearch
     module Indices
       module Actions
         # Simulate resolving the given template name or body
+        # This functionality is Experimental and may be changed or removed
+        # completely in a future release. Elastic will take a best effort approach
+        # to fix any issues, but experimental features are not subject to the
+        # support SLA of official GA features.
         #
         # @option arguments [String] :name The name of the index template
         # @option arguments [Boolean] :create Whether the index template we optionally defined in the body should only be dry-run added if new or can also replace an existing one

--- a/elasticsearch-api/lib/elasticsearch/api/actions/msearch.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/msearch.rb
@@ -31,7 +31,7 @@ module Elasticsearch
       # @option arguments [Hash] :headers Custom HTTP headers
       # @option arguments [Hash] :body The request definitions (metadata-search request definition pairs), separated by newlines (*Required*)
       #
-      # @see https://www.elastic.co/guide/en/elasticsearch/reference/8.0/search-multi-search.html
+      # @see https://www.elastic.co/guide/en/elasticsearch/reference/master/search-multi-search.html
       #
       def msearch(arguments = {})
         raise ArgumentError, "Required argument 'body' missing" unless arguments[:body]

--- a/elasticsearch-api/lib/elasticsearch/api/actions/put_script.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/put_script.rb
@@ -24,7 +24,6 @@ module Elasticsearch
       # @option arguments [String] :context Script context
       # @option arguments [Time] :timeout Explicit operation timeout
       # @option arguments [Time] :master_timeout Specify timeout for connection to master
-      # @option arguments [String] :context Context name to compile script against
       # @option arguments [Hash] :headers Custom HTTP headers
       # @option arguments [Hash] :body The document (*Required*)
       #

--- a/elasticsearch-api/lib/elasticsearch/api/actions/rank_eval.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/rank_eval.rb
@@ -19,6 +19,10 @@ module Elasticsearch
   module API
     module Actions
       # Allows to evaluate the quality of ranked search results over a set of typical search queries
+      # This functionality is Experimental and may be changed or removed
+      # completely in a future release. Elastic will take a best effort approach
+      # to fix any issues, but experimental features are not subject to the
+      # support SLA of official GA features.
       #
       # @option arguments [List] :index A comma-separated list of index names to search; use `_all` or empty string to perform the operation on all indices
       # @option arguments [Boolean] :ignore_unavailable Whether specified concrete indices should be ignored when unavailable (missing or closed)

--- a/elasticsearch-api/lib/elasticsearch/api/actions/scripts_painless_execute.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/scripts_painless_execute.rb
@@ -19,6 +19,10 @@ module Elasticsearch
   module API
     module Actions
       # Allows an arbitrary script to be executed and a result to be returned
+      # This functionality is Experimental and may be changed or removed
+      # completely in a future release. Elastic will take a best effort approach
+      # to fix any issues, but experimental features are not subject to the
+      # support SLA of official GA features.
       #
       # @option arguments [Hash] :headers Custom HTTP headers
       # @option arguments [Hash] :body The script to execute

--- a/elasticsearch-api/lib/elasticsearch/api/actions/scroll.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/scroll.rb
@@ -22,7 +22,6 @@ module Elasticsearch
       #
       # @option arguments [String] :scroll_id The scroll ID *Deprecated*
       # @option arguments [Time] :scroll Specify how long a consistent view of the index should be maintained for scrolled search
-      # @option arguments [String] :scroll_id The scroll ID for scrolled search
       # @option arguments [Boolean] :rest_total_hits_as_int Indicates whether hits.total should be rendered as an integer or an object in the rest search response
       # @option arguments [Hash] :headers Custom HTTP headers
       # @option arguments [Hash] :body The scroll ID if not passed by URL or query parameter.

--- a/elasticsearch-api/utils/thor/templates/_documentation_top.erb
+++ b/elasticsearch-api/utils/thor/templates/_documentation_top.erb
@@ -12,7 +12,7 @@
 <%- end -%><%# Body -%>
 <%# URL parameters -%>
 <%- @params.each do |name, info| -%>
-  <%= docs_helper(name, info) -%>
+  <%= docs_helper(name, info) unless (!@parts.empty? && @parts.keys.include?(name)) -%>
 <%- end -%>
 # @option arguments [Hash] :headers Custom HTTP headers
 <%- if @spec['body'] -%>

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/searchable_snapshots/clear_cache.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/searchable_snapshots/clear_cache.rb
@@ -30,7 +30,6 @@ module Elasticsearch
           # @option arguments [Boolean] :ignore_unavailable Whether specified concrete indices should be ignored when unavailable (missing or closed)
           # @option arguments [Boolean] :allow_no_indices Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)
           # @option arguments [String] :expand_wildcards Whether to expand wildcard expression to concrete indices that are open, closed or both. (options: open, closed, none, all)
-          # @option arguments [List] :index A comma-separated list of index name to limit the operation
           # @option arguments [Hash] :headers Custom HTTP headers
           #
           # @see https://www.elastic.co/guide/en/elasticsearch/reference/master/searchable-snapshots-apis.html

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/watcher/stats.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/watcher/stats.rb
@@ -23,7 +23,6 @@ module Elasticsearch
           # Retrieves the current Watcher metrics.
           #
           # @option arguments [List] :metric Controls what additional stat metrics should be include in the response (options: _all, queued_watches, current_watches, pending_watches)
-          # @option arguments [List] :metric Controls what additional stat metrics should be include in the response (options: _all, queued_watches, current_watches, pending_watches)
           # @option arguments [Boolean] :emit_stacktraces Emits stack traces of currently running watches
           # @option arguments [Hash] :headers Custom HTTP headers
           #


### PR DESCRIPTION
This PR avoids duplicating  parameters in the generated class documentation for the API endpoints when these parameters are listed both as parts and as parameters.

As seen in #1055.