### PR TITLE
Changed the key of the parameter of Reindex from `target` to `dest`

### DIFF
--- a/elasticsearch-extensions/README.md
+++ b/elasticsearch-extensions/README.md
@@ -74,7 +74,7 @@ a `reindex` method is added to the client:
     client.index index: 'test', type: 'd', body: { title: 'foo' }
 
     client.reindex source: { index: 'test' },
-                   target: { index: 'test', client: target_client },
+                   dest: { index: 'test', client: target_client },
                    transform: lambda { |doc| doc['_source']['title'].upcase! },
                    refresh: true
     # => { errors: 0 }
@@ -95,7 +95,7 @@ You can also use the `Reindex` class directly:
 
     reindex = Elasticsearch::Extensions::Reindex.new \
                 source: { index: 'test', client: client },
-                target: { index: 'test-copy' }
+                dest: { index: 'test-copy' }
 
     reindex.perform
 

--- a/elasticsearch-extensions/test/reindex/integration/reindex_test.rb
+++ b/elasticsearch-extensions/test/reindex/integration/reindex_test.rb
@@ -54,7 +54,7 @@ class Elasticsearch::Extensions::ReindexIntegrationTest < Elasticsearch::Test::I
     should "copy documents from one index to another" do
       reindex = Elasticsearch::Extensions::Reindex.new \
                   source: { index: 'test1', client: @client },
-                  target: { index: 'test2' },
+                  dest: { index: 'test2' },
                   batch_size: 2,
                   refresh: true
 
@@ -67,7 +67,7 @@ class Elasticsearch::Extensions::ReindexIntegrationTest < Elasticsearch::Test::I
     should "transform documents with a lambda" do
       reindex = Elasticsearch::Extensions::Reindex.new \
                   source: { index: 'test1', client: @client },
-                  target: { index: 'test2' },
+                  dest: { index: 'test2' },
                   transform: lambda { |d| d['_source']['category'].upcase! },
                   refresh: true
 
@@ -84,7 +84,7 @@ class Elasticsearch::Extensions::ReindexIntegrationTest < Elasticsearch::Test::I
 
       reindex = Elasticsearch::Extensions::Reindex.new \
                   source: { index: 'test1', client: @client },
-                  target: { index: 'test3' }
+                  dest: { index: 'test3' }
 
       result = reindex.perform
 
@@ -97,7 +97,7 @@ class Elasticsearch::Extensions::ReindexIntegrationTest < Elasticsearch::Test::I
     should "reindex via the API integration" do
       @client.indices.create index: 'test4'
 
-      @client.reindex source: { index: 'test1' }, target: { index: 'test4' }
+      @client.reindex source: { index: 'test1' }, dest: { index: 'test4' }
       @client.indices.refresh index: 'test4'
 
       assert_equal 3, @client.search(index: 'test4')['hits']['total']['value']

--- a/elasticsearch-extensions/test/reindex/unit/reindex_test.rb
+++ b/elasticsearch-extensions/test/reindex/unit/reindex_test.rb
@@ -20,7 +20,7 @@ require 'elasticsearch/extensions/reindex'
 
 class Elasticsearch::Extensions::ReindexTest < Elasticsearch::Test::UnitTestCase
   context "The Reindex extension module" do
-    DEFAULT_OPTIONS = { source: { index: 'foo', client: Object.new }, target: { index: 'bar' } }
+    DEFAULT_OPTIONS = { source: { index: 'foo', client: Object.new }, dest: { index: 'bar' } }
 
     should "require options" do
       assert_raise ArgumentError do
@@ -67,7 +67,7 @@ class Elasticsearch::Extensions::ReindexTest < Elasticsearch::Test::UnitTestCase
       should "scroll through the index and save batches in bulk" do
         client  = mock()
         subject = Elasticsearch::Extensions::Reindex.new source: { index: 'foo', client: client },
-                                                         target: { index: 'bar' }
+                                                         dest: { index: 'bar' }
 
         client.expects(:search)
           .returns({ '_scroll_id' => 'scroll_id_1' }.merge(Marshal.load(Marshal.dump(@default_response))))
@@ -87,7 +87,7 @@ class Elasticsearch::Extensions::ReindexTest < Elasticsearch::Test::UnitTestCase
       should "return the number of errors" do
         client  = mock()
         subject = Elasticsearch::Extensions::Reindex.new source: { index: 'foo', client: client },
-                                                         target: { index: 'bar' }
+                                                         dest: { index: 'bar' }
 
         client.expects(:search).returns({ '_scroll_id' => 'scroll_id_1' }.merge(@default_response))
         client.expects(:scroll).returns(@empty_response)
@@ -102,7 +102,7 @@ class Elasticsearch::Extensions::ReindexTest < Elasticsearch::Test::UnitTestCase
         client  = mock()
         subject = Elasticsearch::Extensions::Reindex.new \
           source: { index: 'foo', client: client },
-          target: { index: 'bar' },
+          dest: { index: 'bar' },
           transform: lambda { |d| d['_source']['foo'].upcase!; d }
 
         client.expects(:search).returns({ '_scroll_id' => 'scroll_id_1' }.merge(@default_response))


### PR DESCRIPTION
I fixed the issue where parameter's key for ReindexAPI is actually Dest, though it is written as Target in your documentation. Now it works properly with Dest. 

[ReindexAPI](https://www.elastic.co/guide/en/elasticsearch/reference/7.9/docs-reindex.html)