### PR TITLE
Updates Manticore implementation

### DIFF
--- a/elasticsearch-transport/lib/elasticsearch/transport/transport/http/manticore.rb
+++ b/elasticsearch-transport/lib/elasticsearch/transport/transport/http/manticore.rb
@@ -63,6 +63,7 @@ module Elasticsearch
           include Base
 
           def initialize(arguments={}, &block)
+            @request_options = { headers: (arguments.dig(:transport_options, :headers) || {}) }
             @manticore = build_client(arguments[:options] || {})
             super(arguments, &block)
           end
@@ -109,7 +110,6 @@ module Elasticsearch
           # @return [Connections::Collection]
           #
           def __build_connections
-            @request_options = {}
             apply_headers(@request_options, options[:transport_options])
             apply_headers(@request_options, options)
 
@@ -155,11 +155,11 @@ module Elasticsearch
           private
 
           def apply_headers(request_options, options)
-            headers = (options && options[:headers]) || {}
+            headers = options&.[](:headers) || {}
             headers[CONTENT_TYPE_STR] = find_value(headers, CONTENT_TYPE_REGEX) || DEFAULT_CONTENT_TYPE
             headers[USER_AGENT_STR] = find_value(headers, USER_AGENT_REGEX) || user_agent_header
             headers[ACCEPT_ENCODING] = GZIP if use_compression?
-            request_options.merge!(headers: headers)
+            request_options[:headers].merge!(headers)
           end
 
           def user_agent_header

--- a/elasticsearch-transport/test/unit/transport_manticore_test.rb
+++ b/elasticsearch-transport/test/unit/transport_manticore_test.rb
@@ -17,166 +17,213 @@
 
 require 'test_helper'
 
-unless JRUBY
-  version = ( defined?(RUBY_ENGINE) ? RUBY_ENGINE : 'Ruby' ) + ' ' + RUBY_VERSION
-  puts "SKIP: '#{File.basename(__FILE__)}' only supported on JRuby (you're running #{version})"
-else
+if JRUBY
   require 'elasticsearch/transport/transport/http/manticore'
   require 'manticore'
 
-  class Elasticsearch::Transport::Transport::HTTP::ManticoreTest < Minitest::Test
-    include Elasticsearch::Transport::Transport::HTTP
+  module Elasticsearch
+    module Transport
+      module Transport
+        module HTTP
+          class ManticoreTest < Minitest::Test
+            include Elasticsearch::Transport::Transport::HTTP
 
-    context "Manticore transport" do
-      setup do
-        @transport = Manticore.new :hosts => [ { :host => '127.0.0.1', :port => 8080 } ]
-      end
+            def common_headers
+              {
+                'Content-Type' => 'application/json',
+                'User-Agent' => @transport.send(:user_agent_header)
+              }
+            end
 
-      should "implement host_unreachable_exceptions" do
-        assert_instance_of Array, @transport.host_unreachable_exceptions
-      end
+            context 'Manticore transport' do
+              setup do
+                @transport = Manticore.new(hosts: [{ host: '127.0.0.1', port: 8080 }])
+              end
 
-      should "implement __build_connections" do
-        assert_equal 1, @transport.hosts.size
-        assert_equal 1, @transport.connections.size
+              should 'implement host_unreachable_exceptions' do
+                assert_instance_of Array, @transport.host_unreachable_exceptions
+              end
 
-        assert_instance_of ::Manticore::Client,   @transport.connections.first.connection
-      end
+              should 'implement __build_connections' do
+                assert_equal 1, @transport.hosts.size
+                assert_equal 1, @transport.connections.size
 
-      should "not close connections in __close_connections" do
-        assert_equal 1, @transport.connections.size
-        @transport.__close_connections
-        assert_equal 1, @transport.connections.size
-      end
+                assert_instance_of(::Manticore::Client, @transport.connections.first.connection)
+              end
 
-      should "perform the request" do
-        @transport.connections.first.connection.expects(:get).returns(stub_everything)
-        @transport.perform_request 'GET', '/'
-      end
+              should 'not close connections in __close_connections' do
+                assert_equal 1, @transport.connections.size
+                @transport.__close_connections
+                assert_equal 1, @transport.connections.size
+              end
 
-      should "set body for GET request" do
-        @transport.connections.first.connection.expects(:get).
-          with('http://127.0.0.1:8080/', {:body => '{"foo":"bar"}',
-                                           :headers => {"Content-Type" => "application/json",
-                                                        "User-Agent" => @transport.send(:user_agent_header)}}).returns(stub_everything)
-        @transport.perform_request 'GET', '/', {}, '{"foo":"bar"}'
-      end
+              should 'perform the request' do
+                @transport.connections.first.connection.expects(:get).returns(stub_everything)
+                response = @transport.perform_request('GET', '/')
+              end
 
-      should "set body for PUT request" do
-        @transport.connections.first.connection.expects(:put).
-          with('http://127.0.0.1:8080/', {:body => '{"foo":"bar"}',
-                                           :headers => {"Content-Type" => "application/json",
-                                                        "User-Agent" => @transport.send(:user_agent_header)}}).returns(stub_everything)
-        @transport.perform_request 'PUT', '/', {}, {:foo => 'bar'}
-      end
+              should 'set body for GET request' do
+                @transport.connections.first.connection.expects(:get)
+                  .with(
+                    'http://127.0.0.1:8080/',
+                    {
+                      body: '{"foo":"bar"}',
+                      headers: common_headers
+                    }
+                  ).returns(stub_everything)
+                @transport.perform_request 'GET', '/', {}, '{"foo":"bar"}'
+              end
 
-      should "serialize the request body" do
-        @transport.connections.first.connection.expects(:post).
-          with('http://127.0.0.1:8080/', {:body => '{"foo":"bar"}',
-                                           :headers => {"Content-Type" => "application/json",
-                                                        "User-Agent" => @transport.send(:user_agent_header)}}).returns(stub_everything)
-        @transport.perform_request 'POST', '/', {}, {'foo' => 'bar'}
-      end
+              should 'set body for PUT request' do
+                @transport.connections.first.connection.expects(:put)
+                  .with(
+                    'http://127.0.0.1:8080/',
+                    {
+                      body: '{"foo":"bar"}',
+                      headers: {
+                        'Content-Type' => 'application/json',
+                        'User-Agent' => @transport.send(:user_agent_header)
+                      }
+                    }
+                  ).returns(stub_everything)
+                @transport.perform_request 'PUT', '/', {}, { foo: 'bar' }
+              end
 
-      should "set custom headers for PUT request" do
-        @transport.connections.first.connection.expects(:put).
-          with('http://127.0.0.1:8080/', {:body => '{"foo":"bar"}',
-                                           :headers => {"Content-Type" => "application/json",
-                                                        "User-Agent" => @transport.send(:user_agent_header)}})
-          .returns(stub_everything)
-        @transport.perform_request 'PUT', '/', {}, '{"foo":"bar"}', {"Content-Type" => "application/x-ndjson"}
-      end
+              should 'serialize the request body' do
+                @transport.connections.first.connection.expects(:post)
+                  .with(
+                    'http://127.0.0.1:8080/',
+                    {
+                      body: '{"foo":"bar"}',
+                      headers: {
+                        'Content-Type' => 'application/json',
+                        'User-Agent' => @transport.send(:user_agent_header)
+                      }
+                    }
+                  ).returns(stub_everything)
+                @transport.perform_request 'POST', '/', {}, { 'foo' => 'bar' }
+              end
 
-      should "not serialize a String request body" do
-        @transport.connections.first.connection.expects(:post).
-          with('http://127.0.0.1:8080/', {:body => '{"foo":"bar"}',
-                                           :headers => {"Content-Type" => "application/json",
-                                                        "User-Agent" => @transport.send(:user_agent_header)}}).returns(stub_everything)
-        @transport.serializer.expects(:dump).never
-        @transport.perform_request 'POST', '/', {}, '{"foo":"bar"}'
-      end
+              should 'set custom headers for PUT request' do
+                @transport.connections.first.connection.expects(:put)
+                  .with(
+                    'http://127.0.0.1:8080/',
+                    {
+                      body: '{"foo":"bar"}',
+                      headers: {
+                        'Content-Type' => 'application/json',
+                        'User-Agent' => @transport.send(:user_agent_header)
+                      }
+                    }
+                  ).returns(stub_everything)
+                @transport.perform_request 'PUT', '/', {}, '{"foo":"bar"}', { 'Content-Type' => 'application/x-ndjson' }
+              end
 
-      should "set application/json header" do
-        options = {
-          :headers => { "content-type" => "application/json"}
-        }
+              should 'not serialize a String request body' do
+                @transport.connections.first.connection.expects(:post)
+                  .with(
+                    'http://127.0.0.1:8080/',
+                    {
+                      body: '{"foo":"bar"}',
+                      headers: {
+                        'Content-Type' => 'application/json',
+                        'User-Agent' => @transport.send(:user_agent_header)
+                      }
+                    }
+                  ).returns(stub_everything)
+                @transport.serializer.expects(:dump).never
+                @transport.perform_request 'POST', '/', {}, '{"foo":"bar"}'
+              end
 
-        transport = Manticore.new :hosts => [ { :host => 'localhost', :port => 8080 } ], :options => options
+              should 'set application/json header' do
+                options = {
+                  headers: { 'content-type' => 'application/json' }
+                }
 
-        transport.connections.first.connection.stub("http://localhost:8080/", :body => "\"\"", :headers => {"Content-Type" => "application/x-ndjson",
-                                                                                                             "User-Agent" => @transport.send(:user_agent_header)}, :code => 200 )
+                transport = Manticore.new(hosts: [{ host: 'localhost', port: 8080 }], options: options)
+                transport.connections.first.connection.stub(
+                  'http://localhost:8080/',
+                  body: '""',
+                  headers: {
+                    'Content-Type' => 'application/x-ndjson',
+                    'User-Agent' => @transport.send(:user_agent_header)
+                  },
+                  code: 200
+                )
+                response = transport.perform_request('GET', '/', {})
+                assert_equal response.status, 200
+              end
 
-        response = transport.perform_request 'GET', '/', {}
-        assert_equal response.status, 200
-      end
+              should "set headers from 'transport_options'" do
+                options = {
+                  transport_options: {
+                    headers: { 'Content-Type' => 'foo/bar' }
+                  }
+                }
 
-      should "set headers from 'transport_options'" do
-        options = {
-          :transport_options => {
-            :headers => { "Content-Type" => "foo/bar"}
-          }
-        }
+                transport = Manticore.new(hosts: [{ host: 'localhost', port: 8080 }], options: options)
 
-        transport = Manticore.new :hosts => [ { :host => 'localhost', :port => 8080 } ], :options => options
+                assert_equal(
+                  'foo/bar',
+                  transport.connections.first.connection.instance_variable_get(:@options)[:headers]['Content-Type']
+                )
+                # TODO: Needs to check @request_options
+              end
 
-        assert_equal('foo/bar', transport.connections.first.connection.instance_variable_get(:@options)[:headers]['Content-Type'])
-        # TODO: Needs to check @request_options
-      end
+              should 'handle HTTP methods' do
+                @transport.connections.first.connection.expects(:delete).with('http://127.0.0.1:8080/', { headers: common_headers }).returns(stub_everything)
+                @transport.connections.first.connection.expects(:head).with('http://127.0.0.1:8080/', { headers: common_headers }).returns(stub_everything)
+                @transport.connections.first.connection.expects(:get).with('http://127.0.0.1:8080/', { headers: common_headers }).returns(stub_everything)
+                @transport.connections.first.connection.expects(:put).with('http://127.0.0.1:8080/', { headers: common_headers }).returns(stub_everything)
+                @transport.connections.first.connection.expects(:post).with('http://127.0.0.1:8080/', { headers: common_headers }).returns(stub_everything)
 
-      should "handle HTTP methods" do
-        @transport.connections.first.connection.expects(:delete).with('http://127.0.0.1:8080/', { headers: {"Content-Type" => "application/json",
-                                                                                                             "User-Agent" => @transport.send(:user_agent_header)}}).returns(stub_everything)
-        @transport.connections.first.connection.expects(:head).with('http://127.0.0.1:8080/', { headers: {"Content-Type" => "application/json",
-                                                                                                           "User-Agent" => @transport.send(:user_agent_header)}}).returns(stub_everything)
-        @transport.connections.first.connection.expects(:get).with('http://127.0.0.1:8080/', { headers: {"Content-Type" => "application/json",
-                                                                                                          "User-Agent" => @transport.send(:user_agent_header)}}).returns(stub_everything)
-        @transport.connections.first.connection.expects(:put).with('http://127.0.0.1:8080/', { headers: {"Content-Type" => "application/json",
-                                                                                                          "User-Agent" => @transport.send(:user_agent_header)}}).returns(stub_everything)
-        @transport.connections.first.connection.expects(:post).with('http://127.0.0.1:8080/', { headers: {"Content-Type" => "application/json",
-                                                                                                           "User-Agent" => @transport.send(:user_agent_header)}}).returns(stub_everything)
+                %w[HEAD GET PUT POST DELETE].each { |method| @transport.perform_request method, '/' }
 
-        %w| HEAD GET PUT POST DELETE |.each { |method| @transport.perform_request method, '/' }
+                assert_raise(ArgumentError) { @transport.perform_request 'FOOBAR', '/' }
+              end
 
-        assert_raise(ArgumentError) { @transport.perform_request 'FOOBAR', '/' }
-      end
+              should 'allow to set options for Manticore' do
+                options = { headers: { 'User-Agent' => 'myapp-0.0' } }
+                transport = Manticore.new hosts: [{ host: 'foobar', port: 1234 }], options: options
+                transport.connections.first.connection
+                  .expects(:get)
+                  .with do |_host, _options|
+                  assert_equal 'myapp-0.0', _options[:headers]['User-Agent']
+                  true
+                end
+                  .returns(stub_everything)
 
-      should "allow to set options for Manticore" do
-        options = { :headers => {"User-Agent" => "myapp-0.0" }}
-        transport = Manticore.new :hosts => [ { :host => 'foobar', :port => 1234 } ], :options => options
-        transport.connections.first.connection
-          .expects(:get)
-          .with do |host, _options|
-            assert_equal 'myapp-0.0', _options[:headers]['User-Agent']
-            true
+                transport.perform_request 'GET', '/', {}
+              end
+
+              should 'allow to set ssl options for Manticore' do
+                options = {
+                  ssl: {
+                    truststore: 'test.jks',
+                    truststore_password: 'test',
+                    verify: false
+                  }
+                }
+
+                ::Manticore::Client.expects(:new).with(options)
+                transport = Manticore.new hosts: [{ host: 'foobar', port: 1234 }], options: options
+              end
+
+              should 'pass :transport_options to Manticore::Client' do
+                options = {
+                  transport_options: { potatoes: 1 }
+                }
+
+                ::Manticore::Client.expects(:new).with(potatoes: 1, ssl: {})
+                transport = Manticore.new hosts: [{ host: 'foobar', port: 1234 }], options: options
+              end
+            end
           end
-          .returns(stub_everything)
-
-        transport.perform_request 'GET', '/', {}
-      end
-
-      should "allow to set ssl options for Manticore" do
-        options = {
-          :ssl => {
-            :truststore => "test.jks",
-            :truststore_password => "test",
-            :verify => false
-          }
-        }
-
-        ::Manticore::Client.expects(:new).with(options)
-        transport = Manticore.new :hosts => [ { :host => 'foobar', :port => 1234 } ], :options => options
-      end
-
-      should "pass :transport_options to Manticore::Client" do
-        options = {
-          :transport_options => { :potatoes => 1 }
-        }
-
-        ::Manticore::Client.expects(:new).with(:potatoes => 1, :ssl => {})
-        transport = Manticore.new :hosts => [ { :host => 'foobar', :port => 1234 } ], :options => options
+        end
       end
     end
-
   end
-
+else
+  version = "#{defined?(RUBY_ENGINE) ? RUBY_ENGINE : 'Ruby'} #{RUBY_VERSION}"
+  puts "SKIP: '#{File.basename(__FILE__)}' only supported on JRuby (you're running #{version})"
 end

--- a/elasticsearch-transport/test/unit/transport_manticore_test.rb
+++ b/elasticsearch-transport/test/unit/transport_manticore_test.rb
@@ -184,7 +184,7 @@ if JRUBY
 
               should 'allow to set options for Manticore' do
                 options = { headers: { 'User-Agent' => 'myapp-0.0' } }
-                transport = Manticore.new hosts: [{ host: 'foobar', port: 1234 }], options: options
+                transport = Manticore.new(hosts: [{ host: 'foobar', port: 1234 }], options: options)
                 transport.connections.first.connection
                   .expects(:get)
                   .with do |_host, _options|
@@ -209,13 +209,35 @@ if JRUBY
                 transport = Manticore.new hosts: [{ host: 'foobar', port: 1234 }], options: options
               end
 
+              should 'allow custom headers' do
+                transport_options = { headers: { 'Authorization' => 'Basic token' } }
+                transport = Manticore.new(
+                  hosts: [{ host: 'foobar', port: 1234 }],
+                  transport_options: transport_options
+                )
+
+                assert_equal(
+                  transport.instance_variable_get(:@request_options)[:headers]['Authorization'],
+                  'Basic token'
+                )
+                transport.connections.first.connection
+                  .expects(:get)
+                  .with do |_host, _options|
+                  assert_equal('Basic token', _options[:headers]['Authorization'])
+                  true
+                end
+                  .returns(stub_everything)
+
+                transport.perform_request('GET', '/', {})
+              end
+
               should 'pass :transport_options to Manticore::Client' do
                 options = {
                   transport_options: { potatoes: 1 }
                 }
 
                 ::Manticore::Client.expects(:new).with(potatoes: 1, ssl: {})
-                transport = Manticore.new hosts: [{ host: 'foobar', port: 1234 }], options: options
+                transport = Manticore.new(hosts: [{ host: 'foobar', port: 1234 }], options: options)
               end
             end
           end


### PR DESCRIPTION
If we're sending headers in the `transport_options` parameter, this implementation saves them in an instance variable. When we build the client, `Manticore::Client.new` doesn't store headers, so I think that's how we were losing it in the first place. And since `request_options[:headers]` is being initialized, we don't need the `||=` fix now.

Related: #1428, #1426