### PR TITLE
[API] Escapes spaces with %20 for URL encoded strings

### DIFF
--- a/elasticsearch-api/lib/elasticsearch/api/utils.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/utils.rb
@@ -14,14 +14,13 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+require 'erb'
 
 module Elasticsearch
   module API
-
     # Generic utility methods
     #
     module Utils
-
       # URL-escape a string
       #
       # @example
@@ -31,7 +30,7 @@ module Elasticsearch
       # @api private
       def __escape(string)
         return string if string == '*'
-        defined?(EscapeUtils) ? EscapeUtils.escape_url(string.to_s) : CGI.escape(string.to_s)
+        ERB::Util.url_encode(string.to_s)
       end
 
       # Create a "list" of values from arguments, ignoring nil values and encoding special characters.

--- a/elasticsearch-api/spec/elasticsearch/api/utils_spec.rb
+++ b/elasticsearch-api/spec/elasticsearch/api/utils_spec.rb
@@ -28,25 +28,13 @@ describe Elasticsearch::API::Utils do
     end
 
     it 'encodes special characters' do
-      expect(utils.__escape('foo bar')).to eq('foo+bar')
+      expect(utils.__escape('foo bar')).to eq('foo%20bar')
       expect(utils.__escape('foo/bar')).to eq('foo%2Fbar')
       expect(utils.__escape('foo^bar')).to eq('foo%5Ebar')
     end
 
     it 'does not encode asterisks' do
       expect(utils.__escape('*')).to eq('*')
-    end
-
-    it 'users CGI.escape by default' do
-      expect(CGI).to receive(:escape).and_call_original
-      expect(utils.__escape('foo bar')).to eq('foo+bar')
-    end
-
-    it 'uses the escape_utils gem when available', unless: defined?(JRUBY_VERSION) do
-      require 'escape_utils'
-      expect(CGI).not_to receive(:escape)
-      expect(EscapeUtils).to receive(:escape_url).and_call_original
-      expect(utils.__escape('foo bar')).to eq('foo+bar')
     end
   end
 
@@ -73,7 +61,7 @@ describe Elasticsearch::API::Utils do
 
     context 'when the escape option is set to false' do
       it 'does not escape the characters' do
-        expect(utils.__listify(['foo', 'bar^bam'], :escape => false)).to eq('foo,bar^bam')
+        expect(utils.__listify(['foo', 'bar^bam'], escape: false)).to eq('foo,bar^bam')
       end
     end
   end
@@ -100,19 +88,19 @@ describe Elasticsearch::API::Utils do
     context 'when the input is an array of hashes' do
       let(:result) do
         utils.__bulkify [
-          { :index =>  { :_index => 'myindexA', :_type => 'mytype', :_id => '1', :data => { :title => 'Test' } } },
-          { :update => { :_index => 'myindexB', :_type => 'mytype', :_id => '2', :data => { :doc => { :title => 'Update' } } } },
-          { :delete => { :_index => 'myindexC', :_type => 'mytypeC', :_id => '3' } }
+          { index: { _index: 'myindexA', _id: '1', data: { title: 'Test' } } },
+          { update: { _index: 'myindexB', _id: '2', data: { doc: { title: 'Update' } } } },
+          { delete: { _index: 'myindexC', _id: '3' } }
         ]
       end
 
       let(:expected_string) do
         <<-PAYLOAD.gsub(/^\s+/, '')
-                {"index":{"_index":"myindexA","_type":"mytype","_id":"1"}}
+                {"index":{"_index":"myindexA","_id":"1"}}
                 {"title":"Test"}
-                {"update":{"_index":"myindexB","_type":"mytype","_id":"2"}}
+                {"update":{"_index":"myindexB","_id":"2"}}
                 {"doc":{"title":"Update"}}
-                {"delete":{"_index":"myindexC","_type":"mytypeC","_id":"3"}}
+                {"delete":{"_index":"myindexC","_id":"3"}}
         PAYLOAD
       end
 
@@ -316,7 +304,7 @@ describe Elasticsearch::API::Utils do
       end
 
       let(:unsupported_params) do
-        [ { :foo => { :explanation => 'NOT_SUPPORTED'} }, :moo ]
+        [ { foo: { explanation: 'NOT_SUPPORTED'} }, :moo ]
       end
 
 

--- a/elasticsearch/spec/integration/characters_escaping_spec.rb
+++ b/elasticsearch/spec/integration/characters_escaping_spec.rb
@@ -1,0 +1,94 @@
+# Licensed to Elasticsearch B.V. under one or more contributor
+# license agreements. See the NOTICE file distributed with
+# this work for additional information regarding copyright
+# ownership. Elasticsearch B.V. licenses this file to you under
+# the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+ELASTICSEARCH_URL = ENV['TEST_ES_SERVER'] || "http://localhost:#{(ENV['PORT'] || 9200)}"
+raise URI::InvalidURIError unless ELASTICSEARCH_URL =~ /\A#{URI::DEFAULT_PARSER.make_regexp}\z/
+
+require 'spec_helper'
+
+context 'Elasticsearch client' do
+  let(:client) do
+    Elasticsearch::Client.new(host: ELASTICSEARCH_URL, user: 'elastic', password: 'changeme')
+  end
+  let(:index) { 'tvs' }
+
+  after do
+    client.indices.delete(index: index)
+  end
+
+  context 'escaping spaces in ids' do
+    it 'escapes spaces for id when using index' do
+      response = client.index(index: index, id: 'a test 1', body: { name: 'A test 1' }, refresh: true)
+      expect(response.body['_id']).to eq 'a test 1'
+
+      response = client.search(index: index)
+      expect(response.body['hits']['hits'].first['_id']).to eq 'a test 1'
+
+      # Raises exception, _id is unrecognized
+      expect do
+        client.index(index: index, _id: 'a test 2', body: { name: 'A test 2' })
+      end.to raise_exception Elastic::Transport::Transport::Errors::BadRequest
+
+      # Raises exception, id is a query parameter
+      expect do
+        client.index(index: index, body: { name: 'A test 3', _id: 'a test 3' })
+      end.to raise_exception Elastic::Transport::Transport::Errors::BadRequest
+    end
+
+    it 'escapes spaces for id when using create' do
+      # Works with create
+      response = client.create(index: index, id: 'a test 4', body: { name: 'A test 4' })
+      expect(response.body['_id']).to eq 'a test 4'
+    end
+
+    it 'escapes spaces for id when using bulk' do
+      body = [
+        { create: { _index: index, _id: 'a test 5', data: { name: 'A test 5' } } }
+      ]
+      expect(client.bulk(body: body, refresh: true).status).to eq 200
+
+      response = client.search(index: index)
+      expect(
+        response.body['hits']['hits'].select { |a| a['_id'] == 'a test 5' }.size
+      ).to eq 1
+    end
+  end
+
+  context 'it doesnae escape plus signs in id' do
+    it 'escapes spaces for id when using index' do
+      response = client.index(index: index, id: 'a+test+1', body: { name: 'A test 1' })
+      expect(response.body['_id']).to eq 'a+test+1'
+    end
+
+    it 'escapes spaces for id when using create' do
+      # Works with create
+      response = client.create(index: index, id: 'a+test+2', body: { name: 'A test 2' })
+      expect(response.body['_id']).to eq 'a+test+2'
+    end
+
+    it 'escapes spaces for id when using bulk' do
+      body = [
+        { create: { _index: index, _id: 'a+test+3', data: { name: 'A test 3' } } }
+      ]
+      expect(client.bulk(body: body, refresh: true).status).to eq 200
+
+      response = client.search(index: index)
+      expect(
+        response.body['hits']['hits'].select { |a| a['_id'] == 'a+test+3' }.size
+      ).to eq 1
+    end
+  end
+end


### PR DESCRIPTION
This Pull Request addresses the issue where if you index a document with an id such as `an id`, it would get escaped to `an+id` instead of `an%20id` when using `index` or `create`. This will result in the document id being `an+id` instead of the intended value `an id`. It's an initial approach to fixing #1475.