### PR TITLE
Metaheader update

### DIFF
--- a/api-spec-testing/test_file/action.rb
+++ b/api-spec-testing/test_file/action.rb
@@ -75,12 +75,16 @@ module Elasticsearch
             end
             if ENV['QUIET'] == 'true'
               # todo: create a method on Elasticsearch::Client that can clone the client with new options
-              Elasticsearch::Client.new(host: URL,
-                                        transport_options: TRANSPORT_OPTIONS.merge( headers: headers))
+              Elasticsearch::Client.new(
+                host: URL,
+                transport_options: TRANSPORT_OPTIONS.merge(headers: headers)
+              )
             else
-              Elasticsearch::Client.new(host: URL,
-                                        tracer: Logger.new($stdout),
-                                        transport_options: TRANSPORT_OPTIONS.merge( headers: headers))
+              Elasticsearch::Client.new(
+                host: URL,
+                tracer: Logger.new($stdout),
+                transport_options: TRANSPORT_OPTIONS.merge(headers: headers)
+              )
             end
           when 'catch', 'warnings', 'allowed_warnings'
             client

--- a/elasticsearch-api/spec/rest_yaml_tests_helper.rb
+++ b/elasticsearch-api/spec/rest_yaml_tests_helper.rb
@@ -47,7 +47,6 @@ YAML_FILES_DIRECTORY = "#{PROJECT_PATH}/../tmp/rest-api-spec/test/free"
 
 SINGLE_TEST = if ENV['SINGLE_TEST'] && !ENV['SINGLE_TEST'].empty?
                 test_target = ENV['SINGLE_TEST']
-                path = File.expand_path(File.dirname('..'), '..')
 
                 if test_target.match?(/\.yml$/)
                   ["#{PROJECT_PATH}/../tmp/rest-api-spec/test/free/#{test_target}"]

--- a/elasticsearch-transport/lib/elasticsearch/transport/meta_header.rb
+++ b/elasticsearch-transport/lib/elasticsearch/transport/meta_header.rb
@@ -41,13 +41,29 @@ module Elasticsearch
       end
 
       def meta_header_service_version
-        if defined?(Elastic::META_HEADER_SERVICE_VERSION)
-          Elastic::META_HEADER_SERVICE_VERSION
+        if enterprise_search?
+          Elastic::ENTERPRISE_SERVICE_VERSION
+        elsif elasticsearch?
+          Elastic::ELASTICSEARCH_SERVICE_VERSION
         elsif defined?(Elasticsearch::VERSION)
           [:es, client_meta_version(Elasticsearch::VERSION)]
         else
           [:es, client_meta_version(Elasticsearch::Transport::VERSION)]
         end
+      end
+
+      def enterprise_search?
+        defined?(Elastic::ENTERPRISE_SERVICE_VERSION) &&
+          called_from?('enterprise-search-ruby')
+      end
+
+      def elasticsearch?
+        defined?(Elastic::ELASTICSEARCH_SERVICE_VERSION) &&
+          called_from?('elasticsearch')
+      end
+
+      def called_from?(service)
+        !caller.select { |c| c.match?(service) }.empty?
       end
 
       # We return the current version if it's a release, but if it's a pre/alpha/beta release we

--- a/elasticsearch-transport/lib/elasticsearch/transport/meta_header.rb
+++ b/elasticsearch-transport/lib/elasticsearch/transport/meta_header.rb
@@ -19,7 +19,6 @@ require 'base64'
 
 module Elasticsearch
   module Transport
-
     # Methods for the Elastic meta header used by Cloud.
     # X-Elastic-Client-Meta HTTP header which is used by Elastic Cloud and can be disabled when
     # instantiating the Client with the :enable_meta_header parameter set to `false`.

--- a/elasticsearch-transport/spec/elasticsearch/transport/meta_header_spec.rb
+++ b/elasticsearch-transport/spec/elasticsearch/transport/meta_header_spec.rb
@@ -251,7 +251,7 @@ describe Elasticsearch::Transport::Client do
 
     context 'when using a different service version' do
       before do
-        stub_const("Elastic::META_HEADER_SERVICE_VERSION", [:ent, '8.0.0'])
+        stub_const('Elastic::ELASTICSEARCH_SERVICE_VERSION', [:ent, '8.0.0'])
       end
 
       let(:client) { Elasticsearch::Client.new }

--- a/elasticsearch/lib/elasticsearch.rb
+++ b/elasticsearch/lib/elasticsearch.rb
@@ -37,5 +37,5 @@ module Elastic
   end
 
   # Constant for elasticsearch-transport meta-header
-  META_HEADER_SERVICE_VERSION = [:es, client_meta_version].freeze
+  ELASTICSEARCH_SERVICE_VERSION = [:es, client_meta_version].freeze
 end


### PR DESCRIPTION
Refactors meta header to support using other Elastic clients in same project.
Related issue: https://github.com/elastic/enterprise-search-ruby/issues/145

