### PR TITLE
[CI] Change benchmarks Jenkins job to depend on master

### DIFF
--- a/.ci/jobs/elastic+elasticsearch-ruby+benchmarks.yml
+++ b/.ci/jobs/elastic+elasticsearch-ruby+benchmarks.yml
@@ -6,7 +6,7 @@
     display-name: 'elastic / elasticsearch-ruby # benchmarks'
     description: Client benchmarks for the Ruby client
     parameters:
-      - string: { name: branch_specifier, default: refs/heads/benchmarks }
+      - string: { name: branch_specifier, default: refs/heads/master }
     triggers:
       - timed: "H H/12 * * *"
     vault:


### PR DESCRIPTION
After this is merged, it should be fine to remove the `benchmarks` branch.