### PR TITLE
[CI] Updates make.sh and release task for consistency

### DIFF
--- a/.ci/make.sh
+++ b/.ci/make.sh
@@ -11,7 +11,6 @@ repo=$(realpath "$script_path/../")
 # shellcheck disable=SC1090
 CMD=$1
 VERSION=$2
-VERSION_QUALIFIER=${VERSION-''}
 set -euo pipefail
 
 TARGET_DIR=${TARGET_DIR-.ci/output}
@@ -23,11 +22,8 @@ GIT_NAME=${GIT_NAME-elastic}
 GIT_EMAIL=${GIT_EMAIL-'clients-team@elastic.co'}
 
 case $CMD in
-    assemble_snapshot)
-        TASK=assemble_snapshot[$VERSION_QUALIFIER,$TARGET_DIR]
-        ;;
     assemble)
-        TASK=assemble[$VERSION_QUALIFIER,$TARGET_DIR]
+        TASK=assemble[$VERSION,$TARGET_DIR]
         ;;
     *)
         echo -e "\nUsage:"


### PR DESCRIPTION
With this update, release and release snapshot change to this:

**Release**

```
$ .ci/make.sh assemble '8.0.0'
```

Will create `elasticsearch-ruby-8.0.0.zip` in `.ci/ouput` with the following files:
- `elasticsearch-8.0.0.gem`
- `elasticsearch-api-8.0.0.gem`
- `elasticsearch-transport-8.0.0.gem`
- `elasticsearch-xpack-8.0.0.gem`

**Release Snapshot**

```
$ .ci/make.sh assemble '8.0.0-SNAPSHOT'
```

Will create `elasticsearch-ruby-8.0.0-SNAPSHOT.zip` in `.ci/output` with the following files:
- `elasticsearch-8.0.0.20201216153118-SNAPSHOT.gem`
- `elasticsearch-api-8.0.0.20201216153118-SNAPSHOT.gem`
- `elasticsearch-transport-8.0.0.20201216153118-SNAPSHOT.gem`
- `elasticsearch-xpack-8.0.0.20201216153118-SNAPSHOT.gem`

