### PR TITLE
Meta header

### DIFF
--- a/elasticsearch-api/spec/elasticsearch/api/client_spec.rb
+++ b/elasticsearch-api/spec/elasticsearch/api/client_spec.rb
@@ -18,27 +18,23 @@
 require 'spec_helper'
 
 describe 'API Client' do
-
   let(:client) do
     Class.new { include Elasticsearch::API }.new
   end
 
   describe '#cluster' do
-
     it 'responds to the method' do
       expect(client.respond_to?(:cluster)).to be(true)
     end
   end
 
   describe '#indices' do
-
     it 'responds to the method' do
       expect(client.respond_to?(:indices)).to be(true)
     end
   end
 
   describe '#bulk' do
-
     it 'responds to the method' do
       expect(client.respond_to?(:bulk)).to be(true)
     end

--- a/elasticsearch-transport/Gemfile
+++ b/elasticsearch-transport/Gemfile
@@ -32,7 +32,7 @@ if File.exist? File.expand_path('../../elasticsearch/elasticsearch.gemspec', __F
   gem 'elasticsearch', path: File.expand_path('../../elasticsearch', __FILE__), require: false
 end
 
-group :development do
+group :development, :test do
   gem 'rspec'
   if defined?(JRUBY_VERSION)
     gem 'pry-nav'

--- a/elasticsearch-transport/lib/elasticsearch/transport/client.rb
+++ b/elasticsearch-transport/lib/elasticsearch/transport/client.rb
@@ -221,10 +221,12 @@ module Elasticsearch
       end
 
       def meta_header_service_version
-        if defined?(META_HEADER_SERVICE_VERSION)
-          META_HEADER_SERVICE_VERSION
-        else
+        if defined?(Elastic::META_HEADER_SERVICE_VERSION)
+          Elastic::META_HEADER_SERVICE_VERSION
+        elsif defined?(Elasticsearch::VERSION)
           ['es', Elasticsearch::VERSION]
+        else
+          ['es', Elasticsearch::Transport::VERSION]
         end
       end
 

--- a/elasticsearch-transport/lib/elasticsearch/transport/client.rb
+++ b/elasticsearch-transport/lib/elasticsearch/transport/client.rb
@@ -207,8 +207,10 @@ module Elasticsearch
       def set_meta_header
         return if @arguments[:enable_meta_header] == false
 
+        service, version = meta_header_service_version
+
         meta_headers = {
-          es: Elasticsearch::VERSION, # TODO - es|ent
+          service.to_sym => version,
           rb: RUBY_VERSION,
           t: Elasticsearch::Transport::VERSION
         }
@@ -216,6 +218,14 @@ module Elasticsearch
         meta_headers.merge!(meta_header_adapter) if meta_header_adapter
 
         add_header({ 'x-elastic-client-meta' => meta_headers.map { |k, v| "#{k}=#{v}" }.join(',') })
+      end
+
+      def meta_header_service_version
+        if defined?(META_HEADER_SERVICE_VERSION)
+          META_HEADER_SERVICE_VERSION
+        else
+          ['es', Elasticsearch::VERSION]
+        end
       end
 
       def meta_header_engine

--- a/elasticsearch-transport/lib/elasticsearch/transport/client.rb
+++ b/elasticsearch-transport/lib/elasticsearch/transport/client.rb
@@ -137,11 +137,10 @@ module Elasticsearch
         @arguments[:randomize_hosts]    ||= false
         @arguments[:transport_options]  ||= {}
         @arguments[:http]               ||= {}
-        @arguments[:enable_meta_header] ||= true
+        @arguments[:enable_meta_header] = arguments.fetch(:enable_meta_header) { true }
         @options[:http]                 ||= {}
 
         set_api_key if (@api_key = @arguments[:api_key])
-        set_meta_header unless @arguments[:enable_meta_header] == false
 
         @seeds = extract_cloud_creds(@arguments)
         @seeds ||= __extract_hosts(@arguments[:hosts] ||
@@ -161,14 +160,17 @@ module Elasticsearch
         if @arguments[:transport]
           @transport = @arguments[:transport]
         else
-          transport_class = @arguments[:transport_class] || DEFAULT_TRANSPORT_CLASS
-          @transport = if transport_class == Transport::HTTP::Faraday
-                         transport_class.new(hosts: @seeds, options: @arguments) do |faraday|
-                           faraday.adapter(@arguments[:adapter] || __auto_detect_adapter)
+          @transport_class = @arguments[:transport_class] || DEFAULT_TRANSPORT_CLASS
+          @transport = if @transport_class == Transport::HTTP::Faraday
+                         @arguments[:adapter] ||= __auto_detect_adapter
+                         set_meta_header
+                         @transport_class.new(hosts: @seeds, options: @arguments) do |faraday|
+                           faraday.adapter(@arguments[:adapter])
                            block&.call faraday
                          end
                        else
-                         transport_class.new(hosts: @seeds, options: @arguments)
+                         set_meta_header
+                         @transport_class.new(hosts: @seeds, options: @arguments)
                        end
         end
       end
@@ -203,12 +205,16 @@ module Elasticsearch
       end
 
       def set_meta_header
+        return if @arguments[:enable_meta_header] == false
+
         meta_headers = {
-          es: Elasticsearch::VERSION,
+          es: Elasticsearch::VERSION, # TODO - es|ent
           rb: RUBY_VERSION,
           t: Elasticsearch::Transport::VERSION
         }
         meta_headers.merge!(meta_header_engine) if meta_header_engine
+        meta_headers.merge!(meta_header_adapter) if meta_header_adapter
+
         add_header({ 'x-elastic-client-meta' => meta_headers.map { |k, v| "#{k}=#{v}" }.join(',') })
       end
 
@@ -222,6 +228,29 @@ module Elasticsearch
           { rbx: RUBY_VERSION }
         else
           { RUBY_ENGINE.to_sym => RUBY_VERSION }
+        end
+      end
+
+      def meta_header_adapter
+        if @transport_class == Transport::HTTP::Faraday
+          {fd: Faraday::VERSION}.merge(
+            case @arguments[:adapter]
+            when :patron
+              {pt: Patron::VERSION}
+            when :net_http
+              {nh: defined?(Net::HTTP::VERSION) ? Net::HTTP::VERSION : Net::HTTP::HTTPVersion}
+            when :typhoeus
+              {ty: Typhoeus::VERSION}
+            when :httpclient
+              {hc: HTTPClient::VERSION}
+            when :net_http_persistent
+              {np: Net::HTTP::Persistent::VERSION}
+            end
+          )
+        elsif defined?(Transport::HTTP::Curb) && @transport_class == Transport::HTTP::Curb
+          {cl: Curl::CURB_VERSION}
+        elsif defined?(Transport::HTTP::Manticore) && @transport_class == Transport::HTTP::Manticore
+          {mc: Manticore::VERSION}
         end
       end
 

--- a/elasticsearch-transport/lib/elasticsearch/transport/client.rb
+++ b/elasticsearch-transport/lib/elasticsearch/transport/client.rb
@@ -19,13 +19,12 @@ require 'base64'
 
 module Elasticsearch
   module Transport
-
     # Handles communication with an Elasticsearch cluster.
     #
     # See {file:README.md README} for usage and code examples.
     #
     class Client
-      DEFAULT_TRANSPORT_CLASS  = Transport::HTTP::Faraday
+      DEFAULT_TRANSPORT_CLASS = Transport::HTTP::Faraday
 
       DEFAULT_LOGGER = lambda do
         require 'logger'
@@ -124,8 +123,8 @@ module Elasticsearch
       #
       # @yield [faraday] Access and configure the `Faraday::Connection` instance directly with a block
       #
-      def initialize(arguments={}, &block)
-        @options = arguments.each_with_object({}){ |(k,v), args| args[k.to_sym] = v }
+      def initialize(arguments = {}, &block)
+        @options = arguments.each_with_object({}) { |(k, v), args| args[k.to_sym] = v }
         @arguments = @options
         @arguments[:logger] ||= @arguments[:log]   ? DEFAULT_LOGGER.call() : nil
         @arguments[:tracer] ||= @arguments[:trace] ? DEFAULT_TRACER.call() : nil
@@ -135,17 +134,17 @@ module Elasticsearch
         @arguments[:randomize_hosts]    ||= false
         @arguments[:transport_options]  ||= {}
         @arguments[:http]               ||= {}
-        @options[:http]               ||= {}
+        @options[:http]                 ||= {}
 
         set_api_key if (@api_key = @arguments[:api_key])
 
         @seeds = extract_cloud_creds(@arguments)
         @seeds ||= __extract_hosts(@arguments[:hosts] ||
-                                     @arguments[:host] ||
-                                     @arguments[:url] ||
-                                     @arguments[:urls] ||
-                                     ENV['ELASTICSEARCH_URL'] ||
-                                     DEFAULT_HOST)
+                                   @arguments[:host] ||
+                                   @arguments[:url] ||
+                                   @arguments[:urls] ||
+                                   ENV['ELASTICSEARCH_URL'] ||
+                                   DEFAULT_HOST)
 
         @send_get_body_as = @arguments[:send_get_body_as] || 'GET'
         @opaque_id_prefix = @arguments[:opaque_id_prefix] || nil
@@ -158,14 +157,14 @@ module Elasticsearch
           @transport = @arguments[:transport]
         else
           transport_class = @arguments[:transport_class] || DEFAULT_TRANSPORT_CLASS
-          if transport_class == Transport::HTTP::Faraday
-            @transport = transport_class.new(hosts: @seeds, options: @arguments) do |faraday|
-              faraday.adapter(@arguments[:adapter] || __auto_detect_adapter)
-              block&.call faraday
-            end
-          else
-            @transport = transport_class.new(hosts: @seeds, options: @arguments)
-          end
+          @transport = if transport_class == Transport::HTTP::Faraday
+                         transport_class.new(hosts: @seeds, options: @arguments) do |faraday|
+                           faraday.adapter(@arguments[:adapter] || __auto_detect_adapter)
+                           block&.call faraday
+                         end
+                       else
+                         transport_class.new(hosts: @seeds, options: @arguments)
+                       end
         end
       end
 
@@ -232,15 +231,15 @@ module Elasticsearch
       #
       def __extract_hosts(hosts_config)
         hosts = case hosts_config
-        when String
-          hosts_config.split(',').map { |h| h.strip! || h }
-        when Array
-          hosts_config
-        when Hash, URI
-          [ hosts_config ]
-        else
-          Array(hosts_config)
-        end
+                when String
+                  hosts_config.split(',').map { |h| h.strip! || h }
+                when Array
+                  hosts_config
+                when Hash, URI
+                  [hosts_config]
+                else
+                  Array(hosts_config)
+                end
 
         host_list = hosts.map { |host| __parse_host(host) }
         @options[:randomize_hosts] ? host_list.shuffle! : host_list
@@ -248,37 +247,37 @@ module Elasticsearch
 
       def __parse_host(host)
         host_parts = case host
-        when String
-          if host =~ /^[a-z]+\:\/\//
-            # Construct a new `URI::Generic` directly from the array returned by URI::split.
-            # This avoids `URI::HTTP` and `URI::HTTPS`, which supply default ports.
-            uri = URI::Generic.new(*URI.split(host))
+                     when String
+                       if host =~ /^[a-z]+\:\/\//
+                         # Construct a new `URI::Generic` directly from the array returned by URI::split.
+                         # This avoids `URI::HTTP` and `URI::HTTPS`, which supply default ports.
+                         uri = URI::Generic.new(*URI.split(host))
 
-            default_port = uri.scheme == 'https' ? 443 : DEFAULT_PORT
+                         default_port = uri.scheme == 'https' ? 443 : DEFAULT_PORT
 
-            { :scheme => uri.scheme,
-              :user => uri.user,
-              :password => uri.password,
-              :host => uri.host,
-              :path => uri.path,
-              :port => uri.port || default_port }
-          else
-            host, port = host.split(':')
-            { :host => host,
-              :port => port }
-          end
-        when URI
-          { :scheme => host.scheme,
-            :user => host.user,
-            :password => host.password,
-            :host => host.host,
-            :path => host.path,
-            :port => host.port }
-        when Hash
-          host
-        else
-          raise ArgumentError, "Please pass host as a String, URI or Hash -- #{host.class} given."
-        end
+                         { :scheme => uri.scheme,
+                           :user => uri.user,
+                           :password => uri.password,
+                           :host => uri.host,
+                           :path => uri.path,
+                           :port => uri.port || default_port }
+                       else
+                         host, port = host.split(':')
+                         { :host => host,
+                           :port => port }
+                       end
+                     when URI
+                       { :scheme => host.scheme,
+                         :user => host.user,
+                         :password => host.password,
+                         :host => host.host,
+                         :path => host.path,
+                         :port => host.port }
+                     when Hash
+                       host
+                     else
+                       raise ArgumentError, "Please pass host as a String, URI or Hash -- #{host.class} given."
+                     end
 
         if @api_key
           # Remove Basic Auth if using API KEY

--- a/elasticsearch-transport/lib/elasticsearch/transport/client.rb
+++ b/elasticsearch-transport/lib/elasticsearch/transport/client.rb
@@ -235,7 +235,7 @@ module Elasticsearch
         when 'ruby'
           {}
         when 'jruby'
-          { jr: JRUBY_VERSION }
+          { jv: ENV_JAVA['java.version'], jr: JRUBY_VERSION }
         when 'rbx'
           { rbx: RUBY_VERSION }
         else

--- a/elasticsearch-transport/spec/elasticsearch/transport/client_spec.rb
+++ b/elasticsearch-transport/spec/elasticsearch/transport/client_spec.rb
@@ -1491,7 +1491,6 @@ describe Elasticsearch::Transport::Client do
     end
 
     context 'when a request is made' do
-
       let!(:response) do
         client.perform_request('GET', '_cluster/health')
       end
@@ -1502,9 +1501,7 @@ describe Elasticsearch::Transport::Client do
     end
 
     describe '#initialize' do
-
       context 'when options are specified' do
-
         let(:transport_options) do
           { headers: { accept: 'application/yaml', content_type: 'application/yaml' } }
         end
@@ -1520,7 +1517,6 @@ describe Elasticsearch::Transport::Client do
       end
 
       context 'when a block is provided' do
-
         let(:client) do
           Elasticsearch::Client.new(host: ELASTICSEARCH_HOSTS.first, logger: logger) do |client|
             client.headers['Accept'] = 'application/yaml'
@@ -1563,11 +1559,8 @@ describe Elasticsearch::Transport::Client do
     end
 
     describe '#options' do
-
       context 'when retry_on_failure is true' do
-
         context 'when a node is unreachable' do
-
           let(:hosts) do
             [ELASTICSEARCH_HOSTS.first, "foobar1", "foobar2"]
           end

--- a/elasticsearch-transport/spec/elasticsearch/transport/client_spec.rb
+++ b/elasticsearch-transport/spec/elasticsearch/transport/client_spec.rb
@@ -246,7 +246,7 @@ describe Elasticsearch::Transport::Client do
       end
 
       let(:client) do
-        described_class.new(adapter: :patron)
+        described_class.new(adapter: :patron, enable_meta_header: false)
       end
 
       it 'uses Faraday with the adapter' do
@@ -260,7 +260,7 @@ describe Elasticsearch::Transport::Client do
       end
 
       let(:client) do
-        described_class.new(adapter: :typhoeus)
+        described_class.new(adapter: :typhoeus, enable_meta_header: false)
       end
 
       it 'uses Faraday with the adapter' do
@@ -274,7 +274,7 @@ describe Elasticsearch::Transport::Client do
       end
 
       let(:client) do
-        described_class.new('adapter' => :patron)
+        described_class.new(adapter: :patron, enable_meta_header: false)
       end
 
       it 'uses Faraday with the adapter' do
@@ -1669,7 +1669,7 @@ describe Elasticsearch::Transport::Client do
           context 'when using the HTTPClient adapter' do
 
             let(:client) do
-              described_class.new(hosts: ELASTICSEARCH_HOSTS, compression: true, adapter: :httpclient)
+              described_class.new(hosts: ELASTICSEARCH_HOSTS, compression: true, adapter: :httpclient, enable_meta_header: false)
             end
 
             it 'compresses the request and decompresses the response' do

--- a/elasticsearch-transport/spec/elasticsearch/transport/meta_header_spec.rb
+++ b/elasticsearch-transport/spec/elasticsearch/transport/meta_header_spec.rb
@@ -19,22 +19,25 @@ require 'spec_helper'
 
 describe Elasticsearch::Transport::Client do
   context 'meta-header' do
-    let(:client) do
-      described_class.new.tap do |klient|
-        allow(klient).to receive(:__build_connections)
-      end
-    end
     let(:subject) { client.transport.connections.first.connection.headers }
     let(:regexp) { /^[a-z]{1,}=[a-z0-9.\-]{1,}(?:,[a-z]{1,}=[a-z0-9.\-]+)*$/ }
+    let(:adapter) { :net_http }
+    let(:adapter_code) { "nh=#{defined?(Net::HTTP::VERSION) ? Net::HTTP::VERSION : Net::HTTP::HTTPVersion}" }
     let(:meta_header) do
       if RUBY_ENGINE == 'jruby'
-        "es=#{Elasticsearch::VERSION},rb=#{RUBY_VERSION},t=#{Elasticsearch::Transport::VERSION},jr=#{JRUBY_VERSION}"
+        "es=#{Elasticsearch::VERSION},rb=#{RUBY_VERSION},t=#{Elasticsearch::Transport::VERSION},jr=#{JRUBY_VERSION},fd=#{Faraday::VERSION},#{adapter_code}"
       else
-        "es=#{Elasticsearch::VERSION},rb=#{RUBY_VERSION},t=#{Elasticsearch::Transport::VERSION}"
+        "es=#{Elasticsearch::VERSION},rb=#{RUBY_VERSION},t=#{Elasticsearch::Transport::VERSION},fd=#{Faraday::VERSION},#{adapter_code}"
       end
     end
 
     context 'single use of meta header' do
+      let(:client) do
+        described_class.new(adapter: adapter).tap do |klient|
+          allow(klient).to receive(:__build_connections)
+        end
+      end
+
       it 'x-elastic-client-header value matches regexp' do
         expect(subject['x-elastic-client-meta']).to match(regexp)
         expect(subject).to include('x-elastic-client-meta' => meta_header)
@@ -44,29 +47,135 @@ describe Elasticsearch::Transport::Client do
     context 'when using user-agent headers' do
       let(:client) do
         transport_options = { headers: { user_agent: 'My Ruby App' } }
-        described_class.new(transport_options: transport_options).tap do |klient|
+        described_class.new(transport_options: transport_options, adapter: adapter).tap do |klient|
           allow(klient).to receive(:__build_connections)
         end
       end
 
       it 'is friendly to previously set headers' do
         expect(subject).to include(user_agent: 'My Ruby App')
+        expect(subject['x-elastic-client-meta']).to match(regexp)
         expect(subject).to include('x-elastic-client-meta' => meta_header)
       end
     end
 
     context 'when using API Key' do
       let(:client) do
-        described_class.new(api_key: 'an_api_key')
+        described_class.new(api_key: 'an_api_key', adapter: adapter)
       end
 
       let(:authorization_header) do
         client.transport.connections.first.connection.headers['Authorization']
       end
 
-      it 'Adds the ApiKey header to the connection' do
+      it 'adds the ApiKey header to the connection' do
         expect(authorization_header).to eq('ApiKey an_api_key')
         expect(subject['x-elastic-client-meta']).to match(regexp)
+        expect(subject).to include('x-elastic-client-meta' => meta_header)
+      end
+    end
+
+    context 'adapters' do
+      let(:meta_header) do
+        if RUBY_ENGINE == 'jruby'
+          "es=#{Elasticsearch::VERSION},rb=#{RUBY_VERSION},t=#{Elasticsearch::Transport::VERSION},jr=#{JRUBY_VERSION},fd=#{Faraday::VERSION}"
+        else
+          "es=#{Elasticsearch::VERSION},rb=#{RUBY_VERSION},t=#{Elasticsearch::Transport::VERSION},fd=#{Faraday::VERSION}"
+        end
+      end
+      let(:client) { described_class.new(adapter: adapter) }
+      let(:headers) { client.transport.connections.first.connection.headers }
+
+      context 'using net/http/persistent' do
+        let(:adapter) { :net_http_persistent }
+
+        it 'sets adapter in the meta header' do
+          require 'net/http/persistent'
+          expect(headers['x-elastic-client-meta']).to match(regexp)
+          meta = "#{meta_header},np=#{Net::HTTP::Persistent::VERSION}"
+          expect(headers).to include('x-elastic-client-meta' => meta)
+        end
+      end
+
+      context 'using httpclient' do
+        let(:adapter) { :httpclient }
+
+        it 'sets adapter in the meta header' do
+          require 'httpclient'
+          expect(headers['x-elastic-client-meta']).to match(regexp)
+          meta = "#{meta_header},hc=#{HTTPClient::VERSION}"
+          expect(headers).to include('x-elastic-client-meta' => meta)
+        end
+      end
+
+      context 'using typhoeus' do
+        let(:adapter) { :typhoeus }
+
+        it 'sets adapter in the meta header' do
+          require 'typhoeus'
+          expect(headers['x-elastic-client-meta']).to match(regexp)
+          meta = "#{meta_header},ty=#{Typhoeus::VERSION}"
+          expect(headers).to include('x-elastic-client-meta' => meta)
+        end
+      end
+
+      unless defined?(JRUBY_VERSION)
+        let(:adapter) { :patron }
+
+        context 'using patron' do
+          it 'sets adapter in the meta header' do
+            require 'patron'
+            expect(headers['x-elastic-client-meta']).to match(regexp)
+            meta = "#{meta_header},pt=#{Patron::VERSION}"
+            expect(headers).to include('x-elastic-client-meta' => meta)
+          end
+        end
+      end
+    end
+
+    if defined?(JRUBY_VERSION)
+      context 'when using manticore' do
+        let(:client) do
+          Elasticsearch::Client.new(transport_class: Elasticsearch::Transport::Transport::HTTP::Manticore)
+        end
+        let(:subject) { client.transport.connections.first.connection.instance_variable_get("@options")[:headers]}
+
+        it 'sets manticore in the metaheader' do
+          expect(subject['x-elastic-client-meta']).to match(regexp)
+          expect(subject['x-elastic-client-meta']).to match(/mc=[0-9.]+/)
+        end
+      end
+    else
+      context 'when using curb' do
+        let(:client) do
+          Elasticsearch::Client.new(transport_class: Elasticsearch::Transport::Transport::HTTP::Curb)
+        end
+
+        it 'sets curb in the metaheader' do
+          expect(subject['x-elastic-client-meta']).to match(regexp)
+          expect(subject['x-elastic-client-meta']).to match(/cl=[0-9.]+/)
+        end
+      end
+    end
+
+    context 'when using custom transport implementation' do
+      class MyTransport
+        include Elasticsearch::Transport::Transport::Base
+        def initialize(args); end
+      end
+      let(:client) { Elasticsearch::Client.new(transport_class: MyTransport) }
+      let(:subject){ client.instance_variable_get("@arguments")[:transport_options][:headers] }
+      let(:meta_header) do
+        if RUBY_ENGINE == 'jruby'
+          "es=#{Elasticsearch::VERSION},rb=#{RUBY_VERSION},t=#{Elasticsearch::Transport::VERSION},jr=#{JRUBY_VERSION}"
+        else
+          "es=#{Elasticsearch::VERSION},rb=#{RUBY_VERSION},t=#{Elasticsearch::Transport::VERSION}"
+        end
+      end
+
+      it 'doesnae set any info about the implementation in the metaheader' do
+        expect(subject['x-elastic-client-meta']).to match(regexp)
+        expect(subject).to include('x-elastic-client-meta' => meta_header)
       end
     end
   end

--- a/elasticsearch-transport/spec/elasticsearch/transport/meta_header_spec.rb
+++ b/elasticsearch-transport/spec/elasticsearch/transport/meta_header_spec.rb
@@ -1,0 +1,73 @@
+# Licensed to Elasticsearch B.V. under one or more contributor
+# license agreements. See the NOTICE file distributed with
+# this work for additional information regarding copyright
+# ownership. Elasticsearch B.V. licenses this file to you under
+# the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+require 'spec_helper'
+
+describe Elasticsearch::Transport::Client do
+  context 'meta-header' do
+    let(:client) do
+      described_class.new.tap do |klient|
+        allow(klient).to receive(:__build_connections)
+      end
+    end
+    let(:subject) { client.transport.connections.first.connection.headers }
+    let(:regexp) { /^[a-z]{1,}=[a-z0-9.\-]{1,}(?:,[a-z]{1,}=[a-z0-9.\-]+)*$/ }
+    let(:meta_header) do
+      if RUBY_ENGINE == 'jruby'
+        "es=#{Elasticsearch::VERSION},rb=#{RUBY_VERSION},t=#{Elasticsearch::Transport::VERSION},jr=#{JRUBY_VERSION}"
+      else
+        "es=#{Elasticsearch::VERSION},rb=#{RUBY_VERSION},t=#{Elasticsearch::Transport::VERSION}"
+      end
+    end
+
+    context 'single use of meta header' do
+      it 'x-elastic-client-header value matches regexp' do
+        expect(subject['x-elastic-client-meta']).to match(regexp)
+        expect(subject).to include('x-elastic-client-meta' => meta_header)
+      end
+    end
+
+    context 'when using user-agent headers' do
+      let(:client) do
+        transport_options = { headers: { user_agent: 'My Ruby App' } }
+        described_class.new(transport_options: transport_options).tap do |klient|
+          allow(klient).to receive(:__build_connections)
+        end
+      end
+
+      it 'is friendly to previously set headers' do
+        expect(subject).to include(user_agent: 'My Ruby App')
+        expect(subject).to include('x-elastic-client-meta' => meta_header)
+      end
+    end
+
+    context 'when using API Key' do
+      let(:client) do
+        described_class.new(api_key: 'an_api_key')
+      end
+
+      let(:authorization_header) do
+        client.transport.connections.first.connection.headers['Authorization']
+      end
+
+      it 'Adds the ApiKey header to the connection' do
+        expect(authorization_header).to eq('ApiKey an_api_key')
+        expect(subject['x-elastic-client-meta']).to match(regexp)
+      end
+    end
+  end
+end

--- a/elasticsearch-transport/spec/elasticsearch/transport/meta_header_spec.rb
+++ b/elasticsearch-transport/spec/elasticsearch/transport/meta_header_spec.rb
@@ -178,5 +178,34 @@ describe Elasticsearch::Transport::Client do
         expect(subject).to include('x-elastic-client-meta' => meta_header)
       end
     end
+
+    context 'when using a different service version' do
+      before do
+        module Elasticsearch
+          module Transport
+            class Client
+              META_HEADER_SERVICE_VERSION = [:ent, '8.0.0']
+            end
+          end
+        end
+      end
+
+      after do
+        module Elasticsearch
+          module Transport
+            class Client
+              META_HEADER_SERVICE_VERSION = [:es, Elasticsearch::VERSION]
+            end
+          end
+        end
+      end
+
+      let(:client) { Elasticsearch::Client.new }
+
+      it 'sets the service version in the metaheader' do
+        expect(subject['x-elastic-client-meta']).to match(regexp)
+        expect(subject['x-elastic-client-meta']).to start_with('ent=8.0.0')
+      end
+    end
   end
 end

--- a/elasticsearch-transport/spec/elasticsearch/transport/meta_header_spec.rb
+++ b/elasticsearch-transport/spec/elasticsearch/transport/meta_header_spec.rb
@@ -181,22 +181,14 @@ describe Elasticsearch::Transport::Client do
 
     context 'when using a different service version' do
       before do
-        module Elasticsearch
-          module Transport
-            class Client
-              META_HEADER_SERVICE_VERSION = [:ent, '8.0.0']
-            end
-          end
+        module Elastic
+          META_HEADER_SERVICE_VERSION = [:ent, '8.0.0']
         end
       end
 
       after do
-        module Elasticsearch
-          module Transport
-            class Client
-              META_HEADER_SERVICE_VERSION = [:es, Elasticsearch::VERSION]
-            end
-          end
+        module Elastic
+          META_HEADER_SERVICE_VERSION = [:es, Elasticsearch::VERSION]
         end
       end
 

--- a/elasticsearch-transport/spec/elasticsearch/transport/meta_header_spec.rb
+++ b/elasticsearch-transport/spec/elasticsearch/transport/meta_header_spec.rb
@@ -20,12 +20,12 @@ require 'spec_helper'
 describe Elasticsearch::Transport::Client do
   context 'meta-header' do
     let(:subject) { client.transport.connections.first.connection.headers }
-    let(:regexp) { /^[a-z]{1,}=[a-z0-9.\-]{1,}(?:,[a-z]{1,}=[a-z0-9.\-]+)*$/ }
+    let(:regexp) { /^[a-z]{1,}=[a-z0-9.\-]{1,}(?:,[a-z]{1,}=[a-z0-9._\-]+)*$/ }
     let(:adapter) { :net_http }
     let(:adapter_code) { "nh=#{defined?(Net::HTTP::VERSION) ? Net::HTTP::VERSION : Net::HTTP::HTTPVersion}" }
     let(:meta_header) do
-      if RUBY_ENGINE == 'jruby'
-        "es=#{Elasticsearch::VERSION},rb=#{RUBY_VERSION},t=#{Elasticsearch::Transport::VERSION},jr=#{JRUBY_VERSION},fd=#{Faraday::VERSION},#{adapter_code}"
+      if jruby?
+        "es=#{Elasticsearch::VERSION},rb=#{RUBY_VERSION},t=#{Elasticsearch::Transport::VERSION},jv=#{ENV_JAVA['java.version']},jr=#{JRUBY_VERSION},fd=#{Faraday::VERSION},#{adapter_code}"
       else
         "es=#{Elasticsearch::VERSION},rb=#{RUBY_VERSION},t=#{Elasticsearch::Transport::VERSION},fd=#{Faraday::VERSION},#{adapter_code}"
       end
@@ -77,8 +77,8 @@ describe Elasticsearch::Transport::Client do
 
     context 'adapters' do
       let(:meta_header) do
-        if RUBY_ENGINE == 'jruby'
-          "es=#{Elasticsearch::VERSION},rb=#{RUBY_VERSION},t=#{Elasticsearch::Transport::VERSION},jr=#{JRUBY_VERSION},fd=#{Faraday::VERSION}"
+        if jruby?
+          "es=#{Elasticsearch::VERSION},rb=#{RUBY_VERSION},t=#{Elasticsearch::Transport::VERSION},jv=#{ENV_JAVA['java.version']},jr=#{JRUBY_VERSION},fd=#{Faraday::VERSION}"
         else
           "es=#{Elasticsearch::VERSION},rb=#{RUBY_VERSION},t=#{Elasticsearch::Transport::VERSION},fd=#{Faraday::VERSION}"
         end
@@ -166,8 +166,8 @@ describe Elasticsearch::Transport::Client do
       let(:client) { Elasticsearch::Client.new(transport_class: MyTransport) }
       let(:subject){ client.instance_variable_get("@arguments")[:transport_options][:headers] }
       let(:meta_header) do
-        if RUBY_ENGINE == 'jruby'
-          "es=#{Elasticsearch::VERSION},rb=#{RUBY_VERSION},t=#{Elasticsearch::Transport::VERSION},jr=#{JRUBY_VERSION}"
+        if jruby?
+          "es=#{Elasticsearch::VERSION},rb=#{RUBY_VERSION},t=#{Elasticsearch::Transport::VERSION},jv=#{ENV_JAVA['java.version']},jr=#{JRUBY_VERSION}"
         else
           "es=#{Elasticsearch::VERSION},rb=#{RUBY_VERSION},t=#{Elasticsearch::Transport::VERSION}"
         end

--- a/elasticsearch/lib/elasticsearch.rb
+++ b/elasticsearch/lib/elasticsearch.rb
@@ -17,3 +17,7 @@ module Elasticsearch
     end
   end
 end
+module Elastic
+  # Constant for elasticsearch-transport meta-header
+  META_HEADER_SERVICE_VERSION = [:es, Elasticsearch::VERSION]
+end

--- a/elasticsearch/lib/elasticsearch.rb
+++ b/elasticsearch/lib/elasticsearch.rb
@@ -11,6 +11,9 @@ module Elasticsearch
   module Transport
     class Client
       include Elasticsearch::API
+
+      # Constant for elasticsearch-transport meta-header
+      META_HEADER_SERVICE_VERSION = [:es, Elasticsearch::VERSION]
     end
   end
 end

--- a/elasticsearch/test/integration/client_integration_test.rb
+++ b/elasticsearch/test/integration/client_integration_test.rb
@@ -57,6 +57,10 @@ module Elasticsearch
           end
         end
 
+        should 'report the right meta header' do
+          headers = @client.transport.connections.first.connection.headers
+          assert_match /^es=#{Elasticsearch::VERSION}/, headers['x-elastic-client-meta']
+        end
       end
     end
   end

--- a/elasticsearch/test/unit/wrapper_gem_test.rb
+++ b/elasticsearch/test/unit/wrapper_gem_test.rb
@@ -7,9 +7,7 @@ require 'test_helper'
 module Elasticsearch
   module Test
     class WrapperGemTest < Minitest::Test
-
       context "Wrapper gem" do
-
         should "require all neccessary subgems" do
           assert defined? Elasticsearch::Client
           assert defined? Elasticsearch::API
@@ -22,9 +20,7 @@ module Elasticsearch
           assert_respond_to client, :cluster
           assert_respond_to client, :indices
         end
-
       end
-
     end
   end
 end


### PR DESCRIPTION
Adds JRuby to language keys:
| Key | Language Key | Name                                  | Allowed Values |
|-----|--------------|---------------------------------------|----------------|
| jr  | rb           | JRuby runtime                         |      version        |

And transport values:
| Key | Language Key | Name                                  | Async | Allowed Values |
|-----|--------------|---------------------------------------|-------|----------------|
| fd  | rb           | Faraday                               |     0 | version        |
| np  | rb           | NetHttpPersistent adapter for Faraday |     0 | version        |
| hc  | rb           | HttpClient adapter for Faraday        |     0 | version        |
| ty  | rb           | Typhoeus adapter for Faraday          |     0 | version        |
| pt  | rb           | Patron adapter for Faraday            |     0 | version        |
| cl  | rb           | Curb transport implementation         |     0 | version        |
| mc  | rb           | Manticore transport implementation    |     0 | version        |