### PR TITLE
Fix thread safety issue in `get_connection`

### DIFF
--- a/elasticsearch-transport/lib/elasticsearch/transport/transport/connections/collection.rb
+++ b/elasticsearch-transport/lib/elasticsearch/transport/transport/connections/collection.rb
@@ -78,16 +78,13 @@ module Elasticsearch
 
           # Returns a connection.
           #
-          # If there are no alive connections, resurrects a connection with least failures.
+          # If there are no alive connections, returns a connection with least failures.
           # Delegates to selector's `#select` method to get the connection.
           #
           # @return [Connection]
           #
           def get_connection(options={})
-            if connections.empty? && dead_connection = dead.sort { |a,b| a.failures <=> b.failures }.first
-              dead_connection.alive!
-            end
-            selector.select(options)
+            selector.select(options) || @connections.min_by(&:failures)
           end
 
           def each(&block)

--- a/elasticsearch-transport/spec/elasticsearch/connections/collection_spec.rb
+++ b/elasticsearch-transport/spec/elasticsearch/connections/collection_spec.rb
@@ -249,6 +249,18 @@ describe Elasticsearch::Transport::Transport::Connections::Collection do
           collection.get_connection.host[:host]
         end).to eq((0..9).to_a)
       end
+
+      it 'always returns a connection' do
+        threads = 20.times.map do
+          Thread.new do
+            20.times.map do
+              collection.get_connection.dead!
+            end
+          end
+        end
+
+        expect(threads.flat_map(&:value).size).to eq(400)
+      end
     end
   end
 end


### PR DESCRIPTION
When multiple threads are accessing a connection collection, the
underlying `@collections` object can change at any point (after
`connections.empty?`, `dead`, or `dead_connection.alive!`). This means
the selector is not necessarily operating on a collection with an alive
connection. Since selectors currently only look at alive connections,
`selector.select` can return `nil` when a dead connection would be
better.

If you run the new test on jruby without the fix, you should see it
returning `nil` and raising a `NoMethodError`:

```
NoMethodError: undefined method `dead!' for nil:NilClass
  <main> at /Users/dharsha/repos/elastic/elasticsearch-ruby/elasticsearch-transport/spec/elasticsearch/connections/collection_spec.rb:257
    each at org/jruby/RubyEnumerator.java:396
     map at org/jruby/RubyEnumerable.java:886
  <main> at /Users/dharsha/repos/elastic/elasticsearch-ruby/elasticsearch-transport/spec/elasticsearch/connections/collection_spec.rb:256
```

This switches to trying the selector first and falling back to the
connection with the least errors if no alive connection is found. The
fallback operates on `@connections` directly because the connections may
have changed state after `selector.select` was called.

Looks like this was introduced here: b5019c210e6467ca3fa09b85ebd4fe835c036bd7