### PR TITLE
[DOCS] Adds Configuration section to Ruby book

### DIFF
--- a/docs/advanced-config.asciidoc
+++ b/docs/advanced-config.asciidoc
@@ -1,0 +1,358 @@
+[[advanced-config]]
+=== Advanced configuration
+
+The client supports many configurations options for setting up and managing 
+connections, configuring logging, customizing the transport library, and so on.
+
+
+[[setting-hosts]]
+==== Setting hosts
+
+To connect to a specific {es} host:
+
+```ruby
+Elasticsearch::Client.new host: 'search.myserver.com'
+```
+
+To connect to a host with specific port:
+
+```ruby
+Elasticsearch::Client.new host: 'myhost:8080'
+```
+
+To connect to multiple hosts:
+
+```ruby
+Elasticsearch::Client.new hosts: ['myhost1', 'myhost2']
+```
+
+Instead of strings, you can pass host information as an array of Hashes:
+
+```ruby
+Elasticsearch::Client.new hosts: [ { host: 'myhost1', port: 8080 }, { host: 'myhost2', port: 8080 } ]
+```
+
+NOTE: When specifying multiple hosts, you probably want to enable the 
+`retry_on_failure` or `retry_on_status` options to perform a failed request on 
+another node (refer to <<retry-failures>>).
+
+Common URL parts – scheme, HTTP authentication credentials, URL prefixes, and so 
+on – are handled automatically:
+
+```ruby
+Elasticsearch::Client.new url: 'https://username:password@api.server.org:4430/search'
+```
+
+You can pass multiple URLs separated by a comma:
+
+```ruby
+Elasticsearch::Client.new urls: 'http://localhost:9200,http://localhost:9201'
+```
+
+Another way to configure URLs is to export the `ELASTICSEARCH_URL` variable.
+
+The client is automatically round-robin across the hosts (unless you select or 
+implement a different <<connection-selector>>).
+
+
+[[default-port]]
+==== Default port
+
+The default port is `9200`. Specify a port for your host(s) if they differ from 
+this default.
+
+If you are using Elastic Cloud, the default port is port `9243`. You must supply 
+your username and password separately, and optionally a port. Refer to 
+<<auth-ec>>.
+
+
+[[logging]]
+==== Logging
+
+To log requests and responses to standard output with the default logger (an 
+instance of Ruby's {::Logger} class), set the log argument to true:
+
+```ruby
+Elasticsearch::Client.new(log: true)
+```
+
+You can also use `ecs-logging` which is a set of libraries that enables you to 
+transform your application logs to structured logs that comply with the Elastic 
+Common Schema (ECS):
+
+[source,ruby]
+------------------------------------
+logger = EcsLogging::Logger.new($stdout)
+Elasticsearch::Client.new(logger: logger)
+------------------------------------
+
+To trace requests and responses in the Curl format, set the `trace` argument:
+
+```ruby
+Elasticsearch::Client.new(trace: true)
+```
+
+You can customize the default logger or tracer:
+
+[source,ruby]
+------------------------------------
+client.transport.logger.formatter = proc { |s, d, p, m| "#{s}: #{m}\n" }
+client.transport.logger.level = Logger::INFO
+------------------------------------
+
+Or, you can use a custom `::Logger` instance:
+
+```ruby
+Elasticsearch::Client.new(logger: Logger.new(STDERR))
+```
+
+You can pass the client any conforming logger implementation:
+
+[source,ruby]
+------------------------------------
+require 'logging' # https://github.com/TwP/logging/
+
+log = Logging.logger['elasticsearch']
+log.add_appenders Logging.appenders.stdout
+log.level = :info
+
+client = Elasticsearch::Client.new(logger: log)
+------------------------------------
+
+
+[[apm-integration]]
+==== APM integration
+
+This client integrates seamlessly with Elastic APM via the Elastic APM Agent. It 
+automatically captures client requests if you are using the agent on your code. 
+If you're using `elastic-apm` v3.8.0 or up, you can set 
+`capture_elasticsearch_queries` to `true` in `config/elastic_apm.yml` to also 
+capture the body from requests in {es}. Refer to 
+https://github.com/elastic/elasticsearch-ruby/tree/master/docs/examples/apm[this example].
+
+
+[[custom-http-headers]]
+==== Custom HTTP Headers
+
+You can set a custom HTTP header on the client's initializer:
+
+[source,ruby]
+------------------------------------
+client = Elasticsearch::Client.new(
+  transport_options: {
+    headers:
+      {user_agent: "My App"}
+  }
+)
+------------------------------------
+
+You can also pass in `headers` as a parameter to any of the API Endpoints to set 
+custom headers for the request:
+
+```ruby
+client.search(index: 'myindex', q: 'title:test', headers: {user_agent: "My App"})
+```
+
+
+[[x-opaque-id]]
+==== Identifying running tasks with X-Opaque-Id
+
+The X-Opaque-Id header allows to track certain calls, or associate certain tasks 
+with the client that started them (refer to 
+{ref}/tasks.html#_identifying_running_tasks[the documentation]). To use this 
+feature, you need to set an id for `opaque_id` on the client on each request. 
+Example:
+
+[source,ruby]
+------------------------------------
+client = Elasticsearch::Client.new
+client.search(index: 'myindex', q: 'title:test', opaque_id: '123456')
+------------------------------------
+
+The search request includes the following HTTP Header:
+
+```ruby
+X-Opaque-Id: 123456
+```
+
+You can also set a prefix for X-Opaque-Id when initializing the client. This is 
+prepended to the id you set before each request if you're using X-Opaque-Id. 
+Example:
+
+[source,ruby]
+------------------------------------
+client = Elasticsearch::Client.new(opaque_id_prefix: 'eu-west1_')
+client.search(index: 'myindex', q: 'title:test', opaque_id: '123456')
+------------------------------------
+
+The request includes the following HTTP Header:
+
+```ruby
+X-Opaque-Id: eu-west1_123456
+```
+
+
+[[setting-timeouts]]
+==== Setting Timeouts
+
+For many operations in {es}, the default timeouts of HTTP libraries are too low. 
+To increase the timeout, you can use the `request_timeout` parameter:
+
+```ruby
+Elasticsearch::Client.new request_timeout: 5*60
+```
+
+You can also use the `transport_options` argument documented below.
+
+
+[[randomizing-hosts]]
+==== Randomizing Hosts
+
+If you pass multiple hosts to the client, it rotates across them in a 
+round-robin fashion by default. When the same client would be running in 
+multiple processes (for exaample, in a Ruby web server such as Thin), it might 
+keep connecting to the same nodes "at once". To prevent this, you can randomize 
+the hosts collection on initialization and reloading:
+
+```ruby
+Elasticsearch::Client.new hosts: ['localhost:9200', 'localhost:9201'], randomize_hosts: true
+```
+
+
+[[retry-failures]]
+==== Retrying on Failures
+
+When the client is initialized with multiple hosts, it makes sense to retry a 
+failed request on a different host:
+
+```ruby
+Elasticsearch::Client.new hosts: ['localhost:9200', 'localhost:9201'], retry_on_failure: true
+```
+
+By default, the client retries the request 3 times. You can specify how many 
+times to retry before it raises an exception by passing a number to 
+`retry_on_failure`:
+
+```ruby
+Elasticsearch::Client.new hosts: ['localhost:9200', 'localhost:9201'], retry_on_failure: 5
+```
+
+You can also use `retry_on_status` to retry when specific status codes are 
+returned:
+
+```ruby
+Elasticsearch::Client.new hosts: ['localhost:9200', 'localhost:9201'], retry_on_status: [502, 503]
+```
+
+These two parameters can also be used together:
+
+```ruby
+Elasticsearch::Client.new hosts: ['localhost:9200', 'localhost:9201'], retry_on_status: [502, 503], retry_on_failure: 10
+```
+
+[[reload-hosts]]
+=== Reloading Hosts
+
+{es} dynamically discovers new nodes in the cluster by default. You can leverage 
+this in the client, and periodically check for new nodes to spread the load.
+
+To retrieve and use the information from the 
+{ref}/cluster-nodes-info.html[Nodes Info API] on every 10,000th request:
+
+```ruby
+Elasticsearch::Client.new hosts: ['localhost:9200', 'localhost:9201'], reload_connections: true
+```
+
+You can pass a specific number of requests after which reloading should be 
+performed:
+
+```ruby
+Elasticsearch::Client.new hosts: ['localhost:9200', 'localhost:9201'], reload_connections: 1_000
+```
+
+To reload connections on failures, use:
+
+```ruby
+Elasticsearch::Client.new hosts: ['localhost:9200', 'localhost:9201'], reload_on_failure: true
+```
+
+The reloading timeouts if not finished under 1 second by default. To change the 
+setting:
+
+```ruby
+Elasticsearch::Client.new hosts: ['localhost:9200', 'localhost:9201'], sniffer_timeout: 3
+```
+
+NOTE: When using reloading hosts ("sniffing") together with authentication, pass 
+the scheme, user and password with the host info – or, for more clarity, in the 
+`http` options:
+
+[source,ruby]
+------------------------------------
+Elasticsearch::Client.new host: 'localhost:9200',
+                          http: { scheme: 'https', user: 'U', password: 'P' },
+                          reload_connections: true,
+                          reload_on_failure: true
+------------------------------------
+
+
+[[connection-selector]]
+=== Connection Selector
+
+By default, the client rotates the connections in a round-robin fashion, using 
+the {Elasticsearch::Transport::Transport::Connections::Selector::RoundRobin} 
+strategy.
+
+You can implement your own strategy to customize the behaviour. For example, 
+let's have a "rack aware" strategy, which prefers the nodes with a specific 
+attribute. The strategy uses the other nodes, only when these are unavailable:
+
+[source,ruby]
+------------------------------------
+class RackIdSelector
+  include Elasticsearch::Transport::Transport::Connections::Selector::Base
+
+  def select(options={})
+    connections.select do |c|
+      # Try selecting the nodes with a `rack_id:x1` attribute first
+      c.host[:attributes] && c.host[:attributes][:rack_id] == 'x1'
+    end.sample || connections.to_a.sample
+  end
+end
+
+Elasticsearch::Client.new hosts: ['x1.search.org', 'x2.search.org'], selector_class: RackIdSelector
+------------------------------------
+
+
+[[serializer-implementations]]
+=== Serializer Implementations
+
+By default, the https://rubygems.org/gems/multi_json[MultiJSON] library is used 
+as the serializer implementation, and it picks up the "right" adapter based on 
+gems available.
+
+The serialization component is pluggable, though, so you can write your own by 
+including the {Elasticsearch::Transport::Transport::Serializer::Base} module, 
+implementing the required contract, and passing it to the client as the 
+`serializer_class` or `serializer` parameter.
+
+
+[[exception-handling]]
+=== Exception Handling
+
+The library defines a 
+https://github.com/elastic/elasticsearch-ruby/blob/master/elasticsearch-transport/lib/elasticsearch/transport/transport/errors.rb[number of exception classes] 
+for various client and server errors, as well as unsuccessful HTTP responses, 
+making it possible to rescue specific exceptions with desired granularity.
+
+The highest-level exception is {Elasticsearch::Transport::Transport::Error} and 
+is raised for any generic client or server errors.
+
+{Elasticsearch::Transport::Transport::ServerError} is raised for server errors 
+only.
+
+As an example for response-specific errors, a 404 response status raises an 
+{Elasticsearch::Transport::Transport::Errors::NotFound} exception.
+
+Finally, {Elasticsearch::Transport::Transport::SnifferTimeoutError} is raised 
+when connection reloading ("sniffing") times out.

--- a/docs/advanced-config.asciidoc
+++ b/docs/advanced-config.asciidoc
@@ -4,7 +4,7 @@
 The client supports many configurations options for setting up and managing 
 connections, configuring logging, customizing the transport library, and so on.
 
-
+[discrete]
 [[setting-hosts]]
 ==== Setting hosts
 
@@ -55,6 +55,7 @@ The client is automatically round-robin across the hosts (unless you select or
 implement a different <<connection-selector>>).
 
 
+[discrete]
 [[default-port]]
 ==== Default port
 
@@ -66,6 +67,7 @@ your username and password separately, and optionally a port. Refer to
 <<auth-ec>>.
 
 
+[discrete]
 [[logging]]
 ==== Logging
 
@@ -120,6 +122,7 @@ client = Elasticsearch::Client.new(logger: log)
 ------------------------------------
 
 
+[discrete]
 [[apm-integration]]
 ==== APM integration
 
@@ -131,6 +134,7 @@ capture the body from requests in {es}. Refer to
 https://github.com/elastic/elasticsearch-ruby/tree/master/docs/examples/apm[this example].
 
 
+[discrete]
 [[custom-http-headers]]
 ==== Custom HTTP Headers
 
@@ -154,14 +158,15 @@ client.search(index: 'myindex', q: 'title:test', headers: {user_agent: "My App"}
 ```
 
 
+[discrete]
 [[x-opaque-id]]
 ==== Identifying running tasks with X-Opaque-Id
 
 The X-Opaque-Id header allows to track certain calls, or associate certain tasks 
 with the client that started them (refer to 
-{ref}/tasks.html#_identifying_running_tasks[the documentation]). To use this 
-feature, you need to set an id for `opaque_id` on the client on each request. 
-Example:
+https://www.elastic.co/guide/en/elasticsearch/reference/master/tasks.html#_identifying_running_tasks[the documentation]). 
+To use this feature, you need to set an id for `opaque_id` on the client on each 
+request. Example:
 
 [source,ruby]
 ------------------------------------
@@ -192,6 +197,7 @@ X-Opaque-Id: eu-west1_123456
 ```
 
 
+[discrete]
 [[setting-timeouts]]
 ==== Setting Timeouts
 
@@ -205,6 +211,7 @@ Elasticsearch::Client.new request_timeout: 5*60
 You can also use the `transport_options` argument documented below.
 
 
+[discrete]
 [[randomizing-hosts]]
 ==== Randomizing Hosts
 
@@ -219,6 +226,7 @@ Elasticsearch::Client.new hosts: ['localhost:9200', 'localhost:9201'], randomize
 ```
 
 
+[discrete]
 [[retry-failures]]
 ==== Retrying on Failures
 
@@ -250,14 +258,17 @@ These two parameters can also be used together:
 Elasticsearch::Client.new hosts: ['localhost:9200', 'localhost:9201'], retry_on_status: [502, 503], retry_on_failure: 10
 ```
 
+
+[discrete]
 [[reload-hosts]]
-=== Reloading Hosts
+==== Reloading Hosts
 
 {es} dynamically discovers new nodes in the cluster by default. You can leverage 
 this in the client, and periodically check for new nodes to spread the load.
 
 To retrieve and use the information from the 
-{ref}/cluster-nodes-info.html[Nodes Info API] on every 10,000th request:
+https://www.elastic.co/guide/en/elasticsearch/reference/current/cluster-nodes-info.html[Nodes Info API] 
+on every 10,000th request:
 
 ```ruby
 Elasticsearch::Client.new hosts: ['localhost:9200', 'localhost:9201'], reload_connections: true
@@ -296,8 +307,9 @@ Elasticsearch::Client.new host: 'localhost:9200',
 ------------------------------------
 
 
+[discrete]
 [[connection-selector]]
-=== Connection Selector
+==== Connection Selector
 
 By default, the client rotates the connections in a round-robin fashion, using 
 the {Elasticsearch::Transport::Transport::Connections::Selector::RoundRobin} 
@@ -324,8 +336,9 @@ Elasticsearch::Client.new hosts: ['x1.search.org', 'x2.search.org'], selector_cl
 ------------------------------------
 
 
+[discrete]
 [[serializer-implementations]]
-=== Serializer Implementations
+==== Serializer Implementations
 
 By default, the https://rubygems.org/gems/multi_json[MultiJSON] library is used 
 as the serializer implementation, and it picks up the "right" adapter based on 
@@ -337,8 +350,9 @@ implementing the required contract, and passing it to the client as the
 `serializer_class` or `serializer` parameter.
 
 
+[discrete]
 [[exception-handling]]
-=== Exception Handling
+==== Exception Handling
 
 The library defines a 
 https://github.com/elastic/elasticsearch-ruby/blob/master/elasticsearch-transport/lib/elasticsearch/transport/transport/errors.rb[number of exception classes] 

--- a/docs/advanced-config.asciidoc
+++ b/docs/advanced-config.asciidoc
@@ -51,8 +51,8 @@ Elasticsearch::Client.new(urls: 'http://localhost:9200,http://localhost:9201')
 
 Another way to configure URLs is to export the `ELASTICSEARCH_URL` variable.
 
-The client is automatically going to use a round-robin algorithm across the hosts (unless you select or 
-implement a different <<connection-selector>>).
+The client is automatically going to use a round-robin algorithm across the 
+hosts (unless you select or implement a different <<connection-selector>>).
 
 
 [discrete]
@@ -78,9 +78,10 @@ instance of Ruby's `::Logger` class), set the log argument to true:
 Elasticsearch::Client.new(log: true)
 ```
 
-You can also use `ecs-logging` which is a set of libraries that enables you to 
-transform your application logs to structured logs that comply with the Elastic 
-Common Schema (ECS):
+You can also use https://github.com/elastic/ecs-logging-ruby[`ecs-logging`] 
+which is a set of libraries that enables you to transform your application logs 
+to structured logs that comply with the 
+https://www.elastic.co/guide/en/ecs/current/ecs-reference.html[Elastic Common Schema (ECS)]:
 
 [source,ruby]
 ------------------------------------

--- a/docs/advanced-config.asciidoc
+++ b/docs/advanced-config.asciidoc
@@ -11,25 +11,25 @@ connections, configuring logging, customizing the transport library, and so on.
 To connect to a specific {es} host:
 
 ```ruby
-Elasticsearch::Client.new host: 'search.myserver.com'
+Elasticsearch::Client.new(host: 'search.myserver.com')
 ```
 
 To connect to a host with specific port:
 
 ```ruby
-Elasticsearch::Client.new host: 'myhost:8080'
+Elasticsearch::Client.new(host: 'myhost:8080')
 ```
 
 To connect to multiple hosts:
 
 ```ruby
-Elasticsearch::Client.new hosts: ['myhost1', 'myhost2']
+Elasticsearch::Client.new(hosts: ['myhost1', 'myhost2'])
 ```
 
 Instead of strings, you can pass host information as an array of Hashes:
 
 ```ruby
-Elasticsearch::Client.new hosts: [ { host: 'myhost1', port: 8080 }, { host: 'myhost2', port: 8080 } ]
+Elasticsearch::Client.new(hosts: [ { host: 'myhost1', port: 8080 }, { host: 'myhost2', port: 8080 } ])
 ```
 
 NOTE: When specifying multiple hosts, you probably want to enable the 
@@ -40,18 +40,18 @@ Common URL parts – scheme, HTTP authentication credentials, URL prefixes, and 
 on – are handled automatically:
 
 ```ruby
-Elasticsearch::Client.new url: 'https://username:password@api.server.org:4430/search'
+Elasticsearch::Client.new(url: 'https://username:password@api.server.org:4430/search')
 ```
 
 You can pass multiple URLs separated by a comma:
 
 ```ruby
-Elasticsearch::Client.new urls: 'http://localhost:9200,http://localhost:9201'
+Elasticsearch::Client.new(urls: 'http://localhost:9200,http://localhost:9201')
 ```
 
 Another way to configure URLs is to export the `ELASTICSEARCH_URL` variable.
 
-The client is automatically round-robin across the hosts (unless you select or 
+The client is automatically going to use a round-robin algorithm across the hosts (unless you select or 
 implement a different <<connection-selector>>).
 
 
@@ -72,7 +72,7 @@ your username and password separately, and optionally a port. Refer to
 ==== Logging
 
 To log requests and responses to standard output with the default logger (an 
-instance of Ruby's {::Logger} class), set the log argument to true:
+instance of Ruby's `::Logger` class), set the log argument to true:
 
 ```ruby
 Elasticsearch::Client.new(log: true)
@@ -205,7 +205,7 @@ For many operations in {es}, the default timeouts of HTTP libraries are too low.
 To increase the timeout, you can use the `request_timeout` parameter:
 
 ```ruby
-Elasticsearch::Client.new request_timeout: 5*60
+Elasticsearch::Client.new(request_timeout: 5*60)
 ```
 
 You can also use the `transport_options` argument documented below.
@@ -222,7 +222,7 @@ keep connecting to the same nodes "at once". To prevent this, you can randomize
 the hosts collection on initialization and reloading:
 
 ```ruby
-Elasticsearch::Client.new hosts: ['localhost:9200', 'localhost:9201'], randomize_hosts: true
+Elasticsearch::Client.new(hosts: ['localhost:9200', 'localhost:9201'], randomize_hosts: true)
 ```
 
 
@@ -234,7 +234,7 @@ When the client is initialized with multiple hosts, it makes sense to retry a
 failed request on a different host:
 
 ```ruby
-Elasticsearch::Client.new hosts: ['localhost:9200', 'localhost:9201'], retry_on_failure: true
+Elasticsearch::Client.new(hosts: ['localhost:9200', 'localhost:9201'], retry_on_failure: true)
 ```
 
 By default, the client retries the request 3 times. You can specify how many 
@@ -242,20 +242,20 @@ times to retry before it raises an exception by passing a number to
 `retry_on_failure`:
 
 ```ruby
-Elasticsearch::Client.new hosts: ['localhost:9200', 'localhost:9201'], retry_on_failure: 5
+ Elasticsearch::Client.new(hosts: ['localhost:9200', 'localhost:9201'], retry_on_failure: 5)
 ```
 
 You can also use `retry_on_status` to retry when specific status codes are 
 returned:
 
 ```ruby
-Elasticsearch::Client.new hosts: ['localhost:9200', 'localhost:9201'], retry_on_status: [502, 503]
+Elasticsearch::Client.new(hosts: ['localhost:9200', 'localhost:9201'], retry_on_status: [502, 503])
 ```
 
 These two parameters can also be used together:
 
 ```ruby
-Elasticsearch::Client.new hosts: ['localhost:9200', 'localhost:9201'], retry_on_status: [502, 503], retry_on_failure: 10
+Elasticsearch::Client.new(hosts: ['localhost:9200', 'localhost:9201'], retry_on_status: [502, 503], retry_on_failure: 10)
 ```
 
 
@@ -271,27 +271,27 @@ https://www.elastic.co/guide/en/elasticsearch/reference/current/cluster-nodes-in
 on every 10,000th request:
 
 ```ruby
-Elasticsearch::Client.new hosts: ['localhost:9200', 'localhost:9201'], reload_connections: true
+Elasticsearch::Client.new(hosts: ['localhost:9200', 'localhost:9201'], reload_connections: true)
 ```
 
 You can pass a specific number of requests after which reloading should be 
 performed:
 
 ```ruby
-Elasticsearch::Client.new hosts: ['localhost:9200', 'localhost:9201'], reload_connections: 1_000
+Elasticsearch::Client.new(hosts: ['localhost:9200', 'localhost:9201'], reload_connections: 1_000)
 ```
 
 To reload connections on failures, use:
 
 ```ruby
-Elasticsearch::Client.new hosts: ['localhost:9200', 'localhost:9201'], reload_on_failure: true
+Elasticsearch::Client.new(hosts: ['localhost:9200', 'localhost:9201'], reload_on_failure: true)
 ```
 
 The reloading timeouts if not finished under 1 second by default. To change the 
 setting:
 
 ```ruby
-Elasticsearch::Client.new hosts: ['localhost:9200', 'localhost:9201'], sniffer_timeout: 3
+Elasticsearch::Client.new(hosts: ['localhost:9200', 'localhost:9201'], sniffer_timeout: 3)
 ```
 
 NOTE: When using reloading hosts ("sniffing") together with authentication, pass 
@@ -300,10 +300,12 @@ the scheme, user and password with the host info – or, for more clarity, in th
 
 [source,ruby]
 ------------------------------------
-Elasticsearch::Client.new host: 'localhost:9200',
-                          http: { scheme: 'https', user: 'U', password: 'P' },
-                          reload_connections: true,
-                          reload_on_failure: true
+Elasticsearch::Client.new(
+  host: 'localhost:9200',
+  http: { scheme: 'https', user: 'U', password: 'P' },
+  reload_connections: true,
+  reload_on_failure: true
+)
 ------------------------------------
 
 
@@ -312,7 +314,7 @@ Elasticsearch::Client.new host: 'localhost:9200',
 ==== Connection Selector
 
 By default, the client rotates the connections in a round-robin fashion, using 
-the {Elasticsearch::Transport::Transport::Connections::Selector::RoundRobin} 
+the `Elasticsearch::Transport::Transport::Connections::Selector::RoundRobin` 
 strategy.
 
 You can implement your own strategy to customize the behaviour. For example, 
@@ -345,7 +347,7 @@ as the serializer implementation, and it picks up the "right" adapter based on
 gems available.
 
 The serialization component is pluggable, though, so you can write your own by 
-including the {Elasticsearch::Transport::Transport::Serializer::Base} module, 
+including the `Elasticsearch::Transport::Transport::Serializer::Base` module, 
 implementing the required contract, and passing it to the client as the 
 `serializer_class` or `serializer` parameter.
 
@@ -359,14 +361,14 @@ https://github.com/elastic/elasticsearch-ruby/blob/master/elasticsearch-transpor
 for various client and server errors, as well as unsuccessful HTTP responses, 
 making it possible to rescue specific exceptions with desired granularity.
 
-The highest-level exception is {Elasticsearch::Transport::Transport::Error} and 
+The highest-level exception is `Elasticsearch::Transport::Transport::Error` and 
 is raised for any generic client or server errors.
 
-{Elasticsearch::Transport::Transport::ServerError} is raised for server errors 
+`Elasticsearch::Transport::Transport::ServerError` is raised for server errors 
 only.
 
 As an example for response-specific errors, a 404 response status raises an 
-{Elasticsearch::Transport::Transport::Errors::NotFound} exception.
+`Elasticsearch::Transport::Transport::Errors::NotFound` exception.
 
-Finally, {Elasticsearch::Transport::Transport::SnifferTimeoutError} is raised 
+Finally, `Elasticsearch::Transport::Transport::SnifferTimeoutError` is raised 
 when connection reloading ("sniffing") times out.

--- a/docs/basic-config.asciidoc
+++ b/docs/basic-config.asciidoc
@@ -1,48 +1,36 @@
 [[basic-config]]
 === Basic configuration
 
+The table below contains the most important initialization parameters that you 
+can use.
+
+
 [cols="<,<,<"]
 |===
-| Parameter          | Data type       | Description
-| hosts              | String, Array   | Single host passed as a String or Hash, or multiple hosts passed as an Array; `host` or `url` keys are also valid.
-| log                | Boolean         | Use the default logger (disabled by default).
-| trace              | Boolean         | Use the default tracer (disabled by default).
-| logger             | Object          | An instance of a Logger-compatible object.
-| tracer             | Object          | An instance of a Logger-compatible object.
-| resurrect_after    | Number          | After how many seconds a dead connection should be tried again.
-| reload_connections | Boolean, Number | Reload connections after X requests (false by default).
-| randomize_hosts    | Boolean         | Shuffle connections on initialization and reload (false by default).
-|  |  |
-|  |  |
-|  |  |
-|  |  |
-|  |  |
-|  |  |
-|  |  |
-|  |  |
-|  |  |
-|  |  |
-|  |  |
-|  |  |
-|  |  |
-|  |  |
-|  |  |
 
-
- 
-[Integer] :sniffer_timeout   Timeout for reloading connections in seconds (1 by default)
-[Boolean,Number] :retry_on_failure   Retry X times when request fails before raising and exception (false by default)
-Array<Number> :retry_on_status Retry when specific status codes are returned
-[Boolean] :reload_on_failure Reload connections after failure (false by default)
-[Integer] :request_timeout The request timeout to be passed to transport in options
-[Symbol] :adapter A specific adapter for Faraday (e.g. `:patron`)
-[Hash] :transport_options Options to be passed to the `Faraday::Connection` constructor
-[Constant] :transport_class  A specific transport class to use, will be initialized by the client and passed hosts and all arguments
-[Object] :transport A specific transport instance
-[Constant] :serializer_class A specific serializer class to use, will be initialized by the transport and passed the transport instance
-[Constant] :selector An instance of selector strategy implemented with {Elasticsearch::Transport::Transport::Connections::Selector::Base}.
-[String] :send_get_body_as Specify the HTTP method to use for GET requests with a body. (Default: GET)
-[true, false] :compression Whether to compress requests. Gzip compression will be used. The default is false. Responses will automatically be inflated if they are compressed. If a custom transport object is used, it must handle the request compression and response inflation.
-[String, Hash] :api_key Use API Key Authentication, either the base64 encoding of `id` and `api_key` joined by a colon as a String, or a hash with the `id` and `api_key` values.
-[String] :opaque_id_prefix set a prefix for X-Opaque-Id when initializing the client. This will be prepended to the id you set before each request if you're using X-Opaque-Id
-[Boolean] :enable_meta_header Enable sending the meta data header to Cloud. (Default: true)
+| **Parameter**        | **Data type**   | **Description**
+| `adapter`            | Symbol          | A specific adapter for Faraday (for example, `:patron`).
+| `api_key`            | String, Hash    | For API key Authentication. Either the base64 encoding of `id` and `api_key` joined by a colon as a string, or a hash with the `id` and `api_key` values.
+| `compression`        | Boolean         | Whether to compress requests. Gzip compression is used. Defaults to `false`. Responses are automatically inflated if they are compressed. If a custom transport object is used, it must handle the request compression and response inflation.
+| `enable_meta_header` | Boolean         | Whether to enable sending the meta data header to Cloud. Defaults to `true`.
+| `hosts`              | String, Array   | Single host passed as a string or hash, or multiple hosts passed as an array; `host` or `url` keys are also valid.
+| `log`                | Boolean         | Whether to use the default logger. Disabled by default.
+| `logger`             | Object          | An instance of a Logger-compatible object.
+| `opaque_id_prefix`   | String          | Sets a prefix for X-Opaque-Id when initializing the client. This is prepended to the id you set before each request if you're using X-Opaque-Id.
+| `randomize_hosts`    | Boolean         | Whether to shuffle connections on initialization and reload. Defaults to `false`.
+| `reload_connections` | Boolean, Number | Whether to reload connections after X requests. Defaults to `false`.
+| `reload_on_failure`  | Boolean         | Whether to reload connections after failure. Defaults to `false`.
+| `request_timeout`    | Integer         | The request timeout to be passed to transport in options.
+| `resurrect_after`    | Integer         | Specifies after how many seconds a dead connection should be tried again.
+| `retry_on_failure`   | Boolean, Number | Whether to retry X times when request fails before raising and exception. Defaults to `false`.
+| `retry_on_status`    | Array, Number   | Specifies which status code needs to be returned to retry.
+| `selector`           | Constant        | An instance of selector strategy implemented with {Elasticsearch::Transport::Transport::Connections::Selector::Base}.
+| `send_get_body_as`   | String          | Specifies the HTTP method to use for GET requests with a body. Defaults to `GET`.
+| `serializer_class`   | Constant        | Specifies a serializer class to use. It is initialized by the transport and passed the transport instance.
+| `sniffer_timeout`    | Integer         | Specifieds the timeout for reloading connections in seconds. Defaults to `1`.
+| `trace`              | Boolean         | Whether to use the default tracer. Disabled by default.
+| `tracer`             | Object          | Specifies an instance of a Logger-compatible object.
+| `transport`          | Object          | Specifies a transport instance.
+| `transport_class`    | Constant        | Specifies a transport class to use. It is initialized by the client and passed hosts and all arguments.
+| `transport_options`  | Hash            | Specifies the options to be passed to the `Faraday::Connection` constructor.
+|===

--- a/docs/basic-config.asciidoc
+++ b/docs/basic-config.asciidoc
@@ -1,0 +1,48 @@
+[[basic-config]]
+=== Basic configuration
+
+[cols="<,<,<"]
+|===
+| Parameter          | Data type       | Description
+| hosts              | String, Array   | Single host passed as a String or Hash, or multiple hosts passed as an Array; `host` or `url` keys are also valid.
+| log                | Boolean         | Use the default logger (disabled by default).
+| trace              | Boolean         | Use the default tracer (disabled by default).
+| logger             | Object          | An instance of a Logger-compatible object.
+| tracer             | Object          | An instance of a Logger-compatible object.
+| resurrect_after    | Number          | After how many seconds a dead connection should be tried again.
+| reload_connections | Boolean, Number | Reload connections after X requests (false by default).
+| randomize_hosts    | Boolean         | Shuffle connections on initialization and reload (false by default).
+|  |  |
+|  |  |
+|  |  |
+|  |  |
+|  |  |
+|  |  |
+|  |  |
+|  |  |
+|  |  |
+|  |  |
+|  |  |
+|  |  |
+|  |  |
+|  |  |
+|  |  |
+
+
+ 
+[Integer] :sniffer_timeout   Timeout for reloading connections in seconds (1 by default)
+[Boolean,Number] :retry_on_failure   Retry X times when request fails before raising and exception (false by default)
+Array<Number> :retry_on_status Retry when specific status codes are returned
+[Boolean] :reload_on_failure Reload connections after failure (false by default)
+[Integer] :request_timeout The request timeout to be passed to transport in options
+[Symbol] :adapter A specific adapter for Faraday (e.g. `:patron`)
+[Hash] :transport_options Options to be passed to the `Faraday::Connection` constructor
+[Constant] :transport_class  A specific transport class to use, will be initialized by the client and passed hosts and all arguments
+[Object] :transport A specific transport instance
+[Constant] :serializer_class A specific serializer class to use, will be initialized by the transport and passed the transport instance
+[Constant] :selector An instance of selector strategy implemented with {Elasticsearch::Transport::Transport::Connections::Selector::Base}.
+[String] :send_get_body_as Specify the HTTP method to use for GET requests with a body. (Default: GET)
+[true, false] :compression Whether to compress requests. Gzip compression will be used. The default is false. Responses will automatically be inflated if they are compressed. If a custom transport object is used, it must handle the request compression and response inflation.
+[String, Hash] :api_key Use API Key Authentication, either the base64 encoding of `id` and `api_key` joined by a colon as a String, or a hash with the `id` and `api_key` values.
+[String] :opaque_id_prefix set a prefix for X-Opaque-Id when initializing the client. This will be prepended to the id you set before each request if you're using X-Opaque-Id
+[Boolean] :enable_meta_header Enable sending the meta data header to Cloud. (Default: true)

--- a/docs/config.asciidoc
+++ b/docs/config.asciidoc
@@ -1,0 +1,9 @@
+[[ruby-config]]
+== Configuration
+
+This page contains information about how to configure the Ruby client tailored 
+to your needs. Almost every aspect of the client is configurable. However, in 
+most cases you only need to set a couple of parameters.
+
+* <<basic-config>>
+* <<advanced-config>>

--- a/docs/config.asciidoc
+++ b/docs/config.asciidoc
@@ -6,4 +6,3 @@ to your needs. Almost every aspect of the client is configurable. However, in
 most cases you only need to set a couple of parameters.
 
 * <<basic-config>>
-* <<advanced-config>>

--- a/docs/config.asciidoc
+++ b/docs/config.asciidoc
@@ -6,3 +6,4 @@ to your needs. Almost every aspect of the client is configurable. However, in
 most cases you only need to set a couple of parameters.
 
 * <<basic-config>>
+* <<advanced-config>>

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -14,6 +14,8 @@ include::config.asciidoc[]
 
 include::basic-config.asciidoc[]
 
+include::advanced-config.asciidoc[]
+
 include::model.asciidoc[]
 
 include::rails.asciidoc[]

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -10,6 +10,10 @@ include::installation.asciidoc[]
 
 include::connecting.asciidoc[]
 
+include::config.asciidoc[]
+
+include::basic-config.asciidoc[]
+
 include::model.asciidoc[]
 
 include::rails.asciidoc[]


### PR DESCRIPTION
## Overview

This PR opens a `Configuration` section in the Ruby client documentation book. It contains basic and advanced configuration options.

This PR is part of the Client docs redesign effort. Related issue: https://github.com/elastic/clients-team/issues/257

### Preview

[Ruby TOC](https://elasticsearch-ruby_1182.docs-preview.app.elstc.co/guide/en/elasticsearch/client/ruby-api/master/index.html)