### PR TITLE
CA Fingerprinting

### DIFF
--- a/elasticsearch-transport/elasticsearch-transport.gemspec
+++ b/elasticsearch-transport/elasticsearch-transport.gemspec
@@ -50,7 +50,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'ansi'
   s.add_development_dependency 'bundler'
   s.add_development_dependency 'cane'
-  s.add_development_dependency 'curb'   unless defined? JRUBY_VERSION
+  s.add_development_dependency 'curb' unless defined? JRUBY_VERSION
   s.add_development_dependency 'hashie'
   s.add_development_dependency 'httpclient'
   s.add_development_dependency 'manticore' if defined? JRUBY_VERSION

--- a/elasticsearch-transport/lib/elasticsearch/transport/client.rb
+++ b/elasticsearch-transport/lib/elasticsearch/transport/client.rb
@@ -115,6 +115,7 @@ module Elasticsearch
       #
       # @option enable_meta_header [Boolean] :enable_meta_header Enable sending the meta data header to Cloud.
       #                                                          (Default: true)
+      # @option ca_fingerprint [String] :ca_fingerprint provide this value to only trust certificates that are signed by a specific CA certificate
       #
       # @yield [faraday] Access and configure the `Faraday::Connection` instance directly with a block
       #
@@ -140,6 +141,7 @@ module Elasticsearch
                                  DEFAULT_HOST)
 
         @send_get_body_as = @arguments[:send_get_body_as] || 'GET'
+        @ca_fingerprint = @arguments.delete(:ca_fingerprint)
 
         if @arguments[:request_timeout]
           @arguments[:transport_options][:request] = { timeout: @arguments[:request_timeout] }
@@ -162,14 +164,41 @@ module Elasticsearch
                        end
         end
       end
+
       # Performs a request through delegation to {#transport}.
       #
       def perform_request(method, path, params = {}, body = nil, headers = nil)
         method = @send_get_body_as if 'GET' == method && body
+        validate_ca_fingerprints if @ca_fingerprint
         transport.perform_request(method, path, params, body, headers)
       end
 
       private
+
+      def validate_ca_fingerprints
+        transport.connections.connections.each do |connection|
+          unless connection.host[:scheme] == 'https'
+            raise Elasticsearch::Transport::Transport::Error, 'CA fingerprinting can\'t be configured over http'
+          end
+
+          next if connection.verified
+
+          ctx = OpenSSL::SSL::SSLContext.new
+          socket = TCPSocket.new(connection.host[:host], connection.host[:port])
+          ssl = OpenSSL::SSL::SSLSocket.new(socket, ctx)
+          ssl.connect
+          cert_store = ssl.peer_cert_chain
+          matching_certs = cert_store.chain.select do |cert|
+            OpenSSL::Digest::SHA256.hexdigest(cert.to_der).upcase == @ca_fingerprint.upcase
+          end
+          if matching_certs.empty?
+            raise Elasticsearch::Transport::Transport::Error,
+                  'Server certificate CA fingerprint does not match the value configured in ca_fingerprint'
+          end
+
+          connection.verified = true
+        end
+      end
 
       def add_header(header)
         headers = @arguments[:transport_options]&.[](:headers) || {}

--- a/elasticsearch-transport/lib/elasticsearch/transport/client.rb
+++ b/elasticsearch-transport/lib/elasticsearch/transport/client.rb
@@ -188,7 +188,7 @@ module Elasticsearch
           ssl = OpenSSL::SSL::SSLSocket.new(socket, ctx)
           ssl.connect
           cert_store = ssl.peer_cert_chain
-          matching_certs = cert_store.chain.select do |cert|
+          matching_certs = cert_store.select do |cert|
             OpenSSL::Digest::SHA256.hexdigest(cert.to_der).upcase == @ca_fingerprint.upcase
           end
           if matching_certs.empty?

--- a/elasticsearch-transport/lib/elasticsearch/transport/transport/connections/connection.rb
+++ b/elasticsearch-transport/lib/elasticsearch/transport/transport/connections/connection.rb
@@ -33,6 +33,7 @@ module Elasticsearch
           DEFAULT_RESURRECT_TIMEOUT = 60
 
           attr_reader :host, :connection, :options, :failures, :dead_since
+          attr_accessor :verified
 
           # @option arguments [Hash]   :host       Host information (example: `{host: 'localhost', port: 9200}`)
           # @option arguments [Object] :connection The transport-specific physical connection or "session"
@@ -42,6 +43,7 @@ module Elasticsearch
             @host       = arguments[:host].is_a?(Hash) ? Redacted.new(arguments[:host]) : arguments[:host]
             @connection = arguments[:connection]
             @options    = arguments[:options] || {}
+            @verified   = false
             @state_mutex = Mutex.new
 
             @options[:resurrect_timeout] ||= DEFAULT_RESURRECT_TIMEOUT
@@ -153,7 +155,6 @@ module Elasticsearch
             "<#{self.class.name} host: #{host} (#{dead? ? 'dead since ' + dead_since.to_s : 'alive'})>"
           end
         end
-
       end
     end
   end

--- a/elasticsearch-transport/lib/elasticsearch/transport/transport/http/faraday.rb
+++ b/elasticsearch-transport/lib/elasticsearch/transport/transport/http/faraday.rb
@@ -61,7 +61,7 @@ module Elasticsearch
           def __build_connection(host, options={}, block=nil)
             client = ::Faraday.new(__full_url(host), options, &block)
             apply_headers(client, options)
-            Connections::Connection.new :host => host, :connection => client
+            Connections::Connection.new(host: host, connection: client)
           end
 
           # Returns an array of implementation specific connection errors.


### PR DESCRIPTION
This will allow to trust certificates that are signed by a specific CA certificate:

```ruby
client = Elasticsearch::Client.new(
  ca_fingerprint: 'fingerprint_value',
  host: "https://elastic:#{password}@#{server}:#{port}",
  adapter: :net_http
)
```