### PR TITLE
[API] Test Runner: Use strict_encode for base 64 variables

### DIFF
--- a/api-spec-testing/test_file/task_group.rb
+++ b/api-spec-testing/test_file/task_group.rb
@@ -304,7 +304,7 @@ module Elasticsearch
                   fields.include?(key)
                 end.values if fields
 
-                to_set = Base64.encode64(values_to_encode.join(':'))
+                to_set = Base64.strict_encode64(values_to_encode.join(':'))
                 @test.cache_value(response_key, to_set)
               end
             end


### PR DESCRIPTION
Backports #1496