### PR TITLE
[Client] Fixes bug with headers in Faraday default class

### DIFF
--- a/elasticsearch-transport/lib/elasticsearch/transport/transport/http/faraday.rb
+++ b/elasticsearch-transport/lib/elasticsearch/transport/transport/http/faraday.rb
@@ -33,9 +33,17 @@ module Elasticsearch
           # @return [Response]
           # @see    Transport::Base#perform_request
           #
-          def perform_request(method, path, params={}, body=nil, headers=nil, opts={})
+          def perform_request(method, path, params = {}, body = nil, headers = nil, opts = {})
             super do |connection, url|
-              headers = headers || connection.connection.headers
+              headers = if connection.connection.headers
+                          if !headers.nil?
+                            connection.connection.headers.merge(headers)
+                          else
+                            connection.connection.headers
+                          end
+                        else
+                          headers
+                        end
 
               response = connection.connection.run_request(method.downcase.to_sym,
                                                            url,


### PR DESCRIPTION
This bug was present when using the default Transport class (`Transport::HTTP::Faraday`). If a user passed in headers when calling a request on the client, the implementation would use this header parameter and override the previously set headers in the connection. With this commit, we merge the headers.