### PR TITLE
[CLIENT] When version is pre/alpha, use X.X.Xp for meta header version

### DIFF
--- a/elasticsearch-transport/lib/elasticsearch/transport/client.rb
+++ b/elasticsearch-transport/lib/elasticsearch/transport/client.rb
@@ -226,10 +226,18 @@ module Elasticsearch
         if defined?(Elastic::META_HEADER_SERVICE_VERSION)
           Elastic::META_HEADER_SERVICE_VERSION
         elsif defined?(Elasticsearch::VERSION)
-          ['es', Elasticsearch::VERSION]
+          [:es, client_meta_version(Elasticsearch::VERSION)]
         else
-          ['es', Elasticsearch::Transport::VERSION]
+          [:es, client_meta_version(Elasticsearch::Transport::VERSION)]
         end
+      end
+
+      def client_meta_version(version)
+        regexp = /^([0-9]+\.[0-9]+\.[0-9]+)(\.?[a-z0-9.-]+)?$/
+        match = version.match(regexp)
+        return "#{match[1]}p" if (match[2])
+
+        version
       end
 
       def meta_header_engine

--- a/elasticsearch/lib/elasticsearch.rb
+++ b/elasticsearch/lib/elasticsearch.rb
@@ -28,6 +28,15 @@ module Elasticsearch
   end
 end
 module Elastic
+  # If the version is X.X.X.pre/alpha/beta, use X.X.Xp for the meta-header:
+  def self.client_meta_version
+    regexp = /^([0-9]+\.[0-9]+\.[0-9]+)\.?([a-z0-9.-]+)?$/
+    match = Elasticsearch::VERSION.match(regexp)
+    return "#{match[1]}p" if match[2]
+
+    Elasticsearch::VERSION
+  end
+
   # Constant for elasticsearch-transport meta-header
-  META_HEADER_SERVICE_VERSION = [:es, Elasticsearch::VERSION]
+  META_HEADER_SERVICE_VERSION = [:es, client_meta_version].freeze
 end


### PR DESCRIPTION
Backports #1188