### PR TITLE
Fix CHANGELOG.md for 7.13.1 version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
-## 7.13.0
+## 7.13.1
 
 ### Client
-- Fixes thread safety issue in `get_connection` - [https://github.com/elastic/elasticsearch-ruby/pull/1325](Pull Request).
+- Fixes thread safety issue in `get_connection` - [Pull Request](https://github.com/elastic/elasticsearch-ruby/pull/1325).
 
 ## 7.13.0
 


### PR DESCRIPTION
Hi! I noticed that https://github.com/elastic/elasticsearch-ruby/pull/1333 accidentally had broken GitHub markdown formatting and that it also accidentally copy-pasted 7.13.1 version to be 7.13.0 instead.

This PR fixes the CHANGELOG.md so that it links correctly to #1325 and that the version shown in there is correct.