### PR TITLE
[Client] Fix extracting cloud host when cloud host provides a port

### DIFF
--- a/elasticsearch-transport/lib/elasticsearch/transport/client.rb
+++ b/elasticsearch-transport/lib/elasticsearch/transport/client.rb
@@ -195,17 +195,25 @@ module Elasticsearch
       end
 
       def extract_cloud_creds(arguments)
-        return unless arguments[:cloud_id]
+        return unless arguments[:cloud_id] && !arguments[:cloud_id].empty?
 
         name = arguments[:cloud_id].split(':')[0]
         cloud_url, elasticsearch_instance = Base64.decode64(arguments[:cloud_id].gsub("#{name}:", '')).split('$')
+
+        if cloud_url.include?(':')
+          url, port = cloud_url.split(':')
+          host = "#{elasticsearch_instance}.#{url}"
+        else
+          host = "#{elasticsearch_instance}.#{cloud_url}"
+          port = arguments[:port] || DEFAULT_CLOUD_PORT
+        end
         [
           {
             scheme: 'https',
             user: arguments[:user],
             password: arguments[:password],
-            host: "#{elasticsearch_instance}.#{cloud_url}",
-            port: arguments[:port] || DEFAULT_CLOUD_PORT
+            host: host,
+            port: port.to_i
           }
         ]
       end

--- a/elasticsearch-transport/spec/elasticsearch/transport/client_spec.rb
+++ b/elasticsearch-transport/spec/elasticsearch/transport/client_spec.rb
@@ -428,6 +428,51 @@ describe Elasticsearch::Transport::Client do
         ).to eq('https://elasticfantastic:changeme@abcd.localhost:9243')
       end
     end
+
+    context 'when the cloud host provides a port' do
+      let(:client) do
+        described_class.new(
+          cloud_id: 'name:ZWxhc3RpY19zZXJ2ZXI6OTI0MyRlbGFzdGljX2lk',
+          user: 'elastic',
+          password: 'changeme'
+        )
+      end
+
+      let(:hosts) do
+        client.transport.hosts
+      end
+
+      it 'creates the correct full url' do
+        expect(hosts[0][:host]).to eq('elastic_id.elastic_server')
+        expect(hosts[0][:protocol]).to eq('https')
+        expect(hosts[0][:user]).to eq('elastic')
+        expect(hosts[0][:password]).to eq('changeme')
+        expect(hosts[0][:port]).to eq(9243)
+      end
+    end
+
+    context 'when the cloud host provides a port and the port is also specified' do
+      let(:client) do
+        described_class.new(
+          cloud_id: 'name:ZWxhc3RpY19zZXJ2ZXI6OTI0MyRlbGFzdGljX2lk',
+          user: 'elastic',
+          password: 'changeme',
+          port: 9200
+        )
+      end
+
+      let(:hosts) do
+        client.transport.hosts
+      end
+
+      it 'creates the correct full url' do
+        expect(hosts[0][:host]).to eq('elastic_id.elastic_server')
+        expect(hosts[0][:protocol]).to eq('https')
+        expect(hosts[0][:user]).to eq('elastic')
+        expect(hosts[0][:password]).to eq('changeme')
+        expect(hosts[0][:port]).to eq(9243)
+      end
+    end
   end
 
   shared_examples_for 'a client that extracts hosts' do


### PR DESCRIPTION
Fixes #1081.

Will be backported to `7.x` and `7.10` for release.