### PR TITLE
[CI] Updates Test Coverage

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -30,7 +30,6 @@ gem 'rake'
 gem 'require-prof' unless defined?(JRUBY_VERSION) || defined?(Rubinius)
 gem 'ruby-prof'    unless defined?(JRUBY_VERSION) || defined?(Rubinius)
 gem 'shoulda-context'
-gem 'simplecov', '~> 0.17', '< 0.18'
-gem 'simplecov-rcov'
+gem 'simplecov'
 gem 'test-unit', '~> 2'
 gem 'yard'

--- a/elasticsearch-api/elasticsearch-api.gemspec
+++ b/elasticsearch-api/elasticsearch-api.gemspec
@@ -67,8 +67,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'escape_utils' unless defined? JRUBY_VERSION
   s.add_development_dependency 'jbuilder'
   s.add_development_dependency 'require-prof' unless defined?(JRUBY_VERSION) || defined?(Rubinius)
-  s.add_development_dependency 'simplecov', '~> 0.17', '< 0.18'
-  s.add_development_dependency 'simplecov-rcov'
+  s.add_development_dependency 'simplecov'
   s.add_development_dependency 'test-unit', '~> 2'
   s.add_development_dependency 'ruby-prof' unless defined?(JRUBY_VERSION) || defined?(Rubinius)
 

--- a/elasticsearch-api/spec/spec_helper.rb
+++ b/elasticsearch-api/spec/spec_helper.rb
@@ -14,6 +14,10 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+if ENV['COVERAGE'] && ENV['CI'].nil?
+  require 'simplecov'
+  SimpleCov.start { add_filter %r{^/test|spec/} }
+end
 
 if defined?(JRUBY_VERSION)
   require 'pry-nav'

--- a/elasticsearch-api/utils/thor/templates/test_helper.rb
+++ b/elasticsearch-api/utils/thor/templates/test_helper.rb
@@ -15,10 +15,6 @@
 # specific language governing permissions and limitations
 # under the License.
 
-RUBY_1_8 = defined?(RUBY_VERSION) && RUBY_VERSION < '1.9'
-
-require 'rubygems' if RUBY_1_8
-
 require 'simplecov' and SimpleCov.start { add_filter "/test|test_/" } if ENV["COVERAGE"]
 
 require 'test/unit'

--- a/elasticsearch-extensions/test/test_helper.rb
+++ b/elasticsearch-extensions/test/test_helper.rb
@@ -25,7 +25,7 @@ TEST_HOST, TEST_PORT = ELASTICSEARCH_HOSTS.first.split(':') if ELASTICSEARCH_HOS
 
 JRUBY = defined?(JRUBY_VERSION)
 
-if ENV['COVERAGE'] && ENV['CI'].nil? && !RUBY_1_8
+if ENV['COVERAGE']
   require 'simplecov'
   SimpleCov.start { add_filter "/test|test_" }
 end

--- a/elasticsearch-transport/README.md
+++ b/elasticsearch-transport/README.md
@@ -558,16 +558,14 @@ Github's pull requests and issues are used to communicate, send bug reports and 
 To work on the code, clone and bootstrap the main repository first --
 please see instructions in the main [README](../README.md#development).
 
-To run tests, launch a testing cluster -- again, see instructions
-in the main [README](../README.md#development) -- and use the Rake tasks:
+To run tests, launch a testing cluster and use the Rake tasks:
 
 ```
 time rake test:unit
 time rake test:integration
 ```
 
-Unit tests have to use Ruby 1.8 compatible syntax, integration tests
-can use Ruby 2.x syntax and features.
+Use `COVERAGE=true` before running a test task to check coverage with Simplecov.
 
 ## License
 

--- a/elasticsearch-transport/elasticsearch-transport.gemspec
+++ b/elasticsearch-transport/elasticsearch-transport.gemspec
@@ -47,29 +47,28 @@ Gem::Specification.new do |s|
   s.add_dependency 'multi_json'
   s.add_dependency 'faraday', '~> 1'
 
+  s.add_development_dependency 'ansi'
+  s.add_development_dependency 'bundler'
   s.add_development_dependency 'cane'
   s.add_development_dependency 'curb'   unless defined? JRUBY_VERSION
   s.add_development_dependency 'elasticsearch-extensions'
-  s.add_development_dependency 'minitest'
-  s.add_development_dependency 'minitest-reporters'
-  s.add_development_dependency 'rake', '~> 13'
-  s.add_development_dependency 'require-prof' unless defined?(JRUBY_VERSION) || defined?(Rubinius)
-  s.add_development_dependency 'ruby-prof'    unless defined?(JRUBY_VERSION) || defined?(Rubinius)
-  s.add_development_dependency 'simplecov', '~> 0.17', '< 0.18'
-  s.add_development_dependency 'simplecov-rcov'
-  s.add_development_dependency 'ansi'
   s.add_development_dependency 'hashie'
   s.add_development_dependency 'httpclient'
-  s.add_development_dependency 'manticore', '~> 0.6' if defined? JRUBY_VERSION
+  s.add_development_dependency 'manticore' if defined? JRUBY_VERSION
+  s.add_development_dependency 'minitest'
+  s.add_development_dependency 'minitest-reporters'
   s.add_development_dependency 'mocha'
   s.add_development_dependency 'net-http-persistent'
   s.add_development_dependency 'patron' unless defined? JRUBY_VERSION
   s.add_development_dependency 'pry'
+  s.add_development_dependency 'rake', '~> 13'
+  s.add_development_dependency 'require-prof' unless defined?(JRUBY_VERSION) || defined?(Rubinius)
+  s.add_development_dependency 'ruby-prof'    unless defined?(JRUBY_VERSION) || defined?(Rubinius)
   s.add_development_dependency 'shoulda-context'
+  s.add_development_dependency 'simplecov'
   s.add_development_dependency 'test-unit', '~> 2'
   s.add_development_dependency 'typhoeus', '~> 1.4'
   s.add_development_dependency 'yard'
-  s.add_development_dependency 'bundler'
 
   s.description = <<-DESC.gsub(/^    /, '')
     Ruby client for Elasticsearch. See the `elasticsearch` gem for full integration.

--- a/elasticsearch-transport/spec/spec_helper.rb
+++ b/elasticsearch-transport/spec/spec_helper.rb
@@ -14,6 +14,10 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+if ENV['COVERAGE'] && ENV['CI'].nil?
+  require 'simplecov'
+  SimpleCov.start { add_filter %r{^/test|spec/} }
+end
 
 require 'elasticsearch'
 require 'elasticsearch-transport'

--- a/elasticsearch-transport/test/test_helper.rb
+++ b/elasticsearch-transport/test/test_helper.rb
@@ -29,23 +29,9 @@ TEST_HOST, TEST_PORT = ELASTICSEARCH_HOSTS.first.split(':') if ELASTICSEARCH_HOS
 RUBY_1_8 = defined?(RUBY_VERSION) && RUBY_VERSION < '1.9'
 JRUBY    = defined?(JRUBY_VERSION)
 
-if RUBY_1_8 and not ENV['BUNDLE_GEMFILE']
-  require 'rubygems'
-  gem 'test-unit'
-end
-
-require 'rubygems' if RUBY_1_8
-
-if ENV['COVERAGE'] && ENV['CI'].nil? && !RUBY_1_8
+if ENV['COVERAGE']
   require 'simplecov'
-  SimpleCov.start { add_filter "/test|test_/" }
-end
-
-if ENV['CI'] && !RUBY_1_8
-  require 'simplecov'
-  require 'simplecov-rcov'
-  SimpleCov.formatter = SimpleCov::Formatter::RcovFormatter
-  SimpleCov.start { add_filter "/test|test_" }
+  SimpleCov.start { add_filter %r{^/test/} }
 end
 
 # Register `at_exit` handler for integration tests shutdown.

--- a/elasticsearch-transport/test/test_helper.rb
+++ b/elasticsearch-transport/test/test_helper.rb
@@ -26,7 +26,6 @@ ELASTICSEARCH_HOSTS = if hosts = ENV['TEST_ES_SERVER'] || ENV['ELASTICSEARCH_HOS
 
 TEST_HOST, TEST_PORT = ELASTICSEARCH_HOSTS.first.split(':') if ELASTICSEARCH_HOSTS
 
-RUBY_1_8 = defined?(RUBY_VERSION) && RUBY_VERSION < '1.9'
 JRUBY    = defined?(JRUBY_VERSION)
 
 if ENV['COVERAGE']
@@ -40,7 +39,6 @@ if defined?(RUBY_VERSION) && RUBY_VERSION > '1.9'
   at_exit { Elasticsearch::Test::IntegrationTestCase.__run_at_exit_hooks }
 end
 
-require 'test/unit' if RUBY_1_8
 require 'minitest/autorun'
 require 'minitest/reporters'
 require 'shoulda/context'
@@ -107,8 +105,7 @@ module Elasticsearch
       extend Elasticsearch::Extensions::Test::StartupShutdown
 
       shutdown { Elasticsearch::Extensions::Test::Cluster.stop if ENV['SERVER'] && started? && Elasticsearch::Extensions::Test::Cluster.running? }
-      context "IntegrationTest" do; should "noop on Ruby 1.8" do; end; end if RUBY_1_8
-    end if defined?(RUBY_VERSION) && RUBY_VERSION > '1.9'
+    end
   end
 
   module Test
@@ -117,7 +114,6 @@ module Elasticsearch
       extend Elasticsearch::Extensions::Test::Profiling
 
       shutdown { Elasticsearch::Extensions::Test::Cluster.stop if ENV['SERVER'] && started? && Elasticsearch::Extensions::Test::Cluster.running? }
-      context "IntegrationTest" do; should "noop on Ruby 1.8" do; end; end if RUBY_1_8
-    end unless RUBY_1_8 || JRUBY
+    end unless JRUBY
   end
 end

--- a/elasticsearch-transport/test/unit/response_test.rb
+++ b/elasticsearch-transport/test/unit/response_test.rb
@@ -26,7 +26,7 @@ class Elasticsearch::Transport::Transport::ResponseTest < Minitest::Test
 
       response = Elasticsearch::Transport::Transport::Response.new 200, body
       assert_equal 'UTF-8', response.body.encoding.name
-    end unless RUBY_1_8
+    end
 
   end
 end

--- a/elasticsearch-transport/test/unit/transport_base_test.rb
+++ b/elasticsearch-transport/test/unit/transport_base_test.rb
@@ -319,7 +319,7 @@ class Elasticsearch::Transport::Transport::BaseTest < Minitest::Test
       @transport.perform_request('GET', '/', &@block)
       assert_equal 2, @transport.counter
     end
-  end unless RUBY_1_8
+  end
 
   context "performing a request with retry on connection failures" do
     setup do
@@ -353,7 +353,7 @@ class Elasticsearch::Transport::Transport::BaseTest < Minitest::Test
         @transport.perform_request('GET', '/', &@block)
       end
     end
-  end unless RUBY_1_8
+  end
 
   context "performing a request with retry on status" do
     setup do
@@ -400,7 +400,7 @@ class Elasticsearch::Transport::Transport::BaseTest < Minitest::Test
         @transport.perform_request('GET', '/', &@block)
       end
     end
-  end  unless RUBY_1_8
+  end
 
   context "logging" do
     setup do
@@ -456,7 +456,7 @@ class Elasticsearch::Transport::Transport::BaseTest < Minitest::Test
       assert_raise Elasticsearch::Transport::Transport::Errors::InternalServerError do
         @transport.perform_request('POST', '_search', &@block)
       end
-    end unless RUBY_1_8
+    end
 
     should "not log a failed Elasticsearch request as fatal" do
       @block = Proc.new { |c, u| puts "ERROR" }
@@ -467,7 +467,7 @@ class Elasticsearch::Transport::Transport::BaseTest < Minitest::Test
 
       # No `BadRequest` error
       @transport.perform_request('POST', '_search', :ignore => 500, &@block)
-    end unless RUBY_1_8
+    end
 
     should "log and re-raise a Ruby exception" do
       @block = Proc.new { |c, u| puts "ERROR" }
@@ -477,7 +477,7 @@ class Elasticsearch::Transport::Transport::BaseTest < Minitest::Test
       @transport.logger.expects(:fatal)
 
       assert_raise(Exception) { @transport.perform_request('POST', '_search', &@block) }
-    end unless RUBY_1_8
+    end
   end
 
   context "tracing" do
@@ -531,7 +531,7 @@ class Elasticsearch::Transport::Transport::BaseTest < Minitest::Test
       assert_raise Elasticsearch::Transport::Transport::Errors::InternalServerError do
         @transport.perform_request('POST', '_search', &@block)
       end
-    end unless RUBY_1_8
+    end
 
   end
 

--- a/elasticsearch-xpack/test/integration/yaml_test_runner.rb
+++ b/elasticsearch-xpack/test/integration/yaml_test_runner.rb
@@ -15,7 +15,6 @@
 # specific language governing permissions and limitations
 # under the License.
 
-RUBY_1_8 = defined?(RUBY_VERSION) && RUBY_VERSION < '1.9'
 JRUBY    = defined?(JRUBY_VERSION)
 
 require 'pathname'

--- a/elasticsearch/README.md
+++ b/elasticsearch/README.md
@@ -86,6 +86,10 @@ Please refer to the specific library documentation for details:
    [[README]](https://github.com/elasticsearch/elasticsearch-ruby/blob/master/elasticsearch-api/README.md)
    [[Documentation]](http://rubydoc.info/gems/elasticsearch-api/file/README.markdown)
 
+## Development
+
+You can run `rake -T` to check the test tasks. Use `COVERAGE=true` before running a test task to check the coverage with Simplecov.
+
 ## License
 
 This software is licensed under the [Apache 2 license](./LICENSE).

--- a/elasticsearch/elasticsearch.gemspec
+++ b/elasticsearch/elasticsearch.gemspec
@@ -55,21 +55,17 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'elasticsearch-extensions'
 
   s.add_development_dependency 'ansi'
-  s.add_development_dependency 'shoulda-context'
-  s.add_development_dependency 'mocha'
-  s.add_development_dependency 'yard'
-  s.add_development_dependency 'pry'
-
-
+  s.add_development_dependency 'cane'
   s.add_development_dependency 'minitest'
   s.add_development_dependency 'minitest-reporters'
-  s.add_development_dependency 'ruby-prof' unless defined?(JRUBY_VERSION) || defined?(Rubinius)
+  s.add_development_dependency 'mocha'
+  s.add_development_dependency 'pry'
   s.add_development_dependency 'require-prof' unless defined?(JRUBY_VERSION) || defined?(Rubinius)
-  s.add_development_dependency 'simplecov', '~> 0.17', '< 0.18'
-  s.add_development_dependency 'simplecov-rcov'
-  s.add_development_dependency 'cane'
-
+  s.add_development_dependency 'ruby-prof' unless defined?(JRUBY_VERSION) || defined?(Rubinius)
+  s.add_development_dependency 'shoulda-context'
+  s.add_development_dependency 'simplecov'
   s.add_development_dependency 'test-unit', '~> 2'
+  s.add_development_dependency 'yard'
 
   s.description = <<-DESC.gsub(/^    /, '')
     Ruby integrations for Elasticsearch (client, API, etc.)

--- a/elasticsearch/test/integration/client_integration_test.rb
+++ b/elasticsearch/test/integration/client_integration_test.rb
@@ -31,7 +31,7 @@ module Elasticsearch
 
       context "Elasticsearch client" do
         setup do
-          system "curl -X DELETE http://#{TEST_HOST}:#{TEST_PORT}/_all > /dev/null 2>&1"
+          system "curl -X DELETE http://#{ELASTICSEARCH_URL}/_all > /dev/null 2>&1"
 
           @logger =  Logger.new(STDERR)
           @logger.formatter = proc do |severity, datetime, progname, msg|
@@ -44,14 +44,17 @@ module Elasticsearch
             ANSI.ansi(severity[0] + ' ', color, :faint) + ANSI.ansi(msg, :white, :faint) + "\n"
           end
 
-          @client = Elasticsearch::Client.new host: "#{TEST_HOST}:#{TEST_PORT}", logger: (ENV['QUIET'] ? nil : @logger)
+          @client = Elasticsearch::Client.new(
+            host: ELASTICSEARCH_URL,
+            logger: (ENV['QUIET'] ? nil : @logger)
+          )
         end
 
         should "perform the API methods" do
           assert_nothing_raised do
             # Index a document
             #
-            @client.index index: 'test-index', type: 'test-type', id: '1', body: { title: 'Test' }
+            @client.index(index: 'test-index', id: '1', body: { title: 'Test' })
 
             # Refresh the index
             #

--- a/elasticsearch/test/test_helper.rb
+++ b/elasticsearch/test/test_helper.rb
@@ -14,32 +14,16 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+require 'uri'
 
-ELASTICSEARCH_HOSTS = if hosts = ENV['TEST_ES_SERVER'] || ENV['ELASTICSEARCH_HOSTS']
-                        hosts.split(',').map do |host|
-                          /(http\:\/\/)?(\S+)/.match(host)[2]
-                        end
-                      end.freeze
+ELASTICSEARCH_URL = ENV['TEST_ES_SERVER'] ||
+                    "http://localhost:#{(ENV['PORT'] || 9200)}"
+raise URI::InvalidURIError unless ELASTICSEARCH_URL =~ /\A#{URI::DEFAULT_PARSER.make_regexp}\z/
 
-TEST_HOST, TEST_PORT = ELASTICSEARCH_HOSTS.first.split(':') if ELASTICSEARCH_HOSTS
+JRUBY = defined?(JRUBY_VERSION)
 
-RUBY_1_8 = defined?(RUBY_VERSION) && RUBY_VERSION < '1.9'
-JRUBY    = defined?(JRUBY_VERSION)
-
-if RUBY_1_8 and not ENV['BUNDLE_GEMFILE']
-  require 'rubygems'
-  gem 'test-unit'
-end
-
-if ENV['COVERAGE'] && ENV['CI'].nil? && !RUBY_1_8
+if ENV['COVERAGE']
   require 'simplecov'
-  SimpleCov.start { add_filter "/test|test_/" }
-end
-
-if ENV['CI'] && !RUBY_1_8
-  require 'simplecov'
-  require 'simplecov-rcov'
-  SimpleCov.formatter = SimpleCov::Formatter::RcovFormatter
   SimpleCov.start { add_filter "/test|test_" }
 end
 

--- a/elasticsearch/test/test_helper.rb
+++ b/elasticsearch/test/test_helper.rb
@@ -33,8 +33,6 @@ if defined?(RUBY_VERSION) && RUBY_VERSION > '1.9'
   at_exit { Elasticsearch::Test::IntegrationTestCase.__run_at_exit_hooks }
 end
 
-require 'test/unit' if RUBY_1_8
-
 require 'minitest/autorun'
 require 'minitest/reporters'
 require 'shoulda/context'
@@ -83,8 +81,7 @@ module Elasticsearch
       extend Elasticsearch::Extensions::Test::StartupShutdown
 
       shutdown { Elasticsearch::Extensions::Test::Cluster.stop if ENV['SERVER'] && started? && Elasticsearch::Extensions::Test::Cluster.running? }
-      context "IntegrationTest" do; should "noop on Ruby 1.8" do; end; end if RUBY_1_8
-    end if defined?(RUBY_VERSION) && RUBY_VERSION > '1.9'
+    end
   end
 
   module Test
@@ -93,7 +90,6 @@ module Elasticsearch
       extend Elasticsearch::Extensions::Test::Profiling
 
       shutdown { Elasticsearch::Extensions::Test::Cluster.stop if ENV['SERVER'] && started? && Elasticsearch::Extensions::Test::Cluster.running? }
-      context "IntegrationTest" do; should "noop on Ruby 1.8" do; end; end if RUBY_1_8
-    end unless RUBY_1_8 || JRUBY
+    end unless JRUBY
   end
 end


### PR DESCRIPTION
Backports #1334 

- Updates calling simplecov
- Removes simplecov-rcov dependency: Gem is no longer maintained and not currently relevant.
- Clarifies READMEs for using COVERAGE
- Simplifies defaults for `elasticsearch` tests