### PR TITLE
Allow nested aggregation to accept an Aggregation instance.

### DIFF
--- a/elasticsearch-dsl/lib/elasticsearch/dsl/search/base_aggregation_component.rb
+++ b/elasticsearch-dsl/lib/elasticsearch/dsl/search/base_aggregation_component.rb
@@ -53,7 +53,13 @@ module Elasticsearch
           #
           def aggregation(*args, &block)
             @aggregations ||= AggregationsCollection.new
-            @aggregations.update args.first => Aggregation.new(*args, &block)
+
+            if block
+              @aggregations.update args.first => Aggregation.new(*args, &block)
+            else
+              name = args.shift
+              @aggregations.update name => args.shift
+            end
             self
           end
 

--- a/elasticsearch-dsl/test/unit/search_base_aggregation_component_test.rb
+++ b/elasticsearch-dsl/test/unit/search_base_aggregation_component_test.rb
@@ -52,6 +52,20 @@ module Elasticsearch
 
           assert_equal 'foo', subject.to_hash[:aggregations][:inner][:dummy][:field]
         end
+
+        should "add a nested aggregation instance" do
+          nested = Elasticsearch::DSL::Search::Aggregation.new do
+            dummy field: 'foo'
+          end
+          subject.aggregation :inner, nested
+
+          assert !subject.aggregations.empty?, "#{subject.aggregations.inspect} is empty"
+
+          assert_instance_of Elasticsearch::DSL::Search::Aggregation, subject.aggregations[:inner]
+          assert_equal({ dummy: { field: 'foo' } }, subject.aggregations[:inner].to_hash)
+
+          assert_equal 'foo', subject.to_hash[:aggregations][:inner][:dummy][:field]
+        end
       end
     end
   end


### PR DESCRIPTION
For example:
```ruby
nested = Aggregation.new do
  sum field: 'foo'
end

outer = Aggregation.new do
  aggregation(:nested_agg, nested)
end
```

This matches the behavior of the top level query `aggregation` method.