### PR TITLE
[API] Updates APIs

### DIFF
--- a/elasticsearch-api/lib/elasticsearch/api/actions/cluster/get_settings.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/cluster/get_settings.rb
@@ -27,7 +27,7 @@ module Elasticsearch
         # @option arguments [Boolean] :include_defaults Whether to return all default clusters setting.
         # @option arguments [Hash] :headers Custom HTTP headers
         #
-        # @see https://www.elastic.co/guide/en/elasticsearch/reference/7.x/cluster-update-settings.html
+        # @see https://www.elastic.co/guide/en/elasticsearch/reference/7.x/cluster-get-settings.html
         #
         def get_settings(arguments = {})
           headers = arguments.delete(:headers) || {}

--- a/elasticsearch-api/utils/thor/generator/files_helper.rb
+++ b/elasticsearch-api/utils/thor/generator/files_helper.rb
@@ -46,7 +46,7 @@ module Elasticsearch
 
       XPACK_ENDPOINTS = [
         'autoscaling', 'cross_cluster_replication', 'ccr', 'data_frame_transform_deprecated',
-        'enrich', 'eql', 'ilm', 'logstash', 'migration', 'watcher', 'slm'
+        'enrich', 'eql', 'fleet', 'ilm', 'logstash', 'migration', 'watcher', 'slm'
       ]
       XPACK_ENDPOINTS_REGEXP = /data_stream|ml_|reload_search_analyzers|transform/
 

--- a/elasticsearch-xpack/lib/elasticsearch/xpack.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack.rb
@@ -160,6 +160,10 @@ module Elasticsearch
       def logstash
         @logstash ||= xpack.logstash
       end
+
+      def fleet
+        @fleet ||= xpack.fleet
+      end
     end
   end
 end if defined?(Elasticsearch::Transport::Client)

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/fleet/global_checkpoints.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/fleet/global_checkpoints.rb
@@ -1,0 +1,66 @@
+# Licensed to Elasticsearch B.V. under one or more contributor
+# license agreements. See the NOTICE file distributed with
+# this work for additional information regarding copyright
+# ownership. Elasticsearch B.V. licenses this file to you under
+# the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+module Elasticsearch
+  module XPack
+    module API
+      module Fleet
+        module Actions
+          # Returns the current global checkpoints for an index. This API is design for internal use by the fleet server project.
+          # This functionality is Experimental and may be changed or removed
+          # completely in a future release. Elastic will take a best effort approach
+          # to fix any issues, but experimental features are not subject to the
+          # support SLA of official GA features.
+          #
+          # @option arguments [String] :index The name of the index.
+          # @option arguments [Boolean] :wait_for_advance Whether to wait for the global checkpoint to advance past the specified current checkpoints
+          # @option arguments [List] :checkpoints Comma separated list of checkpoints
+          # @option arguments [Time] :timeout Timeout to wait for global checkpoint to advance
+          # @option arguments [Hash] :headers Custom HTTP headers
+          #
+          # @see [TODO]
+          #
+          def global_checkpoints(arguments = {})
+            raise ArgumentError, "Required argument 'index' missing" unless arguments[:index]
+
+            headers = arguments.delete(:headers) || {}
+
+            arguments = arguments.clone
+
+            _index = arguments.delete(:index)
+
+            method = Elasticsearch::API::HTTP_GET
+            path   = "#{Elasticsearch::API::Utils.__listify(_index)}/_fleet/global_checkpoints"
+            params = Elasticsearch::API::Utils.__validate_and_extract_params arguments, ParamsRegistry.get(__method__)
+
+            body = nil
+            perform_request(method, path, params, body, headers).body
+          end
+
+          # Register this action with its valid params when the module is loaded.
+          #
+          # @since 6.2.0
+          ParamsRegistry.register(:global_checkpoints, [
+            :wait_for_advance,
+            :checkpoints,
+            :timeout
+          ].freeze)
+        end
+      end
+    end
+  end
+end

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/fleet/params_registry.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/fleet/params_registry.rb
@@ -1,0 +1,62 @@
+# Licensed to Elasticsearch B.V. under one or more contributor
+# license agreements. See the NOTICE file distributed with
+# this work for additional information regarding copyright
+# ownership. Elasticsearch B.V. licenses this file to you under
+# the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+module Elasticsearch
+  module XPack
+    module API
+      module Fleet
+        module Actions
+          module ParamsRegistry
+            extend self
+
+            # A Mapping of all the actions to their list of valid params.
+            #
+            # @since 7.4.0
+            PARAMS = {}
+
+            # Register an action with its list of valid params.
+            #
+            # @example Register the action.
+            #   ParamsRegistry.register(:benchmark, [ :verbose ])
+            #
+            # @param [ Symbol ] action The action to register.
+            # @param [ Array[Symbol] ] valid_params The list of valid params.
+            #
+            # @since 7.4.0
+            def register(action, valid_params)
+              PARAMS[action.to_sym] = valid_params
+            end
+
+            # Get the list of valid params for a given action.
+            #
+            # @example Get the list of valid params.
+            #   ParamsRegistry.get(:benchmark)
+            #
+            # @param [ Symbol ] action The action.
+            #
+            # @return [ Array<Symbol> ] The list of valid params for the action.
+            #
+            # @since 7.4.0
+            def get(action)
+              PARAMS.fetch(action, [])
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/machine_learning/delete_data_frame_analytics.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/machine_learning/delete_data_frame_analytics.rb
@@ -21,10 +21,6 @@ module Elasticsearch
       module MachineLearning
         module Actions
           # Deletes an existing data frame analytics job.
-          # This functionality is in Beta and is subject to change. The design and
-          # code is less mature than official GA features and is being provided
-          # as-is with no warranties. Beta features are not subject to the support
-          # SLA of official GA features.
           #
           # @option arguments [String] :id The ID of the data frame analytics to delete
           # @option arguments [Boolean] :force True if the job should be forcefully deleted

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/machine_learning/delete_trained_model.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/machine_learning/delete_trained_model.rb
@@ -21,10 +21,6 @@ module Elasticsearch
       module MachineLearning
         module Actions
           # Deletes an existing trained inference model that is currently not referenced by an ingest pipeline.
-          # This functionality is in Beta and is subject to change. The design and
-          # code is less mature than official GA features and is being provided
-          # as-is with no warranties. Beta features are not subject to the support
-          # SLA of official GA features.
           #
           # @option arguments [String] :model_id The ID of the trained model to delete
           # @option arguments [Hash] :headers Custom HTTP headers

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/machine_learning/delete_trained_model_alias.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/machine_learning/delete_trained_model_alias.rb
@@ -21,10 +21,6 @@ module Elasticsearch
       module MachineLearning
         module Actions
           # Deletes a model alias that refers to the trained model
-          # This functionality is in Beta and is subject to change. The design and
-          # code is less mature than official GA features and is being provided
-          # as-is with no warranties. Beta features are not subject to the support
-          # SLA of official GA features.
           #
           # @option arguments [String] :model_alias The trained model alias to delete
           # @option arguments [String] :model_id The trained model where the model alias is assigned

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/machine_learning/evaluate_data_frame.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/machine_learning/evaluate_data_frame.rb
@@ -21,10 +21,6 @@ module Elasticsearch
       module MachineLearning
         module Actions
           # Evaluates the data frame analytics for an annotated index.
-          # This functionality is in Beta and is subject to change. The design and
-          # code is less mature than official GA features and is being provided
-          # as-is with no warranties. Beta features are not subject to the support
-          # SLA of official GA features.
           #
           # @option arguments [Hash] :headers Custom HTTP headers
           # @option arguments [Hash] :body The evaluation definition (*Required*)

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/machine_learning/explain_data_frame_analytics.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/machine_learning/explain_data_frame_analytics.rb
@@ -21,10 +21,6 @@ module Elasticsearch
       module MachineLearning
         module Actions
           # Explains a data frame analytics config.
-          # This functionality is in Beta and is subject to change. The design and
-          # code is less mature than official GA features and is being provided
-          # as-is with no warranties. Beta features are not subject to the support
-          # SLA of official GA features.
           #
           # @option arguments [String] :id The ID of the data frame analytics to explain
           # @option arguments [Hash] :headers Custom HTTP headers

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/machine_learning/get_data_frame_analytics.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/machine_learning/get_data_frame_analytics.rb
@@ -21,10 +21,6 @@ module Elasticsearch
       module MachineLearning
         module Actions
           # Retrieves configuration information for data frame analytics jobs.
-          # This functionality is in Beta and is subject to change. The design and
-          # code is less mature than official GA features and is being provided
-          # as-is with no warranties. Beta features are not subject to the support
-          # SLA of official GA features.
           #
           # @option arguments [String] :id The ID of the data frame analytics to fetch
           # @option arguments [Boolean] :allow_no_match Whether to ignore if a wildcard expression matches no data frame analytics. (This includes `_all` string or when no data frame analytics have been specified)

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/machine_learning/get_data_frame_analytics_stats.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/machine_learning/get_data_frame_analytics_stats.rb
@@ -21,10 +21,6 @@ module Elasticsearch
       module MachineLearning
         module Actions
           # Retrieves usage information for data frame analytics jobs.
-          # This functionality is in Beta and is subject to change. The design and
-          # code is less mature than official GA features and is being provided
-          # as-is with no warranties. Beta features are not subject to the support
-          # SLA of official GA features.
           #
           # @option arguments [String] :id The ID of the data frame analytics stats to fetch
           # @option arguments [Boolean] :allow_no_match Whether to ignore if a wildcard expression matches no data frame analytics. (This includes `_all` string or when no data frame analytics have been specified)

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/machine_learning/get_trained_models.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/machine_learning/get_trained_models.rb
@@ -21,10 +21,6 @@ module Elasticsearch
       module MachineLearning
         module Actions
           # Retrieves configuration information for a trained inference model.
-          # This functionality is in Beta and is subject to change. The design and
-          # code is less mature than official GA features and is being provided
-          # as-is with no warranties. Beta features are not subject to the support
-          # SLA of official GA features.
           #
           # @option arguments [String] :model_id The ID of the trained models to fetch
           # @option arguments [Boolean] :allow_no_match Whether to ignore if a wildcard expression matches no trained models. (This includes `_all` string or when no trained models have been specified)

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/machine_learning/get_trained_models_stats.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/machine_learning/get_trained_models_stats.rb
@@ -21,10 +21,6 @@ module Elasticsearch
       module MachineLearning
         module Actions
           # Retrieves usage information for trained inference models.
-          # This functionality is in Beta and is subject to change. The design and
-          # code is less mature than official GA features and is being provided
-          # as-is with no warranties. Beta features are not subject to the support
-          # SLA of official GA features.
           #
           # @option arguments [String] :model_id The ID of the trained models stats to fetch
           # @option arguments [Boolean] :allow_no_match Whether to ignore if a wildcard expression matches no trained models. (This includes `_all` string or when no trained models have been specified)

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/machine_learning/preview_data_frame_analytics.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/machine_learning/preview_data_frame_analytics.rb
@@ -21,10 +21,6 @@ module Elasticsearch
       module MachineLearning
         module Actions
           # Previews that will be analyzed given a data frame analytics config.
-          # This functionality is in Beta and is subject to change. The design and
-          # code is less mature than official GA features and is being provided
-          # as-is with no warranties. Beta features are not subject to the support
-          # SLA of official GA features.
           #
           # @option arguments [String] :id The ID of the data frame analytics to preview
           # @option arguments [Hash] :headers Custom HTTP headers

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/machine_learning/put_data_frame_analytics.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/machine_learning/put_data_frame_analytics.rb
@@ -21,10 +21,6 @@ module Elasticsearch
       module MachineLearning
         module Actions
           # Instantiates a data frame analytics job.
-          # This functionality is in Beta and is subject to change. The design and
-          # code is less mature than official GA features and is being provided
-          # as-is with no warranties. Beta features are not subject to the support
-          # SLA of official GA features.
           #
           # @option arguments [String] :id The ID of the data frame analytics to create
           # @option arguments [Hash] :headers Custom HTTP headers

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/machine_learning/put_trained_model.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/machine_learning/put_trained_model.rb
@@ -21,10 +21,6 @@ module Elasticsearch
       module MachineLearning
         module Actions
           # Creates an inference trained model.
-          # This functionality is in Beta and is subject to change. The design and
-          # code is less mature than official GA features and is being provided
-          # as-is with no warranties. Beta features are not subject to the support
-          # SLA of official GA features.
           #
           # @option arguments [String] :model_id The ID of the trained models to store
           # @option arguments [Hash] :headers Custom HTTP headers

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/machine_learning/put_trained_model_alias.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/machine_learning/put_trained_model_alias.rb
@@ -21,10 +21,6 @@ module Elasticsearch
       module MachineLearning
         module Actions
           # Creates a new model alias (or reassigns an existing one) to refer to the trained model
-          # This functionality is in Beta and is subject to change. The design and
-          # code is less mature than official GA features and is being provided
-          # as-is with no warranties. Beta features are not subject to the support
-          # SLA of official GA features.
           #
           # @option arguments [String] :model_alias The trained model alias to update
           # @option arguments [String] :model_id The trained model where the model alias should be assigned

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/machine_learning/start_data_frame_analytics.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/machine_learning/start_data_frame_analytics.rb
@@ -21,10 +21,6 @@ module Elasticsearch
       module MachineLearning
         module Actions
           # Starts a data frame analytics job.
-          # This functionality is in Beta and is subject to change. The design and
-          # code is less mature than official GA features and is being provided
-          # as-is with no warranties. Beta features are not subject to the support
-          # SLA of official GA features.
           #
           # @option arguments [String] :id The ID of the data frame analytics to start
           # @option arguments [Time] :timeout Controls the time to wait until the task has started. Defaults to 20 seconds

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/machine_learning/stop_data_frame_analytics.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/machine_learning/stop_data_frame_analytics.rb
@@ -21,10 +21,6 @@ module Elasticsearch
       module MachineLearning
         module Actions
           # Stops one or more data frame analytics jobs.
-          # This functionality is in Beta and is subject to change. The design and
-          # code is less mature than official GA features and is being provided
-          # as-is with no warranties. Beta features are not subject to the support
-          # SLA of official GA features.
           #
           # @option arguments [String] :id The ID of the data frame analytics to stop
           # @option arguments [Boolean] :allow_no_match Whether to ignore if a wildcard expression matches no data frame analytics. (This includes `_all` string or when no data frame analytics have been specified)

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/machine_learning/update_data_frame_analytics.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/actions/machine_learning/update_data_frame_analytics.rb
@@ -21,10 +21,6 @@ module Elasticsearch
       module MachineLearning
         module Actions
           # Updates certain properties of a data frame analytics job.
-          # This functionality is in Beta and is subject to change. The design and
-          # code is less mature than official GA features and is being provided
-          # as-is with no warranties. Beta features are not subject to the support
-          # SLA of official GA features.
           #
           # @option arguments [String] :id The ID of the data frame analytics to update
           # @option arguments [Hash] :headers Custom HTTP headers

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/api/namespace/fleet.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/api/namespace/fleet.rb
@@ -1,0 +1,34 @@
+# Licensed to Elasticsearch B.V. under one or more contributor
+# license agreements. See the NOTICE file distributed with
+# this work for additional information regarding copyright
+# ownership. Elasticsearch B.V. licenses this file to you under
+# the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+module Elasticsearch
+  module XPack
+    module API
+      module Fleet
+        module Actions; end
+
+        class FleetClient
+          include Elasticsearch::API::Common::Client, Elasticsearch::API::Common::Client::Base, Fleet::Actions
+        end
+
+        def fleet
+          @fleet ||= FleetClient.new(self)
+        end
+      end
+    end
+  end
+end

--- a/elasticsearch-xpack/spec/xpack/fleet/global_checkpoints_spec.rb
+++ b/elasticsearch-xpack/spec/xpack/fleet/global_checkpoints_spec.rb
@@ -1,0 +1,44 @@
+# Licensed to Elasticsearch B.V. under one or more contributor
+# license agreements. See the NOTICE file distributed with
+# this work for additional information regarding copyright
+# ownership. Elasticsearch B.V. licenses this file to you under
+# the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+require 'spec_helper'
+
+describe 'client#fleet.global_checkpoints' do
+  let(:expected_args) do
+    [
+      'GET',
+      'foo/_fleet/global_checkpoints',
+      {},
+      nil,
+      {}
+    ]
+  end
+
+  it 'performs the request' do
+    expect(client_double.fleet.global_checkpoints(index: 'foo')).to eq({})
+  end
+
+  let(:client) do
+    Class.new { include Elasticsearch::XPack::API }.new
+  end
+
+  it 'requires the :index argument' do
+    expect {
+      client.fleet.global_checkpoints
+    }.to raise_exception(ArgumentError)
+  end
+end


### PR DESCRIPTION
The following APIs have been migrated from Beta to Stable: `ml.delete_data_frame_analytics`, `ml.delete_trained_model`, `ml.delete_trained_model_alias`, `ml.evaluate_data_frame`, `ml.explain_data_frame_analytics`, `ml.get_data_frame_analytics`, `ml.get_data_frame_analytics_stats`, `ml.get_trained_models`, `ml.get_trained_models_stats`, `ml.preview_data_frame_analytics`, `ml.put_data_frame_analytics`, `ml.put_trained_model`, `ml.put_trained_model_alias`, `ml.start_data_frame_analytics`, `ml.stop_data_frame_analytics`, `ml.update_data_frame_analytics`.

Adds experimental endpoint `fleet.global_checkpoints`.