### PR TITLE
put typhoeus as dependency

### DIFF
--- a/elasticsearch-transport/elasticsearch-transport.gemspec
+++ b/elasticsearch-transport/elasticsearch-transport.gemspec
@@ -46,6 +46,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'multi_json'
   s.add_dependency 'faraday', '~> 1'
+  s.add_dependency 'typhoeus', '~> 1.4'
 
   s.add_development_dependency 'ansi'
   s.add_development_dependency 'bundler'


### PR DESCRIPTION
if someone has `typhoeus` less than 1.4 as a requirement , it will raise `Faraday::Error::ConnectionFailed` [here](https://github.com/typhoeus/typhoeus/blob/v1.3.1/lib/typhoeus/adapters/faraday.rb#L106) which doesn't exist from farady > 1.0, so this will cause a failure