### PR TITLE
[CI] Updates Test Coverage

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -29,7 +29,6 @@ gem 'rake'
 gem 'rubocop'
 gem 'shoulda-context'
 gem 'simplecov'
-gem 'simplecov-rcov'
 gem 'test-unit', '~> 2'
 gem 'yard'
 unless defined?(JRUBY_VERSION) || defined?(Rubinius)

--- a/elasticsearch-api/elasticsearch-api.gemspec
+++ b/elasticsearch-api/elasticsearch-api.gemspec
@@ -68,7 +68,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'require-prof' unless defined?(JRUBY_VERSION) || defined?(Rubinius)
   s.add_development_dependency 'ruby-prof' unless defined?(JRUBY_VERSION) || defined?(Rubinius)
   s.add_development_dependency 'simplecov'
-  s.add_development_dependency 'simplecov-rcov'
 
   s.add_development_dependency 'test-unit', '~> 2'
 

--- a/elasticsearch-api/spec/spec_helper.rb
+++ b/elasticsearch-api/spec/spec_helper.rb
@@ -14,6 +14,10 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+if ENV['COVERAGE'] && ENV['CI'].nil?
+  require 'simplecov'
+  SimpleCov.start { add_filter %r{^/test|spec/} }
+end
 
 if defined?(JRUBY_VERSION)
   require 'pry-nav'

--- a/elasticsearch-transport/README.md
+++ b/elasticsearch-transport/README.md
@@ -621,16 +621,14 @@ Github's pull requests and issues are used to communicate, send bug reports and 
 To work on the code, clone and bootstrap the main repository first --
 please see instructions in the main [README](../README.md#development).
 
-To run tests, launch a testing cluster -- again, see instructions
-in the main [README](../README.md#development) -- and use the Rake tasks:
+To run tests, launch a testing cluster and use the Rake tasks:
 
 ```bash
 time rake test:unit
 time rake test:integration
 ```
 
-Unit tests have to use Ruby 1.8 compatible syntax, integration tests
-can use Ruby 2.x syntax and features.
+Use `COVERAGE=true` before running a test task to check coverage with Simplecov.
 
 ## License
 

--- a/elasticsearch-transport/elasticsearch-transport.gemspec
+++ b/elasticsearch-transport/elasticsearch-transport.gemspec
@@ -53,7 +53,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'curb'   unless defined? JRUBY_VERSION
   s.add_development_dependency 'hashie'
   s.add_development_dependency 'httpclient'
-  s.add_development_dependency 'manticore', '~> 0.6' if defined? JRUBY_VERSION
+  s.add_development_dependency 'manticore' if defined? JRUBY_VERSION
   s.add_development_dependency 'minitest'
   s.add_development_dependency 'minitest-reporters'
   s.add_development_dependency 'mocha'
@@ -64,8 +64,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'require-prof' unless defined?(JRUBY_VERSION) || defined?(Rubinius)
   s.add_development_dependency 'ruby-prof'    unless defined?(JRUBY_VERSION) || defined?(Rubinius)
   s.add_development_dependency 'shoulda-context'
-  s.add_development_dependency 'simplecov', '~> 0.17', '< 0.18'
-  s.add_development_dependency 'simplecov-rcov'
+  s.add_development_dependency 'simplecov'
   s.add_development_dependency 'test-unit', '~> 2'
   s.add_development_dependency 'typhoeus', '~> 1.4'
   s.add_development_dependency 'yard'

--- a/elasticsearch-transport/spec/spec_helper.rb
+++ b/elasticsearch-transport/spec/spec_helper.rb
@@ -14,6 +14,10 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+if ENV['COVERAGE'] && ENV['CI'].nil?
+  require 'simplecov'
+  SimpleCov.start { add_filter %r{^/test|spec/} }
+end
 
 require 'elasticsearch'
 require 'elasticsearch-transport'

--- a/elasticsearch-transport/test/test_helper.rb
+++ b/elasticsearch-transport/test/test_helper.rb
@@ -28,16 +28,9 @@ TEST_HOST, TEST_PORT = ELASTICSEARCH_HOSTS.first.split(':') if ELASTICSEARCH_HOS
 
 JRUBY    = defined?(JRUBY_VERSION)
 
-if ENV['COVERAGE'] && ENV['CI'].nil?
+if ENV['COVERAGE']
   require 'simplecov'
-  SimpleCov.start { add_filter "/test|test_/" }
-end
-
-if ENV['CI']
-  require 'simplecov'
-  require 'simplecov-rcov'
-  SimpleCov.formatter = SimpleCov::Formatter::RcovFormatter
-  SimpleCov.start { add_filter "/test|test_" }
+  SimpleCov.start { add_filter %r{^/test/} }
 end
 
 require 'minitest/autorun'

--- a/elasticsearch/README.md
+++ b/elasticsearch/README.md
@@ -86,6 +86,10 @@ Please refer to the specific library documentation for details:
    [[README]](https://github.com/elasticsearch/elasticsearch-ruby/blob/master/elasticsearch-api/README.md)
    [[Documentation]](http://rubydoc.info/gems/elasticsearch-api/file/README.markdown)
 
+## Development
+
+You can run `rake -T` to check the test tasks. Use `COVERAGE=true` before running a test task to check the coverage with Simplecov.
+
 ## License
 
 This software is licensed under the [Apache 2 license](./LICENSE).

--- a/elasticsearch/elasticsearch.gemspec
+++ b/elasticsearch/elasticsearch.gemspec
@@ -61,7 +61,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'ruby-prof' unless defined?(JRUBY_VERSION) || defined?(Rubinius)
   s.add_development_dependency 'shoulda-context'
   s.add_development_dependency 'simplecov'
-  s.add_development_dependency 'simplecov-rcov'
   s.add_development_dependency 'test-unit', '~> 2'
   s.add_development_dependency 'yard'
 

--- a/elasticsearch/test/integration/client_integration_test.rb
+++ b/elasticsearch/test/integration/client_integration_test.rb
@@ -24,7 +24,7 @@ module Elasticsearch
     class ClientIntegrationTest < Elasticsearch::Test::IntegrationTestCase
       context "Elasticsearch client" do
         setup do
-          system "curl -X DELETE http://#{TEST_HOST}:#{TEST_PORT}/_all > /dev/null 2>&1"
+          system "curl -X DELETE http://#{ELASTICSEARCH_URL}/_all > /dev/null 2>&1"
 
           @logger =  Logger.new(STDERR)
           @logger.formatter = proc do |severity, datetime, progname, msg|
@@ -37,14 +37,17 @@ module Elasticsearch
             ANSI.ansi(severity[0] + ' ', color, :faint) + ANSI.ansi(msg, :white, :faint) + "\n"
           end
 
-          @client = Elasticsearch::Client.new host: "#{TEST_HOST}:#{TEST_PORT}", logger: (ENV['QUIET'] ? nil : @logger)
+          @client = Elasticsearch::Client.new(
+            host: ELASTICSEARCH_URL,
+            logger: (ENV['QUIET'] ? nil : @logger)
+          )
         end
 
         should "perform the API methods" do
           assert_nothing_raised do
             # Index a document
             #
-            @client.index index: 'test-index', id: '1', body: { title: 'Test', type: 'test-type' }
+            @client.index(index: 'test-index', id: '1', body: { title: 'Test', type: 'test-type' })
 
             # Refresh the index
             #

--- a/elasticsearch/test/test_helper.rb
+++ b/elasticsearch/test/test_helper.rb
@@ -14,26 +14,16 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+require 'uri'
 
-ELASTICSEARCH_HOSTS = if (hosts = ENV['TEST_ES_SERVER'] || ENV['ELASTICSEARCH_HOSTS'])
-                        hosts.split(',').map do |host|
-                          /(http\:\/\/)?(\S+)/.match(host)[2]
-                        end
-                      end.freeze
-
-TEST_HOST, TEST_PORT = ELASTICSEARCH_HOSTS.first.split(':') if ELASTICSEARCH_HOSTS
+ELASTICSEARCH_URL = ENV['TEST_ES_SERVER'] ||
+                    "http://localhost:#{(ENV['PORT'] || 9200)}"
+raise URI::InvalidURIError unless ELASTICSEARCH_URL =~ /\A#{URI::DEFAULT_PARSER.make_regexp}\z/
 
 JRUBY = defined?(JRUBY_VERSION)
 
-if ENV['COVERAGE'] && ENV['CI'].nil? && !RUBY_1_8
+if ENV['COVERAGE']
   require 'simplecov'
-  SimpleCov.start { add_filter "/test|test_/" }
-end
-
-if ENV['CI']
-  require 'simplecov'
-  require 'simplecov-rcov'
-  SimpleCov.formatter = SimpleCov::Formatter::RcovFormatter
   SimpleCov.start { add_filter "/test|test_" }
 end
 


### PR DESCRIPTION
- Updates calling simplecov
- Removes simplecov-rcov dependency: Gem is no longer maintained and not currently relevant.
- Clarifies READMEs for using COVERAGE
- Simplifies defaults for `elasticsearch` tests