### PR TITLE
Fix compression

### DIFF
--- a/elasticsearch-transport/lib/elasticsearch/transport/transport/base.rb
+++ b/elasticsearch-transport/lib/elasticsearch/transport/transport/base.rb
@@ -377,17 +377,17 @@ module Elasticsearch
 
         USER_AGENT_STR = 'User-Agent'.freeze
         USER_AGENT_REGEX = /user\-?\_?agent/
+        ACCEPT_ENCODING = 'Accept-Encoding'.freeze
+        CONTENT_ENCODING = 'Content-Encoding'.freeze
         CONTENT_TYPE_STR = 'Content-Type'.freeze
         CONTENT_TYPE_REGEX = /content\-?\_?type/
         DEFAULT_CONTENT_TYPE = 'application/json'.freeze
         GZIP = 'gzip'.freeze
-        ACCEPT_ENCODING = 'Accept-Encoding'.freeze
         GZIP_FIRST_TWO_BYTES = '1f8b'.freeze
         HEX_STRING_DIRECTIVE = 'H*'.freeze
         RUBY_ENCODING = '1.9'.respond_to?(:force_encoding)
 
         def decompress_response(body)
-          return body unless use_compression?
           return body unless gzipped?(body)
 
           io = StringIO.new(body)
@@ -411,7 +411,10 @@ module Elasticsearch
           headers = options[:headers] || {}
           headers[CONTENT_TYPE_STR] = find_value(headers, CONTENT_TYPE_REGEX) || DEFAULT_CONTENT_TYPE
           headers[USER_AGENT_STR] = find_value(headers, USER_AGENT_REGEX) || user_agent_header(client)
-          client.headers[ACCEPT_ENCODING] = GZIP if use_compression?
+          if use_compression?
+            client.headers[ACCEPT_ENCODING] = GZIP
+            client.headers[CONTENT_ENCODING] = GZIP
+          end
           client.headers.merge!(headers)
         end
 

--- a/elasticsearch-transport/spec/elasticsearch/transport/client_spec.rb
+++ b/elasticsearch-transport/spec/elasticsearch/transport/client_spec.rb
@@ -1400,7 +1400,11 @@ describe Elasticsearch::Transport::Client do
             end
 
             it 'sets the Accept-Encoding header' do
-              expect(client.transport.connections[0].connection.headers['Accept-Encoding'])
+              expect(client.transport.connections[0].connection.headers['Accept-Encoding']).to eq 'gzip'
+            end
+
+            it 'sets the Content-Encoding header' do
+              expect(client.transport.connections[0].connection.headers['Content-Encoding']).to eq 'gzip'
             end
 
             it 'preserves the other headers' do
@@ -1419,7 +1423,11 @@ describe Elasticsearch::Transport::Client do
             end
 
             it 'sets the Accept-Encoding header' do
-              expect(client.transport.connections[0].connection.headers['Accept-Encoding'])
+              expect(client.transport.connections[0].connection.headers['Accept-Encoding']).to eq 'gzip'
+            end
+
+            it 'sets the Content-Encoding header' do
+              expect(client.transport.connections[0].connection.headers['Content-Encoding']).to eq 'gzip'
             end
 
             it 'preserves the other headers' do
@@ -1437,7 +1445,11 @@ describe Elasticsearch::Transport::Client do
             end
 
             it 'sets the Accept-Encoding header' do
-              expect(client.transport.connections[0].connection.headers['Accept-Encoding'])
+              expect(client.transport.connections[0].connection.headers['Accept-Encoding']).to eq 'gzip'
+            end
+
+            it 'sets the Content-Encoding header' do
+              expect(client.transport.connections[0].connection.headers['Content-Encoding']).to eq 'gzip'
             end
 
             it 'preserves the other headers' do
@@ -1455,7 +1467,11 @@ describe Elasticsearch::Transport::Client do
             end
 
             it 'sets the Accept-Encoding header' do
-              expect(client.transport.connections[0].connection.headers['Accept-Encoding'])
+              expect(client.transport.connections[0].connection.headers['Accept-Encoding']).to eq 'gzip'
+            end
+
+            it 'sets the Content-Encoding header' do
+              expect(client.transport.connections[0].connection.headers['Content-Encoding']).to eq 'gzip'
             end
 
             it 'preserves the other headers' do
@@ -1473,7 +1489,11 @@ describe Elasticsearch::Transport::Client do
             end
 
             it 'sets the Accept-Encoding header' do
-              expect(client.transport.connections[0].connection.headers['Accept-Encoding'])
+              expect(client.transport.connections[0].connection.headers['Accept-Encoding']).to eq 'gzip'
+            end
+
+            it 'sets the Content-Encoding header' do
+              expect(client.transport.connections[0].connection.headers['Content-Encoding']).to eq 'gzip'
             end
 
             it 'preserves the other headers' do
@@ -1495,7 +1515,11 @@ describe Elasticsearch::Transport::Client do
         end
 
         it 'sets the Accept-Encoding header' do
-          expect(client.transport.connections[0].connection.headers['Accept-Encoding'])
+          expect(client.transport.connections[0].connection.headers['Accept-Encoding']).to eq 'gzip'
+        end
+
+        it 'sets the Content-Encoding header' do
+          expect(client.transport.connections[0].connection.headers['Content-Encoding']).to eq 'gzip'
         end
 
         it 'preserves the other headers' do


### PR DESCRIPTION
It would be lovely if the `compression: true` option actually, you know, compressed things.

- "compression" option should compress outbound requests. This is achieved by setting `Content-Encoding: gzip`, which is automatically handled by the downstream lib.
- Always decompress compressed responses, whether or not `compression` is set.
