### PR TITLE
Determine Elasticsearch version from elasticsearch

### DIFF
--- a/elasticsearch-extensions/lib/elasticsearch/extensions/test/cluster.rb
+++ b/elasticsearch-extensions/lib/elasticsearch/extensions/test/cluster.rb
@@ -531,7 +531,7 @@ module Elasticsearch
 
               @dist = output.match(/Build: ([a-z]+)\//)&.[](1)
 
-              if(m = output.match(/Version: (\d+\.\d+\.\d+).*,/))
+              if m = output.match(/Version: (\d+\.\d+\.\d+).*,/)
                 m[1]
               else
                 raise RuntimeError, "Cannot determine Elasticsearch version from elasticsearch --version output [#{output}]"

--- a/elasticsearch-extensions/lib/elasticsearch/extensions/test/cluster.rb
+++ b/elasticsearch-extensions/lib/elasticsearch/extensions/test/cluster.rb
@@ -531,7 +531,7 @@ module Elasticsearch
 
               @dist = output.match(/Build: ([a-z]+)\//)&.[](1)
 
-              if(m = output.match(/Version: (\d+\.\d+.\d+).*,/))
+              if(m = output.match(/Version: (\d+\.\d+\.\d+).*,/))
                 m[1]
               else
                 raise RuntimeError, "Cannot determine Elasticsearch version from elasticsearch --version output [#{output}]"


### PR DESCRIPTION
Fix errors:

```Cannot determine Elasticsearch version from elasticsearch --version output [Version: 7.10.1, ...```

```Cannot determine Elasticsearch version from elasticsearch --version output [Version: 7.10.0-SNAPSHOT, ... ```

Returns full version numbers:
```7.10.1```,
```7.10.0```