### PR TITLE
Fix jbuilder dependency error

### DIFF
--- a/elasticsearch-api/elasticsearch-api.gemspec
+++ b/elasticsearch-api/elasticsearch-api.gemspec
@@ -60,11 +60,17 @@ Gem::Specification.new do |s|
   # Gems for testing integrations
   s.add_development_dependency 'jsonify'
   s.add_development_dependency 'hashie'
+  # Temporary support for Ruby 2.6, since it's EOL March 2022:
+  if RUBY_VERSION < '2.7.0'
+    s.add_development_dependency 'jbuilder', '< 7.0.0'
+  else
+    s.add_development_dependency 'activesupport'
+    s.add_development_dependency 'jbuilder'
+  end
 
-  s.add_development_dependency 'activesupport', '< 7.0.0'
   s.add_development_dependency 'cane'
   s.add_development_dependency 'escape_utils' unless defined? JRUBY_VERSION
-  s.add_development_dependency 'jbuilder'
+
   s.add_development_dependency 'require-prof' unless defined?(JRUBY_VERSION) || defined?(Rubinius)
   s.add_development_dependency 'ruby-prof' unless defined?(JRUBY_VERSION) || defined?(Rubinius)
   s.add_development_dependency 'simplecov'

--- a/elasticsearch-api/elasticsearch-api.gemspec
+++ b/elasticsearch-api/elasticsearch-api.gemspec
@@ -61,6 +61,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'jsonify'
   s.add_development_dependency 'hashie'
 
+  s.add_development_dependency 'activesupport', '< 7.0.0'
   s.add_development_dependency 'cane'
   s.add_development_dependency 'escape_utils' unless defined? JRUBY_VERSION
   s.add_development_dependency 'jbuilder'

--- a/elasticsearch-api/spec/spec_helper.rb
+++ b/elasticsearch-api/spec/spec_helper.rb
@@ -25,6 +25,7 @@ else
   require 'pry-byebug'
 end
 require 'yaml'
+require 'active_support/isolated_execution_state' unless RUBY_VERSION < '2.7.0'
 require 'jbuilder'
 require 'jsonify'
 require 'elasticsearch'


### PR DESCRIPTION
Fixing `uninitialized constant ActiveSupport::XmlMini::IsolatedExecutionState` error from `jbuilder`. 