### PR TITLE
[7.x] [DOCS] Retitle Elasticsearch Ruby Client doc book

### DIFF
--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -1,4 +1,4 @@
-= Ruby and Rails Integrations
+= Elasticsearch Ruby Client
 
 :doctype:           book
 


### PR DESCRIPTION
7.x backport of https://github.com/elastic/elasticsearch-ruby/pull/1531