### PR TITLE
[CLIENT] Meta header: support unknown faraday adapters

### DIFF
--- a/elasticsearch-transport/lib/elasticsearch/transport/client.rb
+++ b/elasticsearch-transport/lib/elasticsearch/transport/client.rb
@@ -265,6 +265,8 @@ module Elasticsearch
               {hc: HTTPClient::VERSION}
             when :net_http_persistent
               {np: Net::HTTP::Persistent::VERSION}
+            else
+              {}
             end
           )
         elsif defined?(Transport::HTTP::Curb) && @transport_class == Transport::HTTP::Curb

--- a/elasticsearch-transport/spec/elasticsearch/transport/meta_header_spec.rb
+++ b/elasticsearch-transport/spec/elasticsearch/transport/meta_header_spec.rb
@@ -150,6 +150,17 @@ describe Elasticsearch::Transport::Client do
           end
         end
       end
+
+      context 'using other' do
+        let(:adapter) { :some_other_adapter }
+
+        it 'sets adapter in the meta header' do
+          require 'net/http/persistent'
+          Faraday::Adapter.register_middleware some_other_adapter: Faraday::Adapter::NetHttpPersistent
+          expect(headers['x-elastic-client-meta']).to match(regexp)
+          expect(headers).to include('x-elastic-client-meta' => meta_header)
+        end
+      end
     end
 
     if defined?(JRUBY_VERSION)


### PR DESCRIPTION
The adapter detection in the client meta header code introduced in PR #1135 fails on unknown faraday adapters:

    TypeError: no implicit conversion of nil into Hash
    ./lib/elasticsearch/transport/client.rb:256:in `merge'
    ./lib/elasticsearch/transport/client.rb:256:in `meta_header_adapter'
    ./lib/elasticsearch/transport/client.rb:218:in `set_meta_header'
    ./lib/elasticsearch/transport/client.rb:166:in `initialize'

The PR contains a fix to ignore such adapters and simply does not add any version info to the meta header.

As a workaround until fix has been released: The meta header can be disabled using  `enable_meta_header: false` in the client options.