### PR TITLE
[CI] Drops support for 2.5 in master since it is EOL 31/03

### DIFF
--- a/.ci/test-matrix.yml
+++ b/.ci/test-matrix.yml
@@ -6,7 +6,6 @@ RUBY_TEST_VERSION:
 - 3.0.0
 - 2.7.2
 - 2.6.6
-- 2.5.8
 
 TEST_SUITE:
 - free

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: [ 2.5, 2.6, 2.7, 3.0, jruby-9.2 ]
+        ruby: [ 2.6, 2.7, 3.0, jruby-9.2 ]
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
We won't test against Ruby 2.5 in 8.0 since it's EOL on March 31st.