### PR TITLE
Add exception class for 429 status code

### DIFF
--- a/elasticsearch-transport/lib/elasticsearch/transport/transport/errors.rb
+++ b/elasticsearch-transport/lib/elasticsearch/transport/transport/errors.rb
@@ -64,6 +64,7 @@ module Elasticsearch
         418 => 'ImATeapot',
         421 => 'TooManyConnectionsFromThisIP',
         426 => 'UpgradeRequired',
+        429 => 'TooManyRequests',
         450 => 'BlockedByWindowsParentalControls',
         494 => 'RequestHeaderTooLarge',
         497 => 'HTTPToHTTPS',


### PR DESCRIPTION
Elasticsearch responds with 429 status code when thread pool is busy and corresponding queue is full (also when circuit breaker is tripped). Ruby client, however, doesn't have a dedicated exception for the 429 and throws a generic `Elasticsearch::Transport::Transport::ServerError`. This PR adds a custom exception so that `Elasticsearch::Transport::Transport::Errors::TooManyRequests` is raised instead.

Example response:
```json
{
   "error" : {
     "root_cause" : [
       {
         "type" : "es_rejected_execution_exception",
         "reason" : "rejected execution of org.elasticsearch.action.support.replication.TransportWriteAction$1@6128d4b7 on EsThreadPoolExecutor[name = m1qmac.local/wr
 ite, queue capacity = 1, org.elasticsearch.common.util.concurrent.EsThreadPoolExecutor@71b8adaa[Running, pool size = 8, active threads = 2, queued tasks = 0, complet
 ed tasks = 891]]"
       }
     ],
     "type" : "es_rejected_execution_exception",
     "reason" : "rejected execution of org.elasticsearch.action.support.replication.TransportWriteAction$1@6128d4b7 on EsThreadPoolExecutor[name = m1qmac.local/write,
  queue capacity = 1, org.elasticsearch.common.util.concurrent.EsThreadPoolExecutor@71b8adaa[Running, pool size = 8, active threads = 2, queued tasks = 0, completed t
 asks = 891]]"
   },
   "status" : 429
 }
```