### PR TITLE
[CI] GitHub Actions: Wrap Ruby version in quotes

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: [ 2.6, 2.7, '3.0', 3.1, jruby-9.3 ]
+        ruby: [ '2.6', '2.7', '3.0', '3.1', 'jruby-9.3' ]
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
Due to [this issue](https://github.com/ruby/setup-ruby/issues/252), Ruby 3.0 would use 3.1. Adding quotes to every version for consistency.
