### PR TITLE
[DOCS] Adds Integrations section to Ruby book

### DIFF
--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -16,10 +16,6 @@ include::basic-config.asciidoc[]
 
 include::advanced-config.asciidoc[]
 
-include::model.asciidoc[]
-
-include::rails.asciidoc[]
-
-include::persistence.asciidoc[]
+include::integrations.asciidoc[]
 
 include::release_notes/index.asciidoc[]

--- a/docs/integrations.asciidoc
+++ b/docs/integrations.asciidoc
@@ -1,0 +1,18 @@
+[[integrations]]
+== Integrations
+
+The Rubygems listed on this page make it easier to operate with {es} by using 
+the Ruby client.
+
+* <<transport>>
+* <<activemodel_activerecord>>
+* <<ruby_on_rails>>
+* <<persistence>>
+
+include::transport.asciidoc[]
+
+include::model.asciidoc[]
+
+include::rails.asciidoc[]
+
+include::persistence.asciidoc[]

--- a/docs/model.asciidoc
+++ b/docs/model.asciidoc
@@ -1,14 +1,16 @@
 [[activemodel_activerecord]]
-== ActiveModel / ActiveRecord
+=== ActiveModel / ActiveRecord
 
 The `elasticsearch-model` http://rubygems.org/gems/elasticsearch-model[Rubygem]
-provides integration with Ruby domain objects ("models"), commonly found e.g. in Ruby on Rails applications.
+provides integration with Ruby domain objects ("models"), commonly found for 
+example, in Ruby on Rails applications.
 
-It uses the `elasticsearch` Rubygem as the client communicating with the Elasticsearch cluster.
+It uses the `elasticsearch` Rubygem as the client communicating with the {es} 
+cluster.
 
 
 [discrete]
-=== Features
+==== Features
 
 * ActiveModel integration with adapters for ActiveRecord and Mongoid
 * Enumerable-based wrapper for search results
@@ -20,7 +22,7 @@ It uses the `elasticsearch` Rubygem as the client communicating with the Elastic
 
 
 [discrete]
-=== Usage
+==== Usage
 
 Add the library to your Gemfile:
 
@@ -49,8 +51,8 @@ response.took
 # => 3
 ------------------------------------
 
-It is possible to either return results as model instances, or decorated documents from Elasticsearch,
-with the `records` and `results` methods, respectively:
+It is possible to either return results as model instances, or decorated 
+documents from {es}, with the `records` and `results` methods, respectively:
 
 [source,ruby]
 ------------------------------------
@@ -65,5 +67,6 @@ response.results.first._source.title
 # => "Quick brown fox"
 ------------------------------------
 
-Please see the full https://github.com/elastic/elasticsearch-rails/tree/master/elasticsearch-model[documentation]
+Consult the 
+https://github.com/elastic/elasticsearch-rails/tree/master/elasticsearch-model[documentation]
 for more information.

--- a/docs/persistence.asciidoc
+++ b/docs/persistence.asciidoc
@@ -1,33 +1,37 @@
 [[persistence]]
-== Persistence
+=== Persistence
 
-The `elasticsearch-persistence` http://rubygems.org/gems/elasticsearch-persistence[Rubygem]
-provides persistence layer for Ruby domain objects.
+The `elasticsearch-persistence` 
+http://rubygems.org/gems/elasticsearch-persistence[Rubygem] provides persistence 
+layer for Ruby domain objects.
 
-It supports the repository design patterns. Versions before 6.0 also supported the _active record_ design pattern.
-
-
-[discrete]
-=== Repository
-
-The `Elasticsearch::Persistence::Repository` module provides an implementation of the repository pattern and allows to save, delete, find and search objects stored in Elasticsearch, as well as configure mappings and settings for the index.
+It supports the repository design patterns. Versions before 6.0 also supported 
+the _active record_ design pattern.
 
 
 [discrete]
-==== Features
+==== Repository
 
-* Access to the Elasticsearch client
+The `Elasticsearch::Persistence::Repository` module provides an implementation 
+of the repository pattern and allows to save, delete, find and search objects 
+stored in {es}, as well as configure mappings and settings for the index.
+
+
+[discrete]
+===== Features
+
+* Access to the {es} client
 * Setting the index name, document type, and object class for deserialization
 * Composing mappings and settings for the index
 * Creating, deleting or refreshing the index
 * Finding or searching for documents
 * Providing access both to domain objects and hits for search results
-* Providing access to the Elasticsearch response for search results (aggregations, total, ...)
+* Providing access to the {es} response for search results
 * Defining the methods for serialization and deserialization
 
 
 [discrete]
-==== Usage
+===== Usage
 
 Let's have a simple plain old Ruby object (PORO):
 
@@ -46,7 +50,7 @@ class Note
 end
 ------------------------------------
 
-Let's create a default, "dumb" repository, as a first step:
+Create a default, "dumb" repository, as a first step:
 
 [source,ruby]
 ------------------------------------
@@ -55,7 +59,7 @@ class MyRepository; include Elasticsearch::Persistence::Repository; end
 repository = MyRepository.new
 ------------------------------------
 
-We can save a `Note` instance into the repository...
+Save a `Note` instance into the repository:
 
 [source,ruby]
 ------------------------------------
@@ -67,7 +71,7 @@ repository.save(note)
 # < {"_index":"repository","_type":"note","_id":"1","_version":1,"created":true}
 ------------------------------------
 
-...find it...
+Find it:
 
 [source,ruby]
 ------------------------------------
@@ -77,7 +81,7 @@ n = repository.find(1)
 => <Note:0x007fcbfc0c4980 @attributes={"id"=>1, "text"=>"Test"}>
 ------------------------------------
 
-...search for it...
+Search for it:
 
 [source,ruby]
 ------------------------------------
@@ -88,7 +92,7 @@ repository.search(query: { match: { text: 'test' } }).first
 => <Note:0x007fcbfc1c7b70 @attributes={"id"=>1, "text"=>"Test"}>
 ------------------------------------
 
-...or delete it:
+Delete it:
 
 [source,ruby]
 ------------------------------------
@@ -98,12 +102,15 @@ repository.delete(note)
 => {"found"=>true, "_index"=>"repository", "_type"=>"note", "_id"=>"1", "_version"=>2}
 ------------------------------------
 
-The repository module provides a number of features and facilities to configure and customize the behaviour,
-as well as support for extending your own, custom repository class.
+The repository module provides a number of features and facilities to configure 
+and customize the behaviour, as well as support for extending your own, custom 
+repository class.
 
 Please refer to the
 https://github.com/elastic/elasticsearch-rails/tree/master/elasticsearch-persistence#the-repository-pattern[documentation]
 for more information.
 
 Also, check out the
-https://github.com/elastic/elasticsearch-rails/tree/master/elasticsearch-persistence#example-application[example application] which demonstrates the usage patterns of the _repository_ approach to persistence.
+https://github.com/elastic/elasticsearch-rails/tree/master/elasticsearch-persistence#example-application[example application] 
+which demonstrates the usage patterns of the _repository_ approach to 
+persistence.

--- a/docs/rails.asciidoc
+++ b/docs/rails.asciidoc
@@ -1,12 +1,12 @@
 [[ruby_on_rails]]
-== Ruby On Rails
+=== Ruby On Rails
 
 The `elasticsearch-rails` http://rubygems.org/gems/elasticsearch-rails[Rubygem]
 provides features suitable for Ruby on Rails applications.
 
 
 [discrete]
-=== Features
+==== Features
 
 * Rake tasks for importing data from application models
 * Integration with Rails' instrumentation framework
@@ -14,8 +14,11 @@ provides features suitable for Ruby on Rails applications.
 
 
 [discrete]
-=== Example applications
+==== Example applications
 
-You can generate a fully working example Ruby on Rails application with templates provides.
+You can generate a fully working example Ruby on Rails application with 
+templates provides.
 
-Please refer to the https://github.com/elastic/elasticsearch-rails/tree/master/elasticsearch-rails[documentation] for more information.
+Please refer to the 
+https://github.com/elastic/elasticsearch-rails/tree/master/elasticsearch-rails[documentation] 
+for more information.

--- a/docs/transport.asciidoc
+++ b/docs/transport.asciidoc
@@ -1,0 +1,5 @@
+[[transport]]
+=== Transport
+
+This pages is about how the Ruby client handles communication with an {es} 
+cluster.

--- a/docs/transport.asciidoc
+++ b/docs/transport.asciidoc
@@ -14,15 +14,6 @@ It does not handle calling the {es} API.
 The library is compatible with Ruby 1.9 or higher and with all versions of {es} 
 since 0.90.
 
-Feature overview:
-
-* Pluggable logging and tracing
-* Pluggable connection selection strategies (round-robin, random, custom)
-* Pluggable transport implementation, customizable and extendable
-* Pluggable serializer implementation
-* Request retries and dead connections handling
-* Node reloading (based on cluster state) on errors or on demand
-
 For optimal performance, use a HTTP library which supports persistent 
 ("keep-alive") connections, such as https://github.com/toland/patron[patron] or 
 https://github.com/typhoeus/typhoeus[Typhoeus]. Require the library 

--- a/docs/transport.asciidoc
+++ b/docs/transport.asciidoc
@@ -215,3 +215,39 @@ You can write your own transport implementation by including the
 {Elasticsearch::Transport::Transport::Base} module, implementing the required 
 contract, and passing it to the client as the `transport_class` parameter – or 
 by injecting it directly.
+
+[discrete]
+[[transport-architecture]]
+==== Transport architecture
+
+* `Elasticsearch::Transport::Client` is composed of 
+  `Elasticsearch::Transport::Transport`.
+
+* `Elasticsearch::Transport::Transport` is composed of 
+  `Elasticsearch::Transport::Transport::Connections`, and an instance of logger, 
+  tracer, serializer and sniffer.
+
+* Logger and tracer can be any object conforming to Ruby logging interface, for 
+  example, an instance of 
+  https://ruby-doc.org/stdlib-1.9.3/libdoc/logger/rdoc/Logger.html[`Logger`], 
+  https://rubygems.org/gems/log4r[log4r], 
+  https://github.com/TwP/logging/[logging], and so on.
+
+* The `Elasticsearch::Transport::Transport::Serializer::Base` implementations 
+  handle converting data for {es} (for example, to JSON). You can implement your 
+  own serializer.
+
+* `Elasticsearch::Transport::Transport::Sniffer` allows to discover nodes in the 
+  cluster and use them as connections.
+
+* `Elasticsearch::Transport::Transport::Connections::Collection` is composed of 
+  `Elasticsearch::Transport::Transport::Connections::Connection` instances and a 
+  selector instance.
+
+* `Elasticsearch::Transport::Transport::Connections::Connection` contains the 
+  connection attributes such as hostname and port, as well as the concrete 
+  persistent "session" connected to a specific node.
+
+* The `Elasticsearch::Transport::Transport::Connections::Selector::Base` 
+  implementations allow to choose connections from the pool, for example, in a 
+  round-robin or random fashion. You can implement your own selector strategy.

--- a/docs/transport.asciidoc
+++ b/docs/transport.asciidoc
@@ -1,5 +1,226 @@
 [[transport]]
 === Transport
 
-This pages is about how the Ruby client handles communication with an {es} 
-cluster.
+The `elasticsearch-transport` library provides a low-level Ruby client for 
+connecting to an {es} cluster.
+
+It handles connecting to multiple nodes in the cluster, rotating across 
+connections, logging and tracing requests and responses, maintaining failed 
+connections, discovering nodes in the cluster, and provides an abstraction for 
+data serialization and transport.
+
+It does not handle calling the {es} API.
+
+The library is compatible with Ruby 1.9 or higher and with all versions of {es} 
+since 0.90.
+
+Feature overview:
+
+* Pluggable logging and tracing
+* Pluggable connection selection strategies (round-robin, random, custom)
+* Pluggable transport implementation, customizable and extendable
+* Pluggable serializer implementation
+* Request retries and dead connections handling
+* Node reloading (based on cluster state) on errors or on demand
+
+For optimal performance, use a HTTP library which supports persistent 
+("keep-alive") connections, such as https://github.com/toland/patron[patron] or 
+https://github.com/typhoeus/typhoeus[Typhoeus]. Require the library 
+(require 'patron') in your code, and it will be automatically used.
+
+
+[discrete]
+[[transport-install]]
+==== Installation
+
+Install the package from https://rubygems.org/[Rubygems]:
+
+```
+gem install elasticsearch-transport
+```
+
+To use an unreleased version, either add it to your `Gemfile` for 
+http://gembundler.com/[Bundler]:
+
+```
+gem 'elasticsearch-transport', git: 'git://github.com/elasticsearch/elasticsearch-ruby.git'
+```
+
+or install it from a source code checkout:
+
+```
+git clone https://github.com/elasticsearch/elasticsearch-ruby.git
+cd elasticsearch-ruby/elasticsearch-transport
+bundle install
+rake install
+```
+
+
+[discrete]
+[[transport-example-usage]]
+==== Example usage
+
+In the simplest form, connect to {es} running on http://localhost:9200 without 
+any configuration:
+
+```ruby
+require 'elasticsearch/transport'
+
+client = Elasticsearch::Client.new
+response = client.perform_request 'GET', '_cluster/health'
+# => #<Elasticsearch::Transport::Transport::Response:0x007fc5d506ce38 @status=200, @body={ ... } >
+```
+
+Full documentation is available at 
+http://rubydoc.info/gems/elasticsearch-transport.
+
+[discrete]
+[[transport-implementations]]
+==== Transport implementations
+
+By default, the client uses the https://rubygems.org/gems/faraday[Faraday] HTTP 
+library as a transport implementation.
+
+It auto-detects and uses an adapter for Faraday based on gems loaded in your 
+code, preferring HTTP clients with support for persistent connections.
+
+To use the https://github.com/toland/patron[Patron] HTTP, for example, require 
+it:
+
+```
+require 'patron'
+```
+
+Then, create a new client, and the Patron gem will be used as the "driver":
+
+```ruby
+client = Elasticsearch::Client.new
+
+client.transport.connections.first.connection.builder.adapter
+# => Faraday::Adapter::Patron
+
+10.times do
+  client.nodes.stats(metric: 'http')['nodes'].values.each do |n|
+    puts "#{n['name']} : #{n['http']['total_opened']}"
+  end
+end
+
+# => Stiletoo : 24
+# => Stiletoo : 24
+# => Stiletoo : 24
+# => ...
+```
+
+To use a specific adapter for Faraday, pass it as the `adapter` argument:
+
+```ruby
+client = Elasticsearch::Client.new adapter: :net_http_persistent
+
+client.transport.connections.first.connection.builder.handlers
+# => [Faraday::Adapter::NetHttpPersistent]
+```
+
+To pass options to the 
+https://github.com/lostisland/faraday/blob/master/lib/faraday/connection.rb[`Faraday::Connection`] 
+constructor, use the `transport_options` key:
+
+```ruby
+client = Elasticsearch::Client.new transport_options: {
+  request: { open_timeout: 1 },
+  headers: { user_agent:   'MyApp' },
+  params:  { :format => 'yaml' },
+  ssl:     { verify: false }
+}
+```
+
+To configure the Faraday instance directly, use a block:
+
+```ruby
+require 'patron'
+
+client = Elasticsearch::Client.new(host: 'localhost', port: '9200') do |f|
+  f.response :logger
+  f.adapter  :patron
+end
+```
+
+You can use any standard Faraday middleware and plugins in the configuration 
+block.
+
+You can also initialize the transport class yourself, and pass it to the client 
+constructor as the `transport` argument:
+
+```ruby
+require 'patron'
+
+transport_configuration = lambda do |f|
+  f.response :logger
+  f.adapter  :patron
+end
+
+transport = Elasticsearch::Transport::Transport::HTTP::Faraday.new \
+  hosts: [ { host: 'localhost', port: '9200' } ],
+  &transport_configuration
+
+# Pass the transport to the client
+#
+client = Elasticsearch::Client.new transport: transport
+```
+
+Instead of passing the transport to the constructor, you can inject it at run 
+time:
+
+```ruby
+# Set up the transport
+#
+faraday_configuration = lambda do |f|
+  f.instance_variable_set :@ssl, { verify: false }
+  f.adapter :excon
+end
+
+faraday_client = Elasticsearch::Transport::Transport::HTTP::Faraday.new \
+  hosts: [ { host: 'my-protected-host',
+             port: '443',
+             user: 'USERNAME',
+             password: 'PASSWORD',
+             scheme: 'https'
+          }],
+  &faraday_configuration
+
+# Create a default client
+#
+client = Elasticsearch::Client.new
+
+# Inject the transport to the client
+#
+client.transport = faraday_client
+```
+
+You can also use a bundled https://rubygems.org/gems/curb[Curb] based transport 
+implementation:
+
+```ruby
+require 'curb'
+require 'elasticsearch/transport/transport/http/curb'
+
+client = Elasticsearch::Client.new transport_class: Elasticsearch::Transport::Transport::HTTP::Curb
+
+client.transport.connections.first.connection
+# => #<Curl::Easy http://localhost:9200/>
+```
+
+It's possible to customize the Curb instance by passing a block to the 
+constructor as well (in this case, as an inline block):
+
+```ruby
+transport = Elasticsearch::Transport::Transport::HTTP::Curb.new \
+  hosts: [ { host: 'localhost', port: '9200' } ],
+  & lambda { |c| c.verbose = true }
+
+client = Elasticsearch::Client.new transport: transport
+```
+
+You can write your own transport implementation by including the 
+{Elasticsearch::Transport::Transport::Base} module, implementing the required 
+contract, and passing it to the client as the `transport_class` parameter – or 
+by injecting it directly.


### PR DESCRIPTION
## Overview

This PR adds a new section to the Ruby book called `Integrations`. This section contains the following:
* Transport
* ActiveModel / ActiveRecord
* Persistence
* Ruby on Rails

It also reviews the text and makes some minor changes to improve readability.

This PR is part of the Client docs redesign effort. Related issue: https://github.com/elastic/clients-team/issues/257

### Preview

[Integrations](https://elasticsearch-ruby_1236.docs-preview.app.elstc.co/guide/en/elasticsearch/client/ruby-api/master/integrations.html)