### PR TITLE
Rewrite X-Pack test cleanup

### DIFF
--- a/api-spec-testing/test_file.rb
+++ b/api-spec-testing/test_file.rb
@@ -130,7 +130,8 @@ module Elasticsearch
             raise e if count > 9
 
             redo
-          rescue Elasticsearch::Transport::Transport::Errors::BadRequest => e
+          rescue Elasticsearch::Transport::Transport::Errors::BadRequest,
+                 Elasticsearch::Transport::Transport::Errors::Conflict => e
             error = JSON.parse(e.message.gsub(/\[[0-9]{3}\] /, ''))['error']['root_cause'].first
             count += 1
 
@@ -139,6 +140,7 @@ module Elasticsearch
             client.indices.delete(index: error['index']) if error['reason'] =~ /index \[.+\] already exists/
             raise e if count > 9
 
+            sleep(1)
             redo
           end
         end

--- a/api-spec-testing/test_file.rb
+++ b/api-spec-testing/test_file.rb
@@ -39,6 +39,7 @@ module Elasticsearch
       #   TestFile.new(file_name)
       #
       # @param [ String ] file_name The name of the test file.
+      # @param [ Client] An instance of the client
       # @param [ Array<Symbol> ] skip_features The names of features to skip.
       #
       # @since 6.1.0
@@ -105,14 +106,14 @@ module Elasticsearch
       # Run the setup tasks defined for a single test file.
       #
       # @example Run the setup tasks.
-      #   test_file.setup(client)
+      #   test_file.setup
       #
       # @param [ Elasticsearch::Client ] client The client to use to perform the setup tasks.
       #
       # @return [ self ]
       #
       # @since 6.2.0
-      def setup(client)
+      def setup
         return unless @setup
 
         actions = @setup['setup'].select { |action| action['do'] }.map { |action| Action.new(action['do']) }
@@ -147,14 +148,14 @@ module Elasticsearch
       # Run the teardown tasks defined for a single test file.
       #
       # @example Run the teardown tasks.
-      #   test_file.teardown(client)
+      #   test_file.teardown
       #
       # @param [ Elasticsearch::Client ] client The client to use to perform the teardown tasks.
       #
       # @return [ self ]
       #
       # @since 6.2.0
-      def teardown(client)
+      def teardown
         return unless @teardown
 
         actions = @teardown['teardown'].select { |action| action['do'] }.map { |action| Action.new(action['do']) }

--- a/api-spec-testing/test_file.rb
+++ b/api-spec-testing/test_file.rb
@@ -70,9 +70,9 @@ module Elasticsearch
         return true if skip_definition['version'] == 'all'
 
         range_partition = /\s*-\s*/
-        return unless (versions = skip_definition['version']) && skip_definition['version'].partition(range_partition)
+        return unless (versions = skip_definition['version'])
 
-        low, high = __parse_versions(versions)
+        low, high = __parse_versions(versions.partition(range_partition))
         range = low..high
         begin
           server_version = client.info['version']['number']

--- a/api-spec-testing/test_file.rb
+++ b/api-spec-testing/test_file.rb
@@ -21,16 +21,17 @@ require_relative 'test_file/task_group'
 require 'logger'
 
 module Elasticsearch
-
   module RestAPIYAMLTests
+    # Custom exception to raise when a test file needs to be skipped. This is
+    # captured as soon as possible so the test runners can move on to the next test.
+    class SkipTestsException < StandardError
+    end
 
     # Class representing a single test file, containing a setup, teardown, and multiple tests.
     #
     # @since 6.2.0
     class TestFile
-
-      attr_reader :features_to_skip
-      attr_reader :name
+      attr_reader :features_to_skip, :name, :client
 
       # Initialize a single test file.
       #
@@ -41,8 +42,9 @@ module Elasticsearch
       # @param [ Array<Symbol> ] skip_features The names of features to skip.
       #
       # @since 6.1.0
-      def initialize(file_name, features_to_skip = [])
+      def initialize(file_name, client, features_to_skip = [])
         @name = file_name
+        @client = client
         begin
           documents = YAML.load_stream(File.new(file_name))
         rescue StandardError => e
@@ -52,8 +54,38 @@ module Elasticsearch
         end
         @test_definitions = documents.reject { |doc| doc['setup'] || doc['teardown'] }
         @setup = documents.find { |doc| doc['setup'] }
+        skip_entire_test_file? if @setup
         @teardown = documents.find { |doc| doc['teardown'] }
         @features_to_skip = REST_API_YAML_SKIP_FEATURES + features_to_skip
+      end
+
+      def skip_entire_test_file?
+        @skip = @setup['setup']&.select { |a| a['skip'] }
+        return false if @skip.empty?
+
+        raise SkipTestsException if skip_version?(@client, @skip.first['skip'])
+      end
+
+      def skip_version?(client, skip_definition)
+        return true if skip_definition['version'] == 'all'
+
+        range_partition = /\s*-\s*/
+        return unless (versions = skip_definition['version']) && skip_definition['version'].partition(range_partition)
+
+        low, high = __parse_versions(versions)
+        range = low..high
+        begin
+          server_version = client.info['version']['number']
+        rescue
+          warn('Could not determine Elasticsearch version when checking if test should be skipped.')
+        end
+        range.cover?(server_version)
+      end
+
+      def __parse_versions(versions)
+        low = (['', nil].include? versions[0]) ? '0' : versions[0]
+        high = (['', nil].include? versions[2]) ? '9999' : versions[2]
+        [low, high]
       end
 
       # Get a list of tests in the test file.

--- a/api-spec-testing/test_file/action.rb
+++ b/api-spec-testing/test_file/action.rb
@@ -56,6 +56,9 @@ module Elasticsearch
         @definition.each.inject(client) do |client, (method_chain, args)|
           chain = method_chain.split('.')
 
+          # If we have a method nested in a namespace, client becomes the
+          # client/namespace. Eg for `indices.resolve_index`, `client =
+          # client.indices` and then we call `resolve_index` on `client`.
           if chain.size > 1
             client = chain[0...-1].inject(client) do |_client, _method|
               _client.send(_method)

--- a/api-spec-testing/test_file/test.rb
+++ b/api-spec-testing/test_file/test.rb
@@ -219,8 +219,8 @@ module Elasticsearch
           return true if pre_defined_skip?
 
           if @skip
-            @skip.collect { |s| s['skip'] }.any? do |skip|
-              contains_features_to_skip?(features_to_skip, skip) || test_file.skip_version?(client, skip)
+            @skip.collect { |s| s['skip'] }.any? do |skip_definition|
+              contains_features_to_skip?(features_to_skip, skip_definition) || test_file.skip_version?(client, skip_definition)
             end
           end
         end
@@ -244,8 +244,8 @@ module Elasticsearch
 
         private
 
-        def contains_features_to_skip?(features_to_skip, skip_defintion)
-          !(features_to_skip &  ([skip_defintion['features']].flatten || [])).empty?
+        def contains_features_to_skip?(features_to_skip, skip_definition)
+          !(features_to_skip &  ([skip_definition['features']].flatten || [])).empty?
         end
 
         def pre_defined_skip?

--- a/elasticsearch-api/lib/elasticsearch/api/actions/snapshot/clone.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/snapshot/clone.rb
@@ -1,0 +1,66 @@
+# Licensed to Elasticsearch B.V. under one or more contributor
+# license agreements. See the NOTICE file distributed with
+# this work for additional information regarding copyright
+# ownership. Elasticsearch B.V. licenses this file to you under
+# the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+module Elasticsearch
+  module API
+    module Snapshot
+      module Actions
+        # Clones indices from one snapshot into another snapshot in the same repository.
+        #
+        # @option arguments [String] :repository A repository name
+        # @option arguments [String] :snapshot The name of the snapshot to clone from
+        # @option arguments [String] :target_snapshot The name of the cloned snapshot to create
+        # @option arguments [Time] :master_timeout Explicit operation timeout for connection to master node
+        # @option arguments [Hash] :headers Custom HTTP headers
+        # @option arguments [Hash] :body The snapshot clone definition (*Required*)
+        #
+        # @see https://www.elastic.co/guide/en/elasticsearch/reference/7.x/modules-snapshots.html
+        #
+        def clone(arguments = {})
+          raise ArgumentError, "Required argument 'body' missing" unless arguments[:body]
+          raise ArgumentError, "Required argument 'repository' missing" unless arguments[:repository]
+          raise ArgumentError, "Required argument 'snapshot' missing" unless arguments[:snapshot]
+          raise ArgumentError, "Required argument 'target_snapshot' missing" unless arguments[:target_snapshot]
+
+          headers = arguments.delete(:headers) || {}
+
+          arguments = arguments.clone
+
+          _repository = arguments.delete(:repository)
+
+          _snapshot = arguments.delete(:snapshot)
+
+          _target_snapshot = arguments.delete(:target_snapshot)
+
+          method = Elasticsearch::API::HTTP_PUT
+          path   = "_snapshot/#{Utils.__listify(_repository)}/#{Utils.__listify(_snapshot)}/_clone/#{Utils.__listify(_target_snapshot)}"
+          params = Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
+
+          body = arguments[:body]
+          perform_request(method, path, params, body, headers).body
+        end
+
+        # Register this action with its valid params when the module is loaded.
+        #
+        # @since 6.2.0
+        ParamsRegistry.register(:clone, [
+          :master_timeout
+        ].freeze)
+      end
+    end
+  end
+end

--- a/elasticsearch-api/spec/elasticsearch/api/actions/snapshot/clone_spec.rb
+++ b/elasticsearch-api/spec/elasticsearch/api/actions/snapshot/clone_spec.rb
@@ -1,0 +1,67 @@
+# Licensed to Elasticsearch B.V. under one or more contributor
+# license agreements. See the NOTICE file distributed with
+# this work for additional information regarding copyright
+# ownership. Elasticsearch B.V. licenses this file to you under
+# the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+require 'spec_helper'
+
+describe 'client.snapshot#clone' do
+  let(:expected_args) do
+    [
+        'PUT',
+        '_snapshot/foo/bar/_clone/snapshot',
+        {},
+        {},
+        {}
+    ]
+  end
+
+  let(:client) do
+    Class.new { include Elasticsearch::API }.new
+  end
+
+  it 'requires the :body argument' do
+    expect {
+      client.snapshot.clone(snapshot: 'bar')
+    }.to raise_exception(ArgumentError)
+  end
+
+  it 'requires the :repository argument' do
+    expect {
+      client.snapshot.clone(snapshot: 'foo', body: {})
+    }.to raise_exception(ArgumentError)
+  end
+
+  it 'requires the :snapshot argument' do
+    expect {
+      client.snapshot.clone(repository: 'foo', body: {})
+    }.to raise_exception(ArgumentError)
+  end
+
+  it 'requires the :target_snapshot argument' do
+    expect {
+      client.snapshot.clone(repository: 'foo', body: {}, snapshot: 'bar')
+    }.to raise_exception(ArgumentError)
+  end
+
+  it 'performs the request' do
+    expect(client_double.snapshot.clone(
+             repository: 'foo',
+             snapshot: 'bar',
+             body: {},
+             target_snapshot: 'snapshot'
+           )).to eq({})
+  end
+end

--- a/elasticsearch-api/spec/elasticsearch/api/rest_api_yaml_spec.rb
+++ b/elasticsearch-api/spec/elasticsearch/api/rest_api_yaml_spec.rb
@@ -18,7 +18,6 @@ describe 'Rest API YAML tests' do
 
     context "#{file.gsub("#{YAML_FILES_DIRECTORY}/", '')}" do
       test_file.tests.each do |test|
-
         context "#{test.description}" do
           if test.skip_test?(ADMIN_CLIENT)
             skip 'Test contains feature(s) not yet supported or version is not satisfied'
@@ -29,13 +28,13 @@ describe 'Rest API YAML tests' do
 
             # Runs once before each test in a test file
             before(:all) do
-              Elasticsearch::RestAPIYAMLTests::TestFile.clear_data(ADMIN_CLIENT)
+              Elasticsearch::RestAPIYAMLTests::TestFile.wipe_cluster(ADMIN_CLIENT)
               test_file.setup(ADMIN_CLIENT)
             end
 
             after(:all) do
               test_file.teardown(ADMIN_CLIENT)
-              Elasticsearch::RestAPIYAMLTests::TestFile.clear_data(ADMIN_CLIENT)
+              Elasticsearch::RestAPIYAMLTests::TestFile.wipe_cluster(ADMIN_CLIENT)
             end
 
             test.task_groups.each do |task_group|

--- a/elasticsearch-api/spec/elasticsearch/api/rest_api_yaml_spec.rb
+++ b/elasticsearch-api/spec/elasticsearch/api/rest_api_yaml_spec.rb
@@ -9,7 +9,7 @@ describe 'Rest API YAML tests' do
   # Traverse YAML files and create TestFile object:
   REST_API_YAML_FILES.each do |file|
     begin
-      test_file = Elasticsearch::RestAPIYAMLTests::TestFile.new(file, REST_API_YAML_SKIP_FEATURES)
+      test_file = Elasticsearch::RestAPIYAMLTests::TestFile.new(file, ADMIN_CLIENT, REST_API_YAML_SKIP_FEATURES)
     rescue SkipTestsException => _e
       # If the test file has a `skip` at the top level that applies to this
       # version of Elasticsearch, continue with the next text.
@@ -29,11 +29,11 @@ describe 'Rest API YAML tests' do
             # Runs once before each test in a test file
             before(:all) do
               Elasticsearch::RestAPIYAMLTests::TestFile.wipe_cluster(ADMIN_CLIENT)
-              test_file.setup(ADMIN_CLIENT)
+              test_file.setup
             end
 
             after(:all) do
-              test_file.teardown(ADMIN_CLIENT)
+              test_file.teardown
               Elasticsearch::RestAPIYAMLTests::TestFile.wipe_cluster(ADMIN_CLIENT)
             end
 

--- a/elasticsearch-api/spec/elasticsearch/api/rest_api_yaml_spec.rb
+++ b/elasticsearch-api/spec/elasticsearch/api/rest_api_yaml_spec.rb
@@ -8,7 +8,13 @@ require 'rest_yaml_tests_helper'
 describe 'Rest API YAML tests' do
   # Traverse YAML files and create TestFile object:
   REST_API_YAML_FILES.each do |file|
-    test_file = Elasticsearch::RestAPIYAMLTests::TestFile.new(file, REST_API_YAML_SKIP_FEATURES)
+    begin
+      test_file = Elasticsearch::RestAPIYAMLTests::TestFile.new(file, REST_API_YAML_SKIP_FEATURES)
+    rescue SkipTestsException => _e
+      # If the test file has a `skip` at the top level that applies to this
+      # version of Elasticsearch, continue with the next text.
+      next
+    end
 
     context "#{file.gsub("#{YAML_FILES_DIRECTORY}/", '')}" do
       test_file.tests.each do |test|

--- a/elasticsearch-api/spec/rest_yaml_tests_helper.rb
+++ b/elasticsearch-api/spec/rest_yaml_tests_helper.rb
@@ -94,10 +94,6 @@ skipped_tests << { file:        'delete/70_mix_typeless_typeful.yml',
 skipped_tests << { file:        'cat.templates/10_basic.yml',
                    description: '*' }
 
-# node_selector is not supported yet
-skipped_tests << { file: 'cat.aliases/10_basic.yml',
-                   description: '*' }
-
 # Responses are there but not equal (eg.: yellow status)
 skipped_tests << { file: 'cluster.health/10_basic.yml',
                    description: 'cluster health with closed index (pre 7.2.0)' }
@@ -112,4 +108,4 @@ SKIPPED_TESTS = skipped_tests
 REST_API_YAML_FILES = SINGLE_TEST || Dir.glob("#{YAML_FILES_DIRECTORY}/**/*.yml")
 
 # The features to skip
-REST_API_YAML_SKIP_FEATURES = ['warnings'].freeze
+REST_API_YAML_SKIP_FEATURES = ['warnings', 'node_selector'].freeze

--- a/elasticsearch-xpack/lib/elasticsearch/xpack.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 
-require "elasticsearch/api"
-require "elasticsearch/xpack/version"
-require "elasticsearch/xpack/api/actions/params_registry"
+require 'elasticsearch/api'
+require 'elasticsearch/xpack/version'
+require 'elasticsearch/xpack/api/actions/params_registry'
 
 Dir[ File.expand_path('../xpack/api/actions/**/params_registry.rb', __FILE__) ].each   { |f| require f }
 Dir[ File.expand_path('../xpack/api/actions/**/*.rb', __FILE__) ].each   { |f| require f }
@@ -131,6 +131,14 @@ module Elasticsearch
 
       def snapshot_lifecycle_management
         @snapshot_lifecycle_management ||= xpack.snapshot_lifecycle_management
+      end
+
+      def open_point_in_time(arguments = {})
+        xpack.open_point_in_time(arguments)
+      end
+
+      def close_point_in_time(arguments = {})
+        xpack.close_point_in_time(arguments)
       end
     end
   end

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/async_search/status.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/async_search/status.rb
@@ -1,0 +1,50 @@
+# Licensed to Elasticsearch B.V. under one or more contributor
+# license agreements. See the NOTICE file distributed with
+# this work for additional information regarding copyright
+# ownership. Elasticsearch B.V. licenses this file to you under
+# the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+module Elasticsearch
+  module XPack
+    module API
+      module AsyncSearch
+        module Actions
+          # Retrieves the status of a previously submitted async search request given its ID.
+          #
+          # @option arguments [String] :id The async search ID
+          # @option arguments [Hash] :headers Custom HTTP headers
+          #
+          # @see https://www.elastic.co/guide/en/elasticsearch/reference/7.x/async-search.html
+          #
+          def status(arguments = {})
+            raise ArgumentError, "Required argument 'id' missing" unless arguments[:id]
+
+            headers = arguments.delete(:headers) || {}
+
+            arguments = arguments.clone
+
+            _id = arguments.delete(:id)
+
+            method = Elasticsearch::API::HTTP_GET
+            path   = "_async_search/status/#{Elasticsearch::API::Utils.__listify(_id)}"
+            params = {}
+
+            body = nil
+            perform_request(method, path, params, body, headers).body
+          end
+        end
+      end
+    end
+  end
+end

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/indices/delete_data_stream.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/indices/delete_data_stream.rb
@@ -23,6 +23,7 @@ module Elasticsearch
           # Deletes a data stream.
           #
           # @option arguments [List] :name A comma-separated list of data streams to delete; use `*` to delete all data streams
+          # @option arguments [String] :expand_wildcards Whether wildcard expressions should get expanded to open or closed indices (default: open) (options: open, closed, hidden, none, all)
           # @option arguments [Hash] :headers Custom HTTP headers
           #
           # @see https://www.elastic.co/guide/en/elasticsearch/reference/7.x/data-streams.html
@@ -38,11 +39,18 @@ module Elasticsearch
 
             method = Elasticsearch::API::HTTP_DELETE
             path   = "_data_stream/#{Elasticsearch::API::Utils.__listify(_name)}"
-            params = {}
+            params = Elasticsearch::API::Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
 
             body = nil
             perform_request(method, path, params, body, headers).body
           end
+
+          # Register this action with its valid params when the module is loaded.
+          #
+          # @since 6.2.0
+          ParamsRegistry.register(:delete_data_stream, [
+            :expand_wildcards
+          ].freeze)
         end
       end
     end

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/indices/get_data_stream.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/indices/get_data_stream.rb
@@ -23,6 +23,7 @@ module Elasticsearch
           # Returns data streams.
           #
           # @option arguments [List] :name A comma-separated list of data streams to get; use `*` to get all data streams
+          # @option arguments [String] :expand_wildcards Whether wildcard expressions should get expanded to open or closed indices (default: open) (options: open, closed, hidden, none, all)
           # @option arguments [Hash] :headers Custom HTTP headers
           #
           # @see https://www.elastic.co/guide/en/elasticsearch/reference/7.x/data-streams.html
@@ -40,11 +41,18 @@ module Elasticsearch
                      else
                        "_data_stream"
                      end
-            params = {}
+            params = Elasticsearch::API::Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
 
             body = nil
             perform_request(method, path, params, body, headers).body
           end
+
+          # Register this action with its valid params when the module is loaded.
+          #
+          # @since 6.2.0
+          ParamsRegistry.register(:get_data_stream, [
+            :expand_wildcards
+          ].freeze)
         end
       end
     end

--- a/elasticsearch-xpack/spec/rest_yaml_tests_helper.rb
+++ b/elasticsearch-xpack/spec/rest_yaml_tests_helper.rb
@@ -188,4 +188,4 @@ SKIPPED_TESTS << { file: 'ml/jobs_crud.yml',
 REST_API_YAML_FILES = SINGLE_TEST || Dir.glob("#{YAML_FILES_DIRECTORY}/**/*.yml")
 
 # The features to skip
-REST_API_YAML_SKIP_FEATURES = ['warnings'].freeze
+REST_API_YAML_SKIP_FEATURES = ['warnings', 'node_selector'].freeze

--- a/elasticsearch-xpack/spec/rest_yaml_tests_helper.rb
+++ b/elasticsearch-xpack/spec/rest_yaml_tests_helper.rb
@@ -184,6 +184,11 @@ SKIPPED_TESTS << { file: 'analytics/usage.yml',
 SKIPPED_TESTS << { file: 'ml/jobs_crud.yml',
                    description: 'Test put job with model_memory_limit as string and lazy open' }
 
+SKIPPED_TESTS << { file: 'ml/inference_crud.yml',
+                   description: 'Test delete given unused trained model' }
+SKIPPED_TESTS << { file: 'ml/filter_crud.yml',
+                   description: '*' }
+
 # The directory of rest api YAML files.
 REST_API_YAML_FILES = SINGLE_TEST || Dir.glob("#{YAML_FILES_DIRECTORY}/**/*.yml")
 

--- a/elasticsearch-xpack/spec/xpack/rest_api_yaml_spec.rb
+++ b/elasticsearch-xpack/spec/xpack/rest_api_yaml_spec.rb
@@ -20,7 +20,13 @@ require 'rest_yaml_tests_helper'
 
 describe 'XPack Rest API YAML tests' do
   REST_API_YAML_FILES.each do |file|
-    test_file = Elasticsearch::RestAPIYAMLTests::TestFile.new(file, REST_API_YAML_SKIP_FEATURES)
+    begin
+      test_file = Elasticsearch::RestAPIYAMLTests::TestFile.new(file, DEFAULT_CLIENT, REST_API_YAML_SKIP_FEATURES)
+    rescue SkipTestsException => _e
+      # If the test file has a `skip` at the top level that applies to this
+      # version of Elasticsearch, continue with the next text.
+      next
+    end
 
     context "#{file.gsub("#{YAML_FILES_DIRECTORY}/", '')}" do
       before(:all) do

--- a/elasticsearch-xpack/spec/xpack/rest_api_yaml_spec.rb
+++ b/elasticsearch-xpack/spec/xpack/rest_api_yaml_spec.rb
@@ -31,7 +31,7 @@ describe 'XPack Rest API YAML tests' do
     context "#{file.gsub("#{YAML_FILES_DIRECTORY}/", '')}" do
       before(:all) do
         # Runs once before all tests in a test file
-        Elasticsearch::RestAPIYAMLTests::TestFile.clear_data_xpack(ADMIN_CLIENT)
+        Elasticsearch::RestAPIYAMLTests::TestFile.wipe_cluster(ADMIN_CLIENT)
       end
 
       test_file.tests.each do |test|
@@ -51,18 +51,10 @@ describe 'XPack Rest API YAML tests' do
                 ADMIN_CLIENT.xpack.watcher.delete_watch(id: "my_watch")
               rescue Elasticsearch::Transport::Transport::Errors::NotFound
               end
-
               # todo: remove these two lines when Dimitris' PR is merged
               ADMIN_CLIENT.cluster.put_settings(body: { transient: { "xpack.ml.max_model_memory_limit" => nil } })
               ADMIN_CLIENT.cluster.put_settings(body: { persistent: { "xpack.ml.max_model_memory_limit" => nil } })
-              Elasticsearch::RestAPIYAMLTests::TestFile.send(:clear_datafeeds, ADMIN_CLIENT)
-              Elasticsearch::RestAPIYAMLTests::TestFile.send(:clear_ml_jobs, ADMIN_CLIENT)
-              Elasticsearch::RestAPIYAMLTests::TestFile.send(:clear_tasks, ADMIN_CLIENT)
-              Elasticsearch::RestAPIYAMLTests::TestFile.send(:clear_rollup_jobs, ADMIN_CLIENT)
-              Elasticsearch::RestAPIYAMLTests::TestFile.send(:clear_machine_learning_indices, ADMIN_CLIENT)
-              Elasticsearch::RestAPIYAMLTests::TestFile.send(:clear_indices, ADMIN_CLIENT)
-              Elasticsearch::RestAPIYAMLTests::TestFile.send(:clear_transforms, ADMIN_CLIENT)
-              Elasticsearch::RestAPIYAMLTests::TestFile.send(:clear_index_templates, ADMIN_CLIENT)
+              Elasticsearch::RestAPIYAMLTests::TestFile.wipe_cluster(ADMIN_CLIENT)
               test_file.setup(ADMIN_CLIENT)
             end
 

--- a/elasticsearch-xpack/spec/xpack/rest_api_yaml_spec.rb
+++ b/elasticsearch-xpack/spec/xpack/rest_api_yaml_spec.rb
@@ -21,7 +21,7 @@ require 'rest_yaml_tests_helper'
 describe 'XPack Rest API YAML tests' do
   REST_API_YAML_FILES.each do |file|
     begin
-      test_file = Elasticsearch::RestAPIYAMLTests::TestFile.new(file, DEFAULT_CLIENT, REST_API_YAML_SKIP_FEATURES)
+      test_file = Elasticsearch::RestAPIYAMLTests::TestFile.new(file, ADMIN_CLIENT, REST_API_YAML_SKIP_FEATURES)
     rescue SkipTestsException => _e
       # If the test file has a `skip` at the top level that applies to this
       # version of Elasticsearch, continue with the next text.
@@ -55,11 +55,11 @@ describe 'XPack Rest API YAML tests' do
               ADMIN_CLIENT.cluster.put_settings(body: { transient: { "xpack.ml.max_model_memory_limit" => nil } })
               ADMIN_CLIENT.cluster.put_settings(body: { persistent: { "xpack.ml.max_model_memory_limit" => nil } })
               Elasticsearch::RestAPIYAMLTests::TestFile.wipe_cluster(ADMIN_CLIENT)
-              test_file.setup(ADMIN_CLIENT)
+              test_file.setup
             end
 
             after(:all) do
-              test_file.teardown(ADMIN_CLIENT)
+              test_file.teardown
             end
 
             test.task_groups.each do |task_group|

--- a/elasticsearch-xpack/test/unit/async_search/delete_test.rb
+++ b/elasticsearch-xpack/test/unit/async_search/delete_test.rb
@@ -1,0 +1,39 @@
+# Licensed to Elasticsearch B.V. under one or more contributor
+# license agreements. See the NOTICE file distributed with
+# this work for additional information regarding copyright
+# ownership. Elasticsearch B.V. licenses this file to you under
+# the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+require 'test_helper'
+
+module Elasticsearch
+  module Test
+    class XPackAsyncSearchDelete < Minitest::Test
+      subject { FakeClient.new }
+
+      context 'XPack: Async Search Delete' do
+        should 'perform correct request' do
+          subject.expects(:perform_request).with do |method, url, params, body|
+            assert_equal('DELETE', method)
+            assert_equal('_async_search/foo', url)
+            assert_equal({}, params)
+            assert_nil(body)
+          end.returns(FakeResponse.new)
+
+          subject.xpack.async_search.delete(id: 'foo')
+        end
+      end
+    end
+  end
+end

--- a/elasticsearch-xpack/test/unit/async_search/get_test.rb
+++ b/elasticsearch-xpack/test/unit/async_search/get_test.rb
@@ -1,0 +1,39 @@
+# Licensed to Elasticsearch B.V. under one or more contributor
+# license agreements. See the NOTICE file distributed with
+# this work for additional information regarding copyright
+# ownership. Elasticsearch B.V. licenses this file to you under
+# the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+require 'test_helper'
+
+module Elasticsearch
+  module Test
+    class XPackAsyncSearchGet < Minitest::Test
+      subject { FakeClient.new }
+
+      context 'XPack: Async Search Get' do
+        should 'perform correct request' do
+          subject.expects(:perform_request).with do |method, url, params, body|
+            assert_equal('GET', method)
+            assert_equal('_async_search/foo', url)
+            assert_equal({}, params)
+            assert_nil(body)
+          end.returns(FakeResponse.new)
+
+          subject.xpack.async_search.get(id: 'foo')
+        end
+      end
+    end
+  end
+end

--- a/elasticsearch-xpack/test/unit/async_search/status_test.rb
+++ b/elasticsearch-xpack/test/unit/async_search/status_test.rb
@@ -1,0 +1,39 @@
+# Licensed to Elasticsearch B.V. under one or more contributor
+# license agreements. See the NOTICE file distributed with
+# this work for additional information regarding copyright
+# ownership. Elasticsearch B.V. licenses this file to you under
+# the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+require 'test_helper'
+
+module Elasticsearch
+  module Test
+    class XPackAsyncSearchStatus < Minitest::Test
+      subject { FakeClient.new }
+
+      context 'XPack: Async Search Status' do
+        should 'perform correct request' do
+          subject.expects(:perform_request).with do |method, url, params, body|
+            assert_equal('GET', method)
+            assert_equal('_async_search/status/foo', url)
+            assert_equal({}, params)
+            assert_nil(body)
+          end.returns(FakeResponse.new)
+
+          subject.xpack.async_search.status(id: 'foo')
+        end
+      end
+    end
+  end
+end

--- a/elasticsearch-xpack/test/unit/async_search/submit_test.rb
+++ b/elasticsearch-xpack/test/unit/async_search/submit_test.rb
@@ -1,0 +1,50 @@
+# Licensed to Elasticsearch B.V. under one or more contributor
+# license agreements. See the NOTICE file distributed with
+# this work for additional information regarding copyright
+# ownership. Elasticsearch B.V. licenses this file to you under
+# the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+require 'test_helper'
+
+module Elasticsearch
+  module Test
+    class XPackAsyncSearchSubmit < Minitest::Test
+      subject { FakeClient.new }
+
+      context 'XPack: Async Search Submit' do
+        should 'perform correct request' do
+          subject.expects(:perform_request).with do |method, url, params, body|
+            assert_equal('POST', method)
+            assert_equal('_async_search', url)
+            assert_equal({}, params)
+            assert_nil(body)
+          end.returns(FakeResponse.new)
+
+          subject.xpack.async_search.submit
+        end
+
+        should 'perform correct request with index' do
+          subject.expects(:perform_request).with do |method, url, params, body|
+            assert_equal('POST', method)
+            assert_equal('foo/_async_search', url)
+            assert_equal({}, params)
+            assert_nil(body)
+          end.returns(FakeResponse.new)
+
+          subject.xpack.async_search.submit(index: 'foo')
+        end
+      end
+    end
+  end
+end

--- a/elasticsearch-xpack/test/unit/close_point_in_time_test.rb
+++ b/elasticsearch-xpack/test/unit/close_point_in_time_test.rb
@@ -1,0 +1,40 @@
+# Licensed to Elasticsearch B.V. under one or more contributor
+# license agreements. See the NOTICE file distributed with
+# this work for additional information regarding copyright
+# ownership. Elasticsearch B.V. licenses this file to you under
+# the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+require 'test_helper'
+
+module Elasticsearch
+  module Test
+    class XPackClosePointInTimeTest < Minitest::Test
+      context 'XPack: Close Point In Time' do
+        subject { FakeClient.new }
+
+        should 'perform correct request' do
+          subject.expects(:perform_request).with do |method, url, params, body|
+            assert_equal 'DELETE', method
+            assert_equal '_pit', url
+            assert_equal({}, params)
+            assert_nil   body
+            true
+          end.returns(FakeResponse.new)
+
+          subject.xpack.close_point_in_time
+        end
+      end
+    end
+  end
+end

--- a/elasticsearch-xpack/test/unit/open_point_in_time_test.rb
+++ b/elasticsearch-xpack/test/unit/open_point_in_time_test.rb
@@ -1,0 +1,52 @@
+# Licensed to Elasticsearch B.V. under one or more contributor
+# license agreements. See the NOTICE file distributed with
+# this work for additional information regarding copyright
+# ownership. Elasticsearch B.V. licenses this file to you under
+# the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+require 'test_helper'
+
+module Elasticsearch
+  module Test
+    class XPackOpenPointInTimeTest < Minitest::Test
+      context 'XPack: Open Point In Time' do
+        subject { FakeClient.new }
+
+        should 'perform correct request without index' do
+          subject.expects(:perform_request).with do |method, url, params, body|
+            assert_equal 'POST', method
+            assert_equal '_pit', url
+            assert_equal({}, params)
+            assert_nil   body
+            true
+          end.returns(FakeResponse.new)
+
+          subject.xpack.open_point_in_time
+        end
+
+        should 'perform correct request with index' do
+          subject.expects(:perform_request).with do |method, url, params, body|
+            assert_equal 'POST', method
+            assert_equal 'foo/_pit', url
+            assert_equal({}, params)
+            assert_nil   body
+            true
+          end.returns(FakeResponse.new)
+
+          subject.xpack.open_point_in_time(index: 'foo')
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Some backporting from #1074 and rewrite of the X-Pack YAML test runner cleanup based on [PHP's investigation](https://github.com/elastic/elasticsearch-php/blob/7.10/tests/Elasticsearch/Tests/Utility.php#L97).