### PR TITLE
Update 7x

### DIFF
--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/autoscaling/get_autoscaling_capacity.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/autoscaling/get_autoscaling_capacity.rb
@@ -1,0 +1,49 @@
+# Licensed to Elasticsearch B.V. under one or more contributor
+# license agreements. See the NOTICE file distributed with
+# this work for additional information regarding copyright
+# ownership. Elasticsearch B.V. licenses this file to you under
+# the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+module Elasticsearch
+  module XPack
+    module API
+      module Autoscaling
+        module Actions
+          # Gets the current autoscaling capacity based on the configured autoscaling policy.
+          # This functionality is Experimental and may be changed or removed
+          # completely in a future release. Elastic will take a best effort approach
+          # to fix any issues, but experimental features are not subject to the
+          # support SLA of official GA features.
+          #
+          # @option arguments [Hash] :headers Custom HTTP headers
+          #
+          # @see https://www.elastic.co/guide/en/elasticsearch/reference/7.x/autoscaling-get-autoscaling-capacity.html
+          #
+          def get_autoscaling_capacity(arguments = {})
+            headers = arguments.delete(:headers) || {}
+
+            arguments = arguments.clone
+
+            method = Elasticsearch::API::HTTP_GET
+            path   = "_autoscaling/capacity"
+            params = {}
+
+            body = nil
+            perform_request(method, path, params, body, headers).body
+          end
+        end
+      end
+    end
+  end
+end

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/data_frame_transform_deprecated/get_transform.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/data_frame_transform_deprecated/get_transform.rb
@@ -30,6 +30,7 @@ module Elasticsearch
           # @option arguments [Int] :from skips a number of transform configs, defaults to 0
           # @option arguments [Int] :size specifies a max number of transforms to get, defaults to 100
           # @option arguments [Boolean] :allow_no_match Whether to ignore if a wildcard expression matches no transforms. (This includes `_all` string or when no transforms have been specified)
+          # @option arguments [Boolean] :exclude_generated Omits generated fields. Allows transform configurations to be easily copied between clusters and within the same cluster
           # @option arguments [Hash] :headers Custom HTTP headers
           #
           # *Deprecation notice*:
@@ -64,7 +65,8 @@ module Elasticsearch
           ParamsRegistry.register(:get_transform, [
             :from,
             :size,
-            :allow_no_match
+            :allow_no_match,
+            :exclude_generated
           ].freeze)
         end
       end

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/machine_learning/delete_data_frame_analytics.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/machine_learning/delete_data_frame_analytics.rb
@@ -21,10 +21,10 @@ module Elasticsearch
       module MachineLearning
         module Actions
           # Deletes an existing data frame analytics job.
-          # This functionality is Experimental and may be changed or removed
-          # completely in a future release. Elastic will take a best effort approach
-          # to fix any issues, but experimental features are not subject to the
-          # support SLA of official GA features.
+          # This functionality is in Beta and is subject to change. The design and
+          # code is less mature than official GA features and is being provided
+          # as-is with no warranties. Beta features are not subject to the support
+          # SLA of official GA features.
           #
           # @option arguments [String] :id The ID of the data frame analytics to delete
           # @option arguments [Boolean] :force True if the job should be forcefully deleted

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/machine_learning/delete_trained_model.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/machine_learning/delete_trained_model.rb
@@ -21,10 +21,10 @@ module Elasticsearch
       module MachineLearning
         module Actions
           # Deletes an existing trained inference model that is currently not referenced by an ingest pipeline.
-          # This functionality is Experimental and may be changed or removed
-          # completely in a future release. Elastic will take a best effort approach
-          # to fix any issues, but experimental features are not subject to the
-          # support SLA of official GA features.
+          # This functionality is in Beta and is subject to change. The design and
+          # code is less mature than official GA features and is being provided
+          # as-is with no warranties. Beta features are not subject to the support
+          # SLA of official GA features.
           #
           # @option arguments [String] :model_id The ID of the trained model to delete
           # @option arguments [Hash] :headers Custom HTTP headers

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/machine_learning/evaluate_data_frame.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/machine_learning/evaluate_data_frame.rb
@@ -21,10 +21,10 @@ module Elasticsearch
       module MachineLearning
         module Actions
           # Evaluates the data frame analytics for an annotated index.
-          # This functionality is Experimental and may be changed or removed
-          # completely in a future release. Elastic will take a best effort approach
-          # to fix any issues, but experimental features are not subject to the
-          # support SLA of official GA features.
+          # This functionality is in Beta and is subject to change. The design and
+          # code is less mature than official GA features and is being provided
+          # as-is with no warranties. Beta features are not subject to the support
+          # SLA of official GA features.
           #
           # @option arguments [Hash] :headers Custom HTTP headers
           # @option arguments [Hash] :body The evaluation definition (*Required*)

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/machine_learning/explain_data_frame_analytics.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/machine_learning/explain_data_frame_analytics.rb
@@ -21,10 +21,10 @@ module Elasticsearch
       module MachineLearning
         module Actions
           # Explains a data frame analytics config.
-          # This functionality is Experimental and may be changed or removed
-          # completely in a future release. Elastic will take a best effort approach
-          # to fix any issues, but experimental features are not subject to the
-          # support SLA of official GA features.
+          # This functionality is in Beta and is subject to change. The design and
+          # code is less mature than official GA features and is being provided
+          # as-is with no warranties. Beta features are not subject to the support
+          # SLA of official GA features.
           #
           # @option arguments [String] :id The ID of the data frame analytics to explain
           # @option arguments [Hash] :headers Custom HTTP headers

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/machine_learning/get_data_frame_analytics.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/machine_learning/get_data_frame_analytics.rb
@@ -21,15 +21,16 @@ module Elasticsearch
       module MachineLearning
         module Actions
           # Retrieves configuration information for data frame analytics jobs.
-          # This functionality is Experimental and may be changed or removed
-          # completely in a future release. Elastic will take a best effort approach
-          # to fix any issues, but experimental features are not subject to the
-          # support SLA of official GA features.
+          # This functionality is in Beta and is subject to change. The design and
+          # code is less mature than official GA features and is being provided
+          # as-is with no warranties. Beta features are not subject to the support
+          # SLA of official GA features.
           #
           # @option arguments [String] :id The ID of the data frame analytics to fetch
           # @option arguments [Boolean] :allow_no_match Whether to ignore if a wildcard expression matches no data frame analytics. (This includes `_all` string or when no data frame analytics have been specified)
           # @option arguments [Int] :from skips a number of analytics
           # @option arguments [Int] :size specifies a max number of analytics to get
+          # @option arguments [Boolean] :exclude_generated Omits fields that are illegal to set on data frame analytics PUT
           # @option arguments [Hash] :headers Custom HTTP headers
           #
           # @see https://www.elastic.co/guide/en/elasticsearch/reference/7.x/get-dfanalytics.html
@@ -59,7 +60,8 @@ module Elasticsearch
           ParamsRegistry.register(:get_data_frame_analytics, [
             :allow_no_match,
             :from,
-            :size
+            :size,
+            :exclude_generated
           ].freeze)
         end
       end

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/machine_learning/get_data_frame_analytics_stats.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/machine_learning/get_data_frame_analytics_stats.rb
@@ -21,10 +21,10 @@ module Elasticsearch
       module MachineLearning
         module Actions
           # Retrieves usage information for data frame analytics jobs.
-          # This functionality is Experimental and may be changed or removed
-          # completely in a future release. Elastic will take a best effort approach
-          # to fix any issues, but experimental features are not subject to the
-          # support SLA of official GA features.
+          # This functionality is in Beta and is subject to change. The design and
+          # code is less mature than official GA features and is being provided
+          # as-is with no warranties. Beta features are not subject to the support
+          # SLA of official GA features.
           #
           # @option arguments [String] :id The ID of the data frame analytics stats to fetch
           # @option arguments [Boolean] :allow_no_match Whether to ignore if a wildcard expression matches no data frame analytics. (This includes `_all` string or when no data frame analytics have been specified)

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/machine_learning/get_datafeeds.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/machine_learning/get_datafeeds.rb
@@ -25,6 +25,7 @@ module Elasticsearch
           # @option arguments [String] :datafeed_id The ID of the datafeeds to fetch
           # @option arguments [Boolean] :allow_no_match Whether to ignore if a wildcard expression matches no datafeeds. (This includes `_all` string or when no datafeeds have been specified)
           # @option arguments [Boolean] :allow_no_datafeeds Whether to ignore if a wildcard expression matches no datafeeds. (This includes `_all` string or when no datafeeds have been specified) *Deprecated*
+          # @option arguments [Boolean] :exclude_generated Omits fields that are illegal to set on datafeed PUT
           # @option arguments [Hash] :headers Custom HTTP headers
           #
           # @see https://www.elastic.co/guide/en/elasticsearch/reference/7.x/ml-get-datafeed.html
@@ -53,7 +54,8 @@ module Elasticsearch
           # @since 6.2.0
           ParamsRegistry.register(:get_datafeeds, [
             :allow_no_match,
-            :allow_no_datafeeds
+            :allow_no_datafeeds,
+            :exclude_generated
           ].freeze)
         end
       end

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/machine_learning/get_jobs.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/machine_learning/get_jobs.rb
@@ -25,6 +25,7 @@ module Elasticsearch
           # @option arguments [String] :job_id The ID of the jobs to fetch
           # @option arguments [Boolean] :allow_no_match Whether to ignore if a wildcard expression matches no jobs. (This includes `_all` string or when no jobs have been specified)
           # @option arguments [Boolean] :allow_no_jobs Whether to ignore if a wildcard expression matches no jobs. (This includes `_all` string or when no jobs have been specified) *Deprecated*
+          # @option arguments [Boolean] :exclude_generated Omits fields that are illegal to set on job PUT
           # @option arguments [Hash] :headers Custom HTTP headers
           #
           # @see https://www.elastic.co/guide/en/elasticsearch/reference/7.x/ml-get-job.html
@@ -53,7 +54,8 @@ module Elasticsearch
           # @since 6.2.0
           ParamsRegistry.register(:get_jobs, [
             :allow_no_match,
-            :allow_no_jobs
+            :allow_no_jobs,
+            :exclude_generated
           ].freeze)
         end
       end

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/machine_learning/get_trained_models.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/machine_learning/get_trained_models.rb
@@ -21,10 +21,10 @@ module Elasticsearch
       module MachineLearning
         module Actions
           # Retrieves configuration information for a trained inference model.
-          # This functionality is Experimental and may be changed or removed
-          # completely in a future release. Elastic will take a best effort approach
-          # to fix any issues, but experimental features are not subject to the
-          # support SLA of official GA features.
+          # This functionality is in Beta and is subject to change. The design and
+          # code is less mature than official GA features and is being provided
+          # as-is with no warranties. Beta features are not subject to the support
+          # SLA of official GA features.
           #
           # @option arguments [String] :model_id The ID of the trained models to fetch
           # @option arguments [Boolean] :allow_no_match Whether to ignore if a wildcard expression matches no trained models. (This includes `_all` string or when no trained models have been specified)
@@ -34,7 +34,7 @@ module Elasticsearch
           # @option arguments [Int] :from skips a number of trained models
           # @option arguments [Int] :size specifies a max number of trained models to get
           # @option arguments [List] :tags A comma-separated list of tags that the model must have.
-          # @option arguments [Boolean] :for_export Omits fields that are illegal to set on model PUT
+          # @option arguments [Boolean] :exclude_generated Omits fields that are illegal to set on model PUT
           # @option arguments [Hash] :headers Custom HTTP headers
           #
           # @see https://www.elastic.co/guide/en/elasticsearch/reference/7.x/get-trained-models.html
@@ -69,7 +69,7 @@ module Elasticsearch
             :from,
             :size,
             :tags,
-            :for_export
+            :exclude_generated
           ].freeze)
         end
       end

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/machine_learning/get_trained_models_stats.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/machine_learning/get_trained_models_stats.rb
@@ -21,10 +21,10 @@ module Elasticsearch
       module MachineLearning
         module Actions
           # Retrieves usage information for trained inference models.
-          # This functionality is Experimental and may be changed or removed
-          # completely in a future release. Elastic will take a best effort approach
-          # to fix any issues, but experimental features are not subject to the
-          # support SLA of official GA features.
+          # This functionality is in Beta and is subject to change. The design and
+          # code is less mature than official GA features and is being provided
+          # as-is with no warranties. Beta features are not subject to the support
+          # SLA of official GA features.
           #
           # @option arguments [String] :model_id The ID of the trained models stats to fetch
           # @option arguments [Boolean] :allow_no_match Whether to ignore if a wildcard expression matches no trained models. (This includes `_all` string or when no trained models have been specified)

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/machine_learning/put_data_frame_analytics.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/machine_learning/put_data_frame_analytics.rb
@@ -21,10 +21,10 @@ module Elasticsearch
       module MachineLearning
         module Actions
           # Instantiates a data frame analytics job.
-          # This functionality is Experimental and may be changed or removed
-          # completely in a future release. Elastic will take a best effort approach
-          # to fix any issues, but experimental features are not subject to the
-          # support SLA of official GA features.
+          # This functionality is in Beta and is subject to change. The design and
+          # code is less mature than official GA features and is being provided
+          # as-is with no warranties. Beta features are not subject to the support
+          # SLA of official GA features.
           #
           # @option arguments [String] :id The ID of the data frame analytics to create
           # @option arguments [Hash] :headers Custom HTTP headers

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/machine_learning/put_trained_model.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/machine_learning/put_trained_model.rb
@@ -21,10 +21,10 @@ module Elasticsearch
       module MachineLearning
         module Actions
           # Creates an inference trained model.
-          # This functionality is Experimental and may be changed or removed
-          # completely in a future release. Elastic will take a best effort approach
-          # to fix any issues, but experimental features are not subject to the
-          # support SLA of official GA features.
+          # This functionality is in Beta and is subject to change. The design and
+          # code is less mature than official GA features and is being provided
+          # as-is with no warranties. Beta features are not subject to the support
+          # SLA of official GA features.
           #
           # @option arguments [String] :model_id The ID of the trained models to store
           # @option arguments [Hash] :headers Custom HTTP headers

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/machine_learning/start_data_frame_analytics.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/machine_learning/start_data_frame_analytics.rb
@@ -21,10 +21,10 @@ module Elasticsearch
       module MachineLearning
         module Actions
           # Starts a data frame analytics job.
-          # This functionality is Experimental and may be changed or removed
-          # completely in a future release. Elastic will take a best effort approach
-          # to fix any issues, but experimental features are not subject to the
-          # support SLA of official GA features.
+          # This functionality is in Beta and is subject to change. The design and
+          # code is less mature than official GA features and is being provided
+          # as-is with no warranties. Beta features are not subject to the support
+          # SLA of official GA features.
           #
           # @option arguments [String] :id The ID of the data frame analytics to start
           # @option arguments [Time] :timeout Controls the time to wait until the task has started. Defaults to 20 seconds

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/machine_learning/stop_data_frame_analytics.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/machine_learning/stop_data_frame_analytics.rb
@@ -21,10 +21,10 @@ module Elasticsearch
       module MachineLearning
         module Actions
           # Stops one or more data frame analytics jobs.
-          # This functionality is Experimental and may be changed or removed
-          # completely in a future release. Elastic will take a best effort approach
-          # to fix any issues, but experimental features are not subject to the
-          # support SLA of official GA features.
+          # This functionality is in Beta and is subject to change. The design and
+          # code is less mature than official GA features and is being provided
+          # as-is with no warranties. Beta features are not subject to the support
+          # SLA of official GA features.
           #
           # @option arguments [String] :id The ID of the data frame analytics to stop
           # @option arguments [Boolean] :allow_no_match Whether to ignore if a wildcard expression matches no data frame analytics. (This includes `_all` string or when no data frame analytics have been specified)

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/machine_learning/update_data_frame_analytics.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/machine_learning/update_data_frame_analytics.rb
@@ -21,10 +21,10 @@ module Elasticsearch
       module MachineLearning
         module Actions
           # Updates certain properties of a data frame analytics job.
-          # This functionality is Experimental and may be changed or removed
-          # completely in a future release. Elastic will take a best effort approach
-          # to fix any issues, but experimental features are not subject to the
-          # support SLA of official GA features.
+          # This functionality is in Beta and is subject to change. The design and
+          # code is less mature than official GA features and is being provided
+          # as-is with no warranties. Beta features are not subject to the support
+          # SLA of official GA features.
           #
           # @option arguments [String] :id The ID of the data frame analytics to update
           # @option arguments [Hash] :headers Custom HTTP headers

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/transform/get_transform.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/transform/get_transform.rb
@@ -26,6 +26,7 @@ module Elasticsearch
           # @option arguments [Int] :from skips a number of transform configs, defaults to 0
           # @option arguments [Int] :size specifies a max number of transforms to get, defaults to 100
           # @option arguments [Boolean] :allow_no_match Whether to ignore if a wildcard expression matches no transforms. (This includes `_all` string or when no transforms have been specified)
+          # @option arguments [Boolean] :exclude_generated Omits fields that are illegal to set on transform PUT
           # @option arguments [Hash] :headers Custom HTTP headers
           #
           # @see https://www.elastic.co/guide/en/elasticsearch/reference/7.x/get-transform.html
@@ -55,7 +56,8 @@ module Elasticsearch
           ParamsRegistry.register(:get_transform, [
             :from,
             :size,
-            :allow_no_match
+            :allow_no_match,
+            :exclude_generated
           ].freeze)
         end
       end

--- a/elasticsearch-xpack/test/unit/autoscaling/delete_autoscaling_policy_test.rb
+++ b/elasticsearch-xpack/test/unit/autoscaling/delete_autoscaling_policy_test.rb
@@ -1,0 +1,46 @@
+# Licensed to Elasticsearch B.V. under one or more contributor
+# license agreements. See the NOTICE file distributed with
+# this work for additional information regarding copyright
+# ownership. Elasticsearch B.V. licenses this file to you under
+# the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+require 'test_helper'
+
+module Elasticsearch
+  module Test
+    class XPackAutoscalingDeleteAutoscalingPolicyTest < Minitest::Test
+      subject { FakeClient.new }
+
+      context 'XPack: Get Autoscaling Policy' do
+        should 'perform correct request' do
+          subject.expects(:perform_request).with do |method, url, params, body|
+            assert_equal('DELETE', method)
+            assert_equal('_autoscaling/policy/a_policy', url)
+            assert_equal({}, params)
+            assert_nil(body)
+            true
+          end.returns(FakeResponse.new)
+
+          subject.xpack.autoscaling.delete_autoscaling_policy(name: 'a_policy')
+        end
+
+        should 'raise argument error without name' do
+          assert_raises ArgumentError do
+            subject.xpack.autoscaling.delete_autoscaling_policy
+          end
+        end
+      end
+    end
+  end
+end

--- a/elasticsearch-xpack/test/unit/autoscaling/get_autoscaling_capacity_test.rb
+++ b/elasticsearch-xpack/test/unit/autoscaling/get_autoscaling_capacity_test.rb
@@ -1,0 +1,40 @@
+# Licensed to Elasticsearch B.V. under one or more contributor
+# license agreements. See the NOTICE file distributed with
+# this work for additional information regarding copyright
+# ownership. Elasticsearch B.V. licenses this file to you under
+# the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+require 'test_helper'
+
+module Elasticsearch
+  module Test
+    class XPackAutoscalingGetAutoscalingCapacityTest < Minitest::Test
+      subject { FakeClient.new }
+
+      context 'XPack: Get Autoscaling Capacity' do
+        should 'perform correct request' do
+          subject.expects(:perform_request).with do |method, url, params, body|
+            assert_equal('GET', method)
+            assert_equal('_autoscaling/capacity', url)
+            assert_equal({}, params)
+            assert_nil(body)
+            true
+          end.returns(FakeResponse.new)
+
+          subject.xpack.autoscaling.get_autoscaling_capacity
+        end
+      end
+    end
+  end
+end

--- a/elasticsearch-xpack/test/unit/autoscaling/get_autoscaling_decision_test.rb
+++ b/elasticsearch-xpack/test/unit/autoscaling/get_autoscaling_decision_test.rb
@@ -1,0 +1,40 @@
+# Licensed to Elasticsearch B.V. under one or more contributor
+# license agreements. See the NOTICE file distributed with
+# this work for additional information regarding copyright
+# ownership. Elasticsearch B.V. licenses this file to you under
+# the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+require 'test_helper'
+
+module Elasticsearch
+  module Test
+    class XPackAutoscalingGetAutoscalingDecisionTest < Minitest::Test
+      subject { FakeClient.new }
+
+      context 'XPack: Get Autoscaling Decision' do
+        should 'perform correct request' do
+          subject.expects(:perform_request).with do |method, url, params, body|
+            assert_equal('GET', method)
+            assert_equal('_autoscaling/decision', url)
+            assert_equal({}, params)
+            assert_nil(body)
+            true
+          end.returns(FakeResponse.new)
+
+          subject.xpack.autoscaling.get_autoscaling_decision
+        end
+      end
+    end
+  end
+end

--- a/elasticsearch-xpack/test/unit/autoscaling/get_autoscaling_policy_test.rb
+++ b/elasticsearch-xpack/test/unit/autoscaling/get_autoscaling_policy_test.rb
@@ -1,0 +1,46 @@
+# Licensed to Elasticsearch B.V. under one or more contributor
+# license agreements. See the NOTICE file distributed with
+# this work for additional information regarding copyright
+# ownership. Elasticsearch B.V. licenses this file to you under
+# the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+require 'test_helper'
+
+module Elasticsearch
+  module Test
+    class XPackAutoscalingGetAutoscalingPolicyTest < Minitest::Test
+      subject { FakeClient.new }
+
+      context 'XPack: Get Autoscaling Policy' do
+        should 'perform correct request' do
+          subject.expects(:perform_request).with do |method, url, params, body|
+            assert_equal('GET', method)
+            assert_equal('_autoscaling/policy/a_policy', url)
+            assert_equal({}, params)
+            assert_nil(body)
+            true
+          end.returns(FakeResponse.new)
+
+          subject.xpack.autoscaling.get_autoscaling_policy(name: 'a_policy')
+        end
+
+        should 'raise argument error without name' do
+          assert_raises ArgumentError do
+            subject.xpack.autoscaling.get_autoscaling_policy
+          end
+        end
+      end
+    end
+  end
+end

--- a/elasticsearch-xpack/test/unit/autoscaling/put_autoscaling_policy_test.rb
+++ b/elasticsearch-xpack/test/unit/autoscaling/put_autoscaling_policy_test.rb
@@ -1,0 +1,52 @@
+# Licensed to Elasticsearch B.V. under one or more contributor
+# license agreements. See the NOTICE file distributed with
+# this work for additional information regarding copyright
+# ownership. Elasticsearch B.V. licenses this file to you under
+# the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+require 'test_helper'
+
+module Elasticsearch
+  module Test
+    class XPackAutoscalingPutAutoscalingPolicyTest < Minitest::Test
+      subject { FakeClient.new }
+
+      context 'XPack: Put Autoscaling Policy' do
+        should 'perform correct request' do
+          subject.expects(:perform_request).with do |method, url, params, body|
+            assert_equal('PUT', method)
+            assert_equal('_autoscaling/policy/a_policy', url)
+            assert_equal({}, params)
+            assert_equal(body, {})
+            true
+          end.returns(FakeResponse.new)
+
+          subject.xpack.autoscaling.put_autoscaling_policy(name: 'a_policy', body: {})
+        end
+
+        should 'raise argument error without name' do
+          assert_raises ArgumentError do
+            subject.xpack.autoscaling.put_autoscaling_policy(body: {})
+          end
+        end
+
+        should 'raise argument error without body' do
+          assert_raises ArgumentError do
+            subject.xpack.autoscaling.put_autoscaling_policy(name: 'a_policy')
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
- Adds `exclude_generated` parameter to some X-Pack endpoints.
- Adds `autoscaling.get_autoscaling_capacity` and unit tests. 