### PR TITLE
[XPACK] Shows deprecation warning first time xpack is used

### DIFF
--- a/elasticsearch-xpack/lib/elasticsearch/xpack.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack.rb
@@ -65,6 +65,12 @@ module Elasticsearch
       end
 
       def xpack
+        unless @xpack
+          warn('Deprecation notice: The elasticsearch-xpack gem will be deprecated and all the ' \
+               "functionality will be available from elasticsearch-api.\n" \
+               'See https://github.com/elastic/elasticsearch-ruby/issues/1274'
+              )
+        end
         @xpack ||= Elasticsearch::XPack::API::Client.new(self)
       end
 


### PR DESCRIPTION
This adds a warning (**only the first time**) the `.xpack` namespace is called over an instance of the Client.
![image](https://user-images.githubusercontent.com/689327/123968025-c48c5480-d9ae-11eb-8190-6e2c7506b239.png)

See https://github.com/elastic/elasticsearch-ruby/issues/1274