### PR TITLE
[Client] Adds delay_on_retry to wait between each failed connection

### DIFF
--- a/elasticsearch-transport/lib/elasticsearch/transport/client.rb
+++ b/elasticsearch-transport/lib/elasticsearch/transport/client.rb
@@ -86,6 +86,8 @@ module Elasticsearch
       #
       # @option arguments [Boolean,Number] :retry_on_failure   Retry X times when request fails before raising and
       #                                                        exception (false by default)
+      # @option arguments [Number] :delay_on_retry  Delay in milliseconds between each retry (0 by default)
+      #
       # @option arguments Array<Number> :retry_on_status Retry when specific status codes are returned
       #
       # @option arguments [Boolean] :reload_on_failure Reload connections after failure (false by default)
@@ -126,6 +128,7 @@ module Elasticsearch
         @arguments[:tracer] ||= @arguments[:trace] ? DEFAULT_TRACER.call() : nil
         @arguments[:reload_connections] ||= false
         @arguments[:retry_on_failure]   ||= false
+        @arguments[:delay_on_retry]     ||= 0
         @arguments[:reload_on_failure]  ||= false
         @arguments[:randomize_hosts]    ||= false
         @arguments[:transport_options]  ||= {}

--- a/elasticsearch-transport/lib/elasticsearch/transport/transport/base.rb
+++ b/elasticsearch-transport/lib/elasticsearch/transport/transport/base.rb
@@ -54,6 +54,7 @@ module Elasticsearch
           @options     = arguments[:options] || {}
           @options[:http] ||= {}
           @options[:retry_on_status] ||= []
+          @options[:delay_on_retry]  ||= 0
 
           @block       = block
           @compression = !!@options[:compression]
@@ -274,6 +275,7 @@ module Elasticsearch
           start = Time.now
           tries = 0
           reload_on_failure = opts.fetch(:reload_on_failure, @options[:reload_on_failure])
+          delay_on_retry = opts.fetch(:delay_on_retry, @options[:delay_on_retry])
 
           max_retries = if opts.key?(:retry_on_failure)
             opts[:retry_on_failure] === true ? DEFAULT_MAX_RETRIES : opts[:retry_on_failure]
@@ -285,6 +287,7 @@ module Elasticsearch
           ignore = Array(params.delete(:ignore)).compact.map { |s| s.to_i }
 
           begin
+            sleep(delay_on_retry / 1000.0) if tries > 0
             tries     += 1
             connection = get_connection or raise Error.new('Cannot get new connection from pool.')
 
@@ -316,7 +319,6 @@ module Elasticsearch
             log_error "[#{e.class}] #{e.message} #{connection.host.inspect}"
 
             connection.dead!
-
             if reload_on_failure and tries < connections.all.size
               log_warn "[#{e.class}] Reloading connections (attempt #{tries} of #{connections.all.size})"
               reload_connections! and retry

--- a/elasticsearch-transport/spec/elasticsearch/transport/client_spec.rb
+++ b/elasticsearch-transport/spec/elasticsearch/transport/client_spec.rb
@@ -1332,6 +1332,29 @@ describe Elasticsearch::Transport::Client do
         end
       end
 
+      context 'when retry_on_failure is true and delay_on_retry is specified' do
+        context 'when a node is unreachable' do
+          let(:hosts) do
+            [ELASTICSEARCH_HOSTS.first, "foobar1", "foobar2"]
+          end
+
+          let(:options) do
+            { retry_on_failure: true, delay_on_retry: 3000 }
+          end
+
+          let(:responses) do
+            5.times.collect do
+              client.perform_request('GET', '_nodes/_local')
+            end
+          end
+
+          it 'retries on failure' do
+            allow_any_instance_of(Object).to receive(:sleep).with(3000 / 1000)
+            expect(responses.all? { true }).to be(true)
+          end
+        end
+      end
+
       context 'when reload_on_failure is true' do
 
         let(:hosts) do


### PR DESCRIPTION
[Client] Adds delay_on_retry in milliseconds to wait between each failed connection.
For retro compatibility default delay is 0 but an higher value should be better.