### PR TITLE
[CI] Test Runner: Improves pending tasks logging, adds insert_order to filter

### DIFF
--- a/api-spec-testing/test_file.rb
+++ b/api-spec-testing/test_file.rb
@@ -181,8 +181,8 @@ module Elasticsearch
         def wipe_cluster(client)
           if xpack?
             clear_rollup_jobs(client)
-            clear_sml_policies(client)
             wait_for_pending_tasks(client)
+            clear_sml_policies(client)
           end
           clear_snapshots_and_repositories(client)
           clear_datastreams(client) if xpack?

--- a/api-spec-testing/test_file.rb
+++ b/api-spec-testing/test_file.rb
@@ -404,7 +404,12 @@ module Elasticsearch
           datastreams['data_streams'].each do |datastream|
             client.xpack.indices.delete_data_stream(name: datastream['name'], expand_wildcards: 'all')
           end
-          client.indices.delete_data_stream(name: '*')
+          begin
+            client.indices.delete_data_stream(name: '*', expand_wildcards: 'all')
+          rescue StandardError => e
+            LOGGER.error "Caught exception attempting to delete data streams: #{e}"
+            client.indices.delete_data_stream(name: '*')
+          end
         end
 
         def clear_ml_filters(client)

--- a/api-spec-testing/test_file.rb
+++ b/api-spec-testing/test_file.rb
@@ -221,6 +221,7 @@ module Elasticsearch
             results.each do |task|
               next if task.empty?
 
+              LOGGER.debug "Pending task: #{task}"
               count += 1 if task.include?(filter)
             end
             break unless count.positive? && Time.now.to_i < (time + 30)
@@ -237,7 +238,7 @@ module Elasticsearch
             results['tasks'].each do |task|
               next if task.empty?
 
-              LOGGER.info "Pending task: #{task}"
+              LOGGER.debug "Pending cluster task: #{task}"
               tasks_filter.map do |filter|
                 count += 1 if task['source'].include? filter
               end

--- a/api-spec-testing/test_file.rb
+++ b/api-spec-testing/test_file.rb
@@ -229,7 +229,6 @@ module Elasticsearch
         end
 
         def wait_for_cluster_tasks(client)
-          tasks_filter = ['delete-index', 'remove-data-stream', 'ilm-history']
           time = Time.now.to_i
           count = 0
 
@@ -239,9 +238,7 @@ module Elasticsearch
               next if task.empty?
 
               LOGGER.debug "Pending cluster task: #{task}"
-              tasks_filter.map do |filter|
-                count += 1 if task['source'].include? filter
-              end
+              count += 1
             end
             break unless count.positive? && Time.now.to_i < (time + 30)
           end

--- a/elasticsearch-xpack/spec/xpack/rest_api_yaml_spec.rb
+++ b/elasticsearch-xpack/spec/xpack/rest_api_yaml_spec.rb
@@ -56,12 +56,12 @@ describe 'XPack Rest API YAML tests' do
               # todo: remove these two lines when Dimitris' PR is merged
               ADMIN_CLIENT.cluster.put_settings(body: { transient: { 'xpack.ml.max_model_memory_limit' => nil } })
               ADMIN_CLIENT.cluster.put_settings(body: { persistent: { 'xpack.ml.max_model_memory_limit' => nil } })
-              Elasticsearch::RestAPIYAMLTests::TestFile.wipe_cluster(ADMIN_CLIENT)
               test_file.setup
             end
 
             after(:all) do
               test_file.teardown
+              Elasticsearch::RestAPIYAMLTests::TestFile.wipe_cluster(ADMIN_CLIENT)
             end
 
             test.task_groups.each do |task_group|


### PR DESCRIPTION
There's a flaky test in master where a `.ds-ilm-history` index hasn't been removed so another test fails expecting to find another index as the first one in the cluster. There's also some pending `insert_order` cluster tasks related to this index in the logs, so I added `insert_order` to the list of tasks we wait for in `wait_for_cluster_tasks`. Also adding a log to `wait_for_pending_tasks` to better debug these kind of issues.