### PR TITLE
[API] Generator: Fixes order of arguments.clone

### DIFF
--- a/elasticsearch-api/lib/elasticsearch/api/actions/async_search/delete.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/async_search/delete.rb
@@ -29,11 +29,10 @@ module Elasticsearch
         def delete(arguments = {})
           raise ArgumentError, "Required argument 'id' missing" unless arguments[:id]
 
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
           body = nil
-
-          arguments = arguments.clone
 
           _id = arguments.delete(:id)
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/async_search/get.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/async_search/get.rb
@@ -32,11 +32,10 @@ module Elasticsearch
         def get(arguments = {})
           raise ArgumentError, "Required argument 'id' missing" unless arguments[:id]
 
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
           body = nil
-
-          arguments = arguments.clone
 
           _id = arguments.delete(:id)
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/async_search/status.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/async_search/status.rb
@@ -29,11 +29,10 @@ module Elasticsearch
         def status(arguments = {})
           raise ArgumentError, "Required argument 'id' missing" unless arguments[:id]
 
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
           body = nil
-
-          arguments = arguments.clone
 
           _id = arguments.delete(:id)
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/async_search/submit.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/async_search/submit.rb
@@ -69,11 +69,10 @@ module Elasticsearch
         # @see https://www.elastic.co/guide/en/elasticsearch/reference/current/async-search.html
         #
         def submit(arguments = {})
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
-          body = arguments.delete(:body)
-
-          arguments = arguments.clone
+          body   = arguments.delete(:body)
 
           _index = arguments.delete(:index)
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/autoscaling/delete_autoscaling_policy.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/autoscaling/delete_autoscaling_policy.rb
@@ -29,11 +29,10 @@ module Elasticsearch
         def delete_autoscaling_policy(arguments = {})
           raise ArgumentError, "Required argument 'name' missing" unless arguments[:name]
 
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
           body = nil
-
-          arguments = arguments.clone
 
           _name = arguments.delete(:name)
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/autoscaling/get_autoscaling_capacity.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/autoscaling/get_autoscaling_capacity.rb
@@ -26,11 +26,10 @@ module Elasticsearch
         # @see https://www.elastic.co/guide/en/elasticsearch/reference/current/autoscaling-get-autoscaling-capacity.html
         #
         def get_autoscaling_capacity(arguments = {})
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
-          body = nil
-
-          arguments = arguments.clone
+          body   = nil
 
           method = Elasticsearch::API::HTTP_GET
           path   = "_autoscaling/capacity"

--- a/elasticsearch-api/lib/elasticsearch/api/actions/autoscaling/get_autoscaling_policy.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/autoscaling/get_autoscaling_policy.rb
@@ -29,11 +29,10 @@ module Elasticsearch
         def get_autoscaling_policy(arguments = {})
           raise ArgumentError, "Required argument 'name' missing" unless arguments[:name]
 
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
           body = nil
-
-          arguments = arguments.clone
 
           _name = arguments.delete(:name)
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/autoscaling/put_autoscaling_policy.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/autoscaling/put_autoscaling_policy.rb
@@ -31,11 +31,10 @@ module Elasticsearch
           raise ArgumentError, "Required argument 'body' missing" unless arguments[:body]
           raise ArgumentError, "Required argument 'name' missing" unless arguments[:name]
 
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
           body = arguments.delete(:body)
-
-          arguments = arguments.clone
 
           _name = arguments.delete(:name)
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/bulk.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/bulk.rb
@@ -40,11 +40,10 @@ module Elasticsearch
       def bulk(arguments = {})
         raise ArgumentError, "Required argument 'body' missing" unless arguments[:body]
 
+        arguments = arguments.clone
         headers = arguments.delete(:headers) || {}
 
-        body = arguments.delete(:body)
-
-        arguments = arguments.clone
+        body   = arguments.delete(:body)
 
         _index = arguments.delete(:index)
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/cat/aliases.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/cat/aliases.rb
@@ -34,11 +34,10 @@ module Elasticsearch
         # @see https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-alias.html
         #
         def aliases(arguments = {})
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
           body = nil
-
-          arguments = arguments.clone
 
           _name = arguments.delete(:name)
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/cat/allocation.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/cat/allocation.rb
@@ -35,11 +35,10 @@ module Elasticsearch
         # @see https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-allocation.html
         #
         def allocation(arguments = {})
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
           body = nil
-
-          arguments = arguments.clone
 
           _node_id = arguments.delete(:node_id)
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/cat/component_templates.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/cat/component_templates.rb
@@ -34,11 +34,10 @@ module Elasticsearch
         # @see https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-compoentn-templates.html
         #
         def component_templates(arguments = {})
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
           body = nil
-
-          arguments = arguments.clone
 
           _name = arguments.delete(:name)
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/cat/count.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/cat/count.rb
@@ -32,11 +32,10 @@ module Elasticsearch
         # @see https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-count.html
         #
         def count(arguments = {})
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
-          body = nil
-
-          arguments = arguments.clone
+          body   = nil
 
           _index = arguments.delete(:index)
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/cat/fielddata.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/cat/fielddata.rb
@@ -33,11 +33,10 @@ module Elasticsearch
         # @see https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-fielddata.html
         #
         def fielddata(arguments = {})
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
           body = nil
-
-          arguments = arguments.clone
 
           _fields = arguments.delete(:fields)
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/cat/health.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/cat/health.rb
@@ -33,11 +33,10 @@ module Elasticsearch
         # @see https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-health.html
         #
         def health(arguments = {})
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
-          body = nil
-
-          arguments = arguments.clone
+          body   = nil
 
           method = Elasticsearch::API::HTTP_GET
           path   = "_cat/health"

--- a/elasticsearch-api/lib/elasticsearch/api/actions/cat/help.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/cat/help.rb
@@ -28,11 +28,10 @@ module Elasticsearch
         # @see https://www.elastic.co/guide/en/elasticsearch/reference/master/cat.html
         #
         def help(arguments = {})
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
-          body = nil
-
-          arguments = arguments.clone
+          body   = nil
 
           method = Elasticsearch::API::HTTP_GET
           path   = "_cat"

--- a/elasticsearch-api/lib/elasticsearch/api/actions/cat/indices.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/cat/indices.rb
@@ -39,11 +39,10 @@ module Elasticsearch
         # @see https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-indices.html
         #
         def indices(arguments = {})
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
-          body = nil
-
-          arguments = arguments.clone
+          body   = nil
 
           _index = arguments.delete(:index)
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/cat/master.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/cat/master.rb
@@ -33,11 +33,10 @@ module Elasticsearch
         # @see https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-master.html
         #
         def master(arguments = {})
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
-          body = nil
-
-          arguments = arguments.clone
+          body   = nil
 
           method = Elasticsearch::API::HTTP_GET
           path   = "_cat/master"

--- a/elasticsearch-api/lib/elasticsearch/api/actions/cat/ml_data_frame_analytics.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/cat/ml_data_frame_analytics.rb
@@ -35,11 +35,10 @@ module Elasticsearch
         # @see http://www.elastic.co/guide/en/elasticsearch/reference/current/cat-dfanalytics.html
         #
         def ml_data_frame_analytics(arguments = {})
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
           body = nil
-
-          arguments = arguments.clone
 
           _id = arguments.delete(:id)
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/cat/ml_datafeeds.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/cat/ml_datafeeds.rb
@@ -34,11 +34,10 @@ module Elasticsearch
         # @see http://www.elastic.co/guide/en/elasticsearch/reference/current/cat-datafeeds.html
         #
         def ml_datafeeds(arguments = {})
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
           body = nil
-
-          arguments = arguments.clone
 
           _datafeed_id = arguments.delete(:datafeed_id)
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/cat/ml_jobs.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/cat/ml_jobs.rb
@@ -35,11 +35,10 @@ module Elasticsearch
         # @see http://www.elastic.co/guide/en/elasticsearch/reference/current/cat-anomaly-detectors.html
         #
         def ml_jobs(arguments = {})
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
           body = nil
-
-          arguments = arguments.clone
 
           _job_id = arguments.delete(:job_id)
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/cat/ml_trained_models.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/cat/ml_trained_models.rb
@@ -37,11 +37,10 @@ module Elasticsearch
         # @see https://www.elastic.co/guide/en/elasticsearch/reference/current/cat-trained-model.html
         #
         def ml_trained_models(arguments = {})
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
           body = nil
-
-          arguments = arguments.clone
 
           _model_id = arguments.delete(:model_id)
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/cat/nodeattrs.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/cat/nodeattrs.rb
@@ -33,11 +33,10 @@ module Elasticsearch
         # @see https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-nodeattrs.html
         #
         def nodeattrs(arguments = {})
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
-          body = nil
-
-          arguments = arguments.clone
+          body   = nil
 
           method = Elasticsearch::API::HTTP_GET
           path   = "_cat/nodeattrs"

--- a/elasticsearch-api/lib/elasticsearch/api/actions/cat/nodes.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/cat/nodes.rb
@@ -36,11 +36,10 @@ module Elasticsearch
         # @see https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-nodes.html
         #
         def nodes(arguments = {})
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
-          body = nil
-
-          arguments = arguments.clone
+          body   = nil
 
           method = Elasticsearch::API::HTTP_GET
           path   = "_cat/nodes"

--- a/elasticsearch-api/lib/elasticsearch/api/actions/cat/pending_tasks.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/cat/pending_tasks.rb
@@ -34,11 +34,10 @@ module Elasticsearch
         # @see https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-pending-tasks.html
         #
         def pending_tasks(arguments = {})
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
-          body = nil
-
-          arguments = arguments.clone
+          body   = nil
 
           method = Elasticsearch::API::HTTP_GET
           path   = "_cat/pending_tasks"

--- a/elasticsearch-api/lib/elasticsearch/api/actions/cat/plugins.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/cat/plugins.rb
@@ -34,11 +34,10 @@ module Elasticsearch
         # @see https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-plugins.html
         #
         def plugins(arguments = {})
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
-          body = nil
-
-          arguments = arguments.clone
+          body   = nil
 
           method = Elasticsearch::API::HTTP_GET
           path   = "_cat/plugins"

--- a/elasticsearch-api/lib/elasticsearch/api/actions/cat/recovery.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/cat/recovery.rb
@@ -36,11 +36,10 @@ module Elasticsearch
         # @see https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-recovery.html
         #
         def recovery(arguments = {})
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
-          body = nil
-
-          arguments = arguments.clone
+          body   = nil
 
           _index = arguments.delete(:index)
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/cat/repositories.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/cat/repositories.rb
@@ -33,11 +33,10 @@ module Elasticsearch
         # @see https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-repositories.html
         #
         def repositories(arguments = {})
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
-          body = nil
-
-          arguments = arguments.clone
+          body   = nil
 
           method = Elasticsearch::API::HTTP_GET
           path   = "_cat/repositories"

--- a/elasticsearch-api/lib/elasticsearch/api/actions/cat/segments.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/cat/segments.rb
@@ -33,11 +33,10 @@ module Elasticsearch
         # @see https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-segments.html
         #
         def segments(arguments = {})
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
-          body = nil
-
-          arguments = arguments.clone
+          body   = nil
 
           _index = arguments.delete(:index)
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/cat/shards.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/cat/shards.rb
@@ -35,11 +35,10 @@ module Elasticsearch
         # @see https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-shards.html
         #
         def shards(arguments = {})
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
-          body = nil
-
-          arguments = arguments.clone
+          body   = nil
 
           _index = arguments.delete(:index)
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/cat/snapshots.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/cat/snapshots.rb
@@ -35,11 +35,10 @@ module Elasticsearch
         # @see https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-snapshots.html
         #
         def snapshots(arguments = {})
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
           body = nil
-
-          arguments = arguments.clone
 
           _repository = arguments.delete(:repository)
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/cat/tasks.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/cat/tasks.rb
@@ -40,11 +40,10 @@ module Elasticsearch
         # @see https://www.elastic.co/guide/en/elasticsearch/reference/master/tasks.html
         #
         def tasks(arguments = {})
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
-          body = nil
-
-          arguments = arguments.clone
+          body   = nil
 
           method = Elasticsearch::API::HTTP_GET
           path   = "_cat/tasks"

--- a/elasticsearch-api/lib/elasticsearch/api/actions/cat/templates.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/cat/templates.rb
@@ -34,11 +34,10 @@ module Elasticsearch
         # @see https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-templates.html
         #
         def templates(arguments = {})
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
           body = nil
-
-          arguments = arguments.clone
 
           _name = arguments.delete(:name)
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/cat/thread_pool.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/cat/thread_pool.rb
@@ -36,11 +36,10 @@ module Elasticsearch
         # @see https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-thread-pool.html
         #
         def thread_pool(arguments = {})
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
           body = nil
-
-          arguments = arguments.clone
 
           _thread_pool_patterns = arguments.delete(:thread_pool_patterns)
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/cat/transforms.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/cat/transforms.rb
@@ -36,11 +36,10 @@ module Elasticsearch
         # @see https://www.elastic.co/guide/en/elasticsearch/reference/current/cat-transforms.html
         #
         def transforms(arguments = {})
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
           body = nil
-
-          arguments = arguments.clone
 
           _transform_id = arguments.delete(:transform_id)
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/clear_scroll.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/clear_scroll.rb
@@ -32,11 +32,10 @@ module Elasticsearch
       # @see https://www.elastic.co/guide/en/elasticsearch/reference/current/clear-scroll-api.html
       #
       def clear_scroll(arguments = {})
+        arguments = arguments.clone
         headers = arguments.delete(:headers) || {}
 
         body = arguments.delete(:body)
-
-        arguments = arguments.clone
 
         _scroll_id = arguments.delete(:scroll_id)
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/close_point_in_time.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/close_point_in_time.rb
@@ -26,11 +26,10 @@ module Elasticsearch
       # @see https://www.elastic.co/guide/en/elasticsearch/reference/master/point-in-time-api.html
       #
       def close_point_in_time(arguments = {})
+        arguments = arguments.clone
         headers = arguments.delete(:headers) || {}
 
-        body = arguments.delete(:body)
-
-        arguments = arguments.clone
+        body   = arguments.delete(:body)
 
         method = Elasticsearch::API::HTTP_DELETE
         path   = "_pit"

--- a/elasticsearch-api/lib/elasticsearch/api/actions/cluster/allocation_explain.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/cluster/allocation_explain.rb
@@ -29,11 +29,10 @@ module Elasticsearch
         # @see https://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-allocation-explain.html
         #
         def allocation_explain(arguments = {})
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
-          body = arguments.delete(:body)
-
-          arguments = arguments.clone
+          body   = arguments.delete(:body)
 
           method = if body
                      Elasticsearch::API::HTTP_POST

--- a/elasticsearch-api/lib/elasticsearch/api/actions/cluster/delete_component_template.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/cluster/delete_component_template.rb
@@ -31,11 +31,10 @@ module Elasticsearch
         def delete_component_template(arguments = {})
           raise ArgumentError, "Required argument 'name' missing" unless arguments[:name]
 
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
           body = nil
-
-          arguments = arguments.clone
 
           _name = arguments.delete(:name)
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/cluster/delete_voting_config_exclusions.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/cluster/delete_voting_config_exclusions.rb
@@ -27,11 +27,10 @@ module Elasticsearch
         # @see https://www.elastic.co/guide/en/elasticsearch/reference/master/voting-config-exclusions.html
         #
         def delete_voting_config_exclusions(arguments = {})
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
-          body = nil
-
-          arguments = arguments.clone
+          body   = nil
 
           method = Elasticsearch::API::HTTP_DELETE
           path   = "_cluster/voting_config_exclusions"

--- a/elasticsearch-api/lib/elasticsearch/api/actions/cluster/exists_component_template.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/cluster/exists_component_template.rb
@@ -31,11 +31,10 @@ module Elasticsearch
         def exists_component_template(arguments = {})
           raise ArgumentError, "Required argument 'name' missing" unless arguments[:name]
 
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
           body = nil
-
-          arguments = arguments.clone
 
           _name = arguments.delete(:name)
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/cluster/get_component_template.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/cluster/get_component_template.rb
@@ -29,11 +29,10 @@ module Elasticsearch
         # @see https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-component-template.html
         #
         def get_component_template(arguments = {})
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
           body = nil
-
-          arguments = arguments.clone
 
           _name = arguments.delete(:name)
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/cluster/get_settings.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/cluster/get_settings.rb
@@ -30,11 +30,10 @@ module Elasticsearch
         # @see https://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-get-settings.html
         #
         def get_settings(arguments = {})
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
-          body = nil
-
-          arguments = arguments.clone
+          body   = nil
 
           method = Elasticsearch::API::HTTP_GET
           path   = "_cluster/settings"

--- a/elasticsearch-api/lib/elasticsearch/api/actions/cluster/health.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/cluster/health.rb
@@ -38,11 +38,10 @@ module Elasticsearch
         # @see https://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-health.html
         #
         def health(arguments = {})
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
-          body = nil
-
-          arguments = arguments.clone
+          body   = nil
 
           _index = arguments.delete(:index)
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/cluster/pending_tasks.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/cluster/pending_tasks.rb
@@ -29,11 +29,10 @@ module Elasticsearch
         # @see https://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-pending.html
         #
         def pending_tasks(arguments = {})
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
-          body = nil
-
-          arguments = arguments.clone
+          body   = nil
 
           method = Elasticsearch::API::HTTP_GET
           path   = "_cluster/pending_tasks"

--- a/elasticsearch-api/lib/elasticsearch/api/actions/cluster/post_voting_config_exclusions.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/cluster/post_voting_config_exclusions.rb
@@ -29,11 +29,10 @@ module Elasticsearch
         # @see https://www.elastic.co/guide/en/elasticsearch/reference/master/voting-config-exclusions.html
         #
         def post_voting_config_exclusions(arguments = {})
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
-          body = nil
-
-          arguments = arguments.clone
+          body   = nil
 
           method = Elasticsearch::API::HTTP_POST
           path   = "_cluster/voting_config_exclusions"

--- a/elasticsearch-api/lib/elasticsearch/api/actions/cluster/put_component_template.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/cluster/put_component_template.rb
@@ -34,11 +34,10 @@ module Elasticsearch
           raise ArgumentError, "Required argument 'body' missing" unless arguments[:body]
           raise ArgumentError, "Required argument 'name' missing" unless arguments[:name]
 
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
           body = arguments.delete(:body)
-
-          arguments = arguments.clone
 
           _name = arguments.delete(:name)
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/cluster/put_settings.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/cluster/put_settings.rb
@@ -32,11 +32,10 @@ module Elasticsearch
         def put_settings(arguments = {})
           raise ArgumentError, "Required argument 'body' missing" unless arguments[:body]
 
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
           body = arguments.delete(:body) || {}
-
-          arguments = arguments.clone
 
           method = Elasticsearch::API::HTTP_PUT
           path   = "_cluster/settings"

--- a/elasticsearch-api/lib/elasticsearch/api/actions/cluster/remote_info.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/cluster/remote_info.rb
@@ -26,11 +26,10 @@ module Elasticsearch
         # @see https://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-remote-info.html
         #
         def remote_info(arguments = {})
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
-          body = nil
-
-          arguments = arguments.clone
+          body   = nil
 
           method = Elasticsearch::API::HTTP_GET
           path   = "_remote/info"

--- a/elasticsearch-api/lib/elasticsearch/api/actions/cluster/reroute.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/cluster/reroute.rb
@@ -33,11 +33,10 @@ module Elasticsearch
         # @see https://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-reroute.html
         #
         def reroute(arguments = {})
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
           body = arguments.delete(:body) || {}
-
-          arguments = arguments.clone
 
           method = Elasticsearch::API::HTTP_POST
           path   = "_cluster/reroute"

--- a/elasticsearch-api/lib/elasticsearch/api/actions/cluster/state.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/cluster/state.rb
@@ -36,11 +36,10 @@ module Elasticsearch
         # @see https://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-state.html
         #
         def state(arguments = {})
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
           body = nil
-
-          arguments = arguments.clone
 
           _metric = arguments.delete(:metric)
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/cluster/stats.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/cluster/stats.rb
@@ -29,11 +29,10 @@ module Elasticsearch
         # @see https://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-stats.html
         #
         def stats(arguments = {})
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
           body = nil
-
-          arguments = arguments.clone
 
           _node_id = arguments.delete(:node_id)
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/count.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/count.rb
@@ -41,11 +41,10 @@ module Elasticsearch
       # @see https://www.elastic.co/guide/en/elasticsearch/reference/master/search-count.html
       #
       def count(arguments = {})
+        arguments = arguments.clone
         headers = arguments.delete(:headers) || {}
 
-        body = arguments.delete(:body)
-
-        arguments = arguments.clone
+        body   = arguments.delete(:body)
 
         _index = arguments.delete(:index)
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/cross_cluster_replication/delete_auto_follow_pattern.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/cross_cluster_replication/delete_auto_follow_pattern.rb
@@ -29,11 +29,10 @@ module Elasticsearch
         def delete_auto_follow_pattern(arguments = {})
           raise ArgumentError, "Required argument 'name' missing" unless arguments[:name]
 
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
           body = nil
-
-          arguments = arguments.clone
 
           _name = arguments.delete(:name)
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/cross_cluster_replication/follow.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/cross_cluster_replication/follow.rb
@@ -32,11 +32,10 @@ module Elasticsearch
           raise ArgumentError, "Required argument 'body' missing" unless arguments[:body]
           raise ArgumentError, "Required argument 'index' missing" unless arguments[:index]
 
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
-          body = arguments.delete(:body)
-
-          arguments = arguments.clone
+          body   = arguments.delete(:body)
 
           _index = arguments.delete(:index)
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/cross_cluster_replication/follow_info.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/cross_cluster_replication/follow_info.rb
@@ -29,11 +29,10 @@ module Elasticsearch
         def follow_info(arguments = {})
           raise ArgumentError, "Required argument 'index' missing" unless arguments[:index]
 
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
-          body = nil
-
-          arguments = arguments.clone
+          body   = nil
 
           _index = arguments.delete(:index)
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/cross_cluster_replication/follow_stats.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/cross_cluster_replication/follow_stats.rb
@@ -29,11 +29,10 @@ module Elasticsearch
         def follow_stats(arguments = {})
           raise ArgumentError, "Required argument 'index' missing" unless arguments[:index]
 
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
-          body = nil
-
-          arguments = arguments.clone
+          body   = nil
 
           _index = arguments.delete(:index)
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/cross_cluster_replication/forget_follower.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/cross_cluster_replication/forget_follower.rb
@@ -31,11 +31,10 @@ module Elasticsearch
           raise ArgumentError, "Required argument 'body' missing" unless arguments[:body]
           raise ArgumentError, "Required argument 'index' missing" unless arguments[:index]
 
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
-          body = arguments.delete(:body)
-
-          arguments = arguments.clone
+          body   = arguments.delete(:body)
 
           _index = arguments.delete(:index)
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/cross_cluster_replication/get_auto_follow_pattern.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/cross_cluster_replication/get_auto_follow_pattern.rb
@@ -27,11 +27,10 @@ module Elasticsearch
         # @see https://www.elastic.co/guide/en/elasticsearch/reference/current/ccr-get-auto-follow-pattern.html
         #
         def get_auto_follow_pattern(arguments = {})
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
           body = nil
-
-          arguments = arguments.clone
 
           _name = arguments.delete(:name)
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/cross_cluster_replication/pause_auto_follow_pattern.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/cross_cluster_replication/pause_auto_follow_pattern.rb
@@ -29,11 +29,10 @@ module Elasticsearch
         def pause_auto_follow_pattern(arguments = {})
           raise ArgumentError, "Required argument 'name' missing" unless arguments[:name]
 
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
           body = nil
-
-          arguments = arguments.clone
 
           _name = arguments.delete(:name)
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/cross_cluster_replication/pause_follow.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/cross_cluster_replication/pause_follow.rb
@@ -29,11 +29,10 @@ module Elasticsearch
         def pause_follow(arguments = {})
           raise ArgumentError, "Required argument 'index' missing" unless arguments[:index]
 
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
-          body = nil
-
-          arguments = arguments.clone
+          body   = nil
 
           _index = arguments.delete(:index)
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/cross_cluster_replication/put_auto_follow_pattern.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/cross_cluster_replication/put_auto_follow_pattern.rb
@@ -31,11 +31,10 @@ module Elasticsearch
           raise ArgumentError, "Required argument 'body' missing" unless arguments[:body]
           raise ArgumentError, "Required argument 'name' missing" unless arguments[:name]
 
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
           body = arguments.delete(:body)
-
-          arguments = arguments.clone
 
           _name = arguments.delete(:name)
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/cross_cluster_replication/resume_auto_follow_pattern.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/cross_cluster_replication/resume_auto_follow_pattern.rb
@@ -29,11 +29,10 @@ module Elasticsearch
         def resume_auto_follow_pattern(arguments = {})
           raise ArgumentError, "Required argument 'name' missing" unless arguments[:name]
 
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
           body = nil
-
-          arguments = arguments.clone
 
           _name = arguments.delete(:name)
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/cross_cluster_replication/resume_follow.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/cross_cluster_replication/resume_follow.rb
@@ -30,11 +30,10 @@ module Elasticsearch
         def resume_follow(arguments = {})
           raise ArgumentError, "Required argument 'index' missing" unless arguments[:index]
 
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
-          body = arguments.delete(:body)
-
-          arguments = arguments.clone
+          body   = arguments.delete(:body)
 
           _index = arguments.delete(:index)
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/cross_cluster_replication/stats.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/cross_cluster_replication/stats.rb
@@ -26,11 +26,10 @@ module Elasticsearch
         # @see https://www.elastic.co/guide/en/elasticsearch/reference/current/ccr-get-stats.html
         #
         def stats(arguments = {})
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
-          body = nil
-
-          arguments = arguments.clone
+          body   = nil
 
           method = Elasticsearch::API::HTTP_GET
           path   = "_ccr/stats"

--- a/elasticsearch-api/lib/elasticsearch/api/actions/cross_cluster_replication/unfollow.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/cross_cluster_replication/unfollow.rb
@@ -29,11 +29,10 @@ module Elasticsearch
         def unfollow(arguments = {})
           raise ArgumentError, "Required argument 'index' missing" unless arguments[:index]
 
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
-          body = nil
-
-          arguments = arguments.clone
+          body   = nil
 
           _index = arguments.delete(:index)
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/dangling_indices/delete_dangling_index.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/dangling_indices/delete_dangling_index.rb
@@ -32,11 +32,10 @@ module Elasticsearch
         def delete_dangling_index(arguments = {})
           raise ArgumentError, "Required argument 'index_uuid' missing" unless arguments[:index_uuid]
 
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
           body = nil
-
-          arguments = arguments.clone
 
           _index_uuid = arguments.delete(:index_uuid)
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/dangling_indices/import_dangling_index.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/dangling_indices/import_dangling_index.rb
@@ -32,11 +32,10 @@ module Elasticsearch
         def import_dangling_index(arguments = {})
           raise ArgumentError, "Required argument 'index_uuid' missing" unless arguments[:index_uuid]
 
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
           body = nil
-
-          arguments = arguments.clone
 
           _index_uuid = arguments.delete(:index_uuid)
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/dangling_indices/list_dangling_indices.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/dangling_indices/list_dangling_indices.rb
@@ -26,11 +26,10 @@ module Elasticsearch
         # @see https://www.elastic.co/guide/en/elasticsearch/reference/master/modules-gateway-dangling-indices.html
         #
         def list_dangling_indices(arguments = {})
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
-          body = nil
-
-          arguments = arguments.clone
+          body   = nil
 
           method = Elasticsearch::API::HTTP_GET
           path   = "_dangling"

--- a/elasticsearch-api/lib/elasticsearch/api/actions/delete.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/delete.rb
@@ -38,11 +38,10 @@ module Elasticsearch
         raise ArgumentError, "Required argument 'index' missing" unless arguments[:index]
         raise ArgumentError, "Required argument 'id' missing" unless arguments[:id]
 
+        arguments = arguments.clone
         headers = arguments.delete(:headers) || {}
 
         body = nil
-
-        arguments = arguments.clone
 
         _id = arguments.delete(:id)
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/delete_by_query.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/delete_by_query.rb
@@ -59,11 +59,10 @@ module Elasticsearch
         raise ArgumentError, "Required argument 'body' missing" unless arguments[:body]
         raise ArgumentError, "Required argument 'index' missing" unless arguments[:index]
 
+        arguments = arguments.clone
         headers = arguments.delete(:headers) || {}
 
-        body = arguments.delete(:body)
-
-        arguments = arguments.clone
+        body   = arguments.delete(:body)
 
         _index = arguments.delete(:index)
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/delete_by_query_rethrottle.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/delete_by_query_rethrottle.rb
@@ -29,11 +29,10 @@ module Elasticsearch
       def delete_by_query_rethrottle(arguments = {})
         raise ArgumentError, "Required argument 'task_id' missing" unless arguments[:task_id]
 
+        arguments = arguments.clone
         headers = arguments.delete(:headers) || {}
 
         body = nil
-
-        arguments = arguments.clone
 
         _task_id = arguments.delete(:task_id)
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/delete_script.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/delete_script.rb
@@ -30,11 +30,10 @@ module Elasticsearch
       def delete_script(arguments = {})
         raise ArgumentError, "Required argument 'id' missing" unless arguments[:id]
 
+        arguments = arguments.clone
         headers = arguments.delete(:headers) || {}
 
         body = nil
-
-        arguments = arguments.clone
 
         _id = arguments.delete(:id)
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/enrich/delete_policy.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/enrich/delete_policy.rb
@@ -29,11 +29,10 @@ module Elasticsearch
         def delete_policy(arguments = {})
           raise ArgumentError, "Required argument 'name' missing" unless arguments[:name]
 
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
           body = nil
-
-          arguments = arguments.clone
 
           _name = arguments.delete(:name)
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/enrich/execute_policy.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/enrich/execute_policy.rb
@@ -30,11 +30,10 @@ module Elasticsearch
         def execute_policy(arguments = {})
           raise ArgumentError, "Required argument 'name' missing" unless arguments[:name]
 
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
           body = nil
-
-          arguments = arguments.clone
 
           _name = arguments.delete(:name)
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/enrich/get_policy.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/enrich/get_policy.rb
@@ -27,11 +27,10 @@ module Elasticsearch
         # @see https://www.elastic.co/guide/en/elasticsearch/reference/current/get-enrich-policy-api.html
         #
         def get_policy(arguments = {})
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
           body = nil
-
-          arguments = arguments.clone
 
           _name = arguments.delete(:name)
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/enrich/put_policy.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/enrich/put_policy.rb
@@ -31,11 +31,10 @@ module Elasticsearch
           raise ArgumentError, "Required argument 'body' missing" unless arguments[:body]
           raise ArgumentError, "Required argument 'name' missing" unless arguments[:name]
 
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
           body = arguments.delete(:body)
-
-          arguments = arguments.clone
 
           _name = arguments.delete(:name)
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/enrich/stats.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/enrich/stats.rb
@@ -26,11 +26,10 @@ module Elasticsearch
         # @see https://www.elastic.co/guide/en/elasticsearch/reference/current/enrich-stats-api.html
         #
         def stats(arguments = {})
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
-          body = nil
-
-          arguments = arguments.clone
+          body   = nil
 
           method = Elasticsearch::API::HTTP_GET
           path   = "_enrich/_stats"

--- a/elasticsearch-api/lib/elasticsearch/api/actions/eql/delete.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/eql/delete.rb
@@ -29,11 +29,10 @@ module Elasticsearch
         def delete(arguments = {})
           raise ArgumentError, "Required argument 'id' missing" unless arguments[:id]
 
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
           body = nil
-
-          arguments = arguments.clone
 
           _id = arguments.delete(:id)
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/eql/get.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/eql/get.rb
@@ -31,11 +31,10 @@ module Elasticsearch
         def get(arguments = {})
           raise ArgumentError, "Required argument 'id' missing" unless arguments[:id]
 
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
           body = nil
-
-          arguments = arguments.clone
 
           _id = arguments.delete(:id)
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/eql/get_status.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/eql/get_status.rb
@@ -29,11 +29,10 @@ module Elasticsearch
         def get_status(arguments = {})
           raise ArgumentError, "Required argument 'id' missing" unless arguments[:id]
 
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
           body = nil
-
-          arguments = arguments.clone
 
           _id = arguments.delete(:id)
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/eql/search.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/eql/search.rb
@@ -34,11 +34,11 @@ module Elasticsearch
           raise ArgumentError, "Required argument 'body' missing" unless arguments[:body]
           raise ArgumentError, "Required argument 'index' missing" unless arguments[:index]
 
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
           body = arguments.delete(:body)
 
-          arguments = arguments.clone
           arguments[:index] = UNDERSCORE_ALL if !arguments[:index] && arguments[:type]
 
           _index = arguments.delete(:index)

--- a/elasticsearch-api/lib/elasticsearch/api/actions/exists.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/exists.rb
@@ -40,11 +40,10 @@ module Elasticsearch
         raise ArgumentError, "Required argument 'index' missing" unless arguments[:index]
         raise ArgumentError, "Required argument 'id' missing" unless arguments[:id]
 
+        arguments = arguments.clone
         headers = arguments.delete(:headers) || {}
 
         body = nil
-
-        arguments = arguments.clone
 
         _id = arguments.delete(:id)
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/exists_source.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/exists_source.rb
@@ -39,11 +39,10 @@ module Elasticsearch
         raise ArgumentError, "Required argument 'index' missing" unless arguments[:index]
         raise ArgumentError, "Required argument 'id' missing" unless arguments[:id]
 
+        arguments = arguments.clone
         headers = arguments.delete(:headers) || {}
 
         body = nil
-
-        arguments = arguments.clone
 
         _id = arguments.delete(:id)
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/explain.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/explain.rb
@@ -43,11 +43,10 @@ module Elasticsearch
         raise ArgumentError, "Required argument 'index' missing" unless arguments[:index]
         raise ArgumentError, "Required argument 'id' missing" unless arguments[:id]
 
+        arguments = arguments.clone
         headers = arguments.delete(:headers) || {}
 
         body = arguments.delete(:body)
-
-        arguments = arguments.clone
 
         _id = arguments.delete(:id)
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/features/get_features.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/features/get_features.rb
@@ -27,11 +27,10 @@ module Elasticsearch
         # @see https://www.elastic.co/guide/en/elasticsearch/reference/master/get-features-api.html
         #
         def get_features(arguments = {})
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
-          body = nil
-
-          arguments = arguments.clone
+          body   = nil
 
           method = Elasticsearch::API::HTTP_GET
           path   = "_features"

--- a/elasticsearch-api/lib/elasticsearch/api/actions/features/reset_features.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/features/reset_features.rb
@@ -30,11 +30,10 @@ module Elasticsearch
         # @see https://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html
         #
         def reset_features(arguments = {})
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
-          body = nil
-
-          arguments = arguments.clone
+          body   = nil
 
           method = Elasticsearch::API::HTTP_POST
           path   = "_features/_reset"

--- a/elasticsearch-api/lib/elasticsearch/api/actions/field_caps.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/field_caps.rb
@@ -34,11 +34,10 @@ module Elasticsearch
       # @see https://www.elastic.co/guide/en/elasticsearch/reference/master/search-field-caps.html
       #
       def field_caps(arguments = {})
+        arguments = arguments.clone
         headers = arguments.delete(:headers) || {}
 
-        body = arguments.delete(:body)
-
-        arguments = arguments.clone
+        body   = arguments.delete(:body)
 
         _index = arguments.delete(:index)
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/fleet/global_checkpoints.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/fleet/global_checkpoints.rb
@@ -33,11 +33,10 @@ module Elasticsearch
         def global_checkpoints(arguments = {})
           raise ArgumentError, "Required argument 'index' missing" unless arguments[:index]
 
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
-          body = nil
-
-          arguments = arguments.clone
+          body   = nil
 
           _index = arguments.delete(:index)
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/fleet/msearch.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/fleet/msearch.rb
@@ -34,11 +34,10 @@ module Elasticsearch
         def msearch(arguments = {})
           raise ArgumentError, "Required argument 'body' missing" unless arguments[:body]
 
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
-          body = arguments.delete(:body)
-
-          arguments = arguments.clone
+          body   = arguments.delete(:body)
 
           _index = arguments.delete(:index)
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/fleet/search.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/fleet/search.rb
@@ -37,11 +37,11 @@ module Elasticsearch
         def search(arguments = {})
           raise ArgumentError, "Required argument 'index' missing" unless arguments[:index]
 
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
           body = arguments.delete(:body)
 
-          arguments = arguments.clone
           arguments[:index] = UNDERSCORE_ALL if !arguments[:index] && arguments[:type]
 
           _index = arguments.delete(:index)

--- a/elasticsearch-api/lib/elasticsearch/api/actions/get.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/get.rb
@@ -40,11 +40,10 @@ module Elasticsearch
         raise ArgumentError, "Required argument 'index' missing" unless arguments[:index]
         raise ArgumentError, "Required argument 'id' missing" unless arguments[:id]
 
+        arguments = arguments.clone
         headers = arguments.delete(:headers) || {}
 
         body = nil
-
-        arguments = arguments.clone
 
         _id = arguments.delete(:id)
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/get_script.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/get_script.rb
@@ -29,11 +29,10 @@ module Elasticsearch
       def get_script(arguments = {})
         raise ArgumentError, "Required argument 'id' missing" unless arguments[:id]
 
+        arguments = arguments.clone
         headers = arguments.delete(:headers) || {}
 
         body = nil
-
-        arguments = arguments.clone
 
         _id = arguments.delete(:id)
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/get_script_context.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/get_script_context.rb
@@ -25,11 +25,10 @@ module Elasticsearch
       # @see https://www.elastic.co/guide/en/elasticsearch/painless/master/painless-contexts.html
       #
       def get_script_context(arguments = {})
+        arguments = arguments.clone
         headers = arguments.delete(:headers) || {}
 
-        body = nil
-
-        arguments = arguments.clone
+        body   = nil
 
         method = Elasticsearch::API::HTTP_GET
         path   = "_script_context"

--- a/elasticsearch-api/lib/elasticsearch/api/actions/get_script_languages.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/get_script_languages.rb
@@ -25,11 +25,10 @@ module Elasticsearch
       # @see https://www.elastic.co/guide/en/elasticsearch/reference/master/modules-scripting.html
       #
       def get_script_languages(arguments = {})
+        arguments = arguments.clone
         headers = arguments.delete(:headers) || {}
 
-        body = nil
-
-        arguments = arguments.clone
+        body   = nil
 
         method = Elasticsearch::API::HTTP_GET
         path   = "_script_language"

--- a/elasticsearch-api/lib/elasticsearch/api/actions/get_source.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/get_source.rb
@@ -39,11 +39,10 @@ module Elasticsearch
         raise ArgumentError, "Required argument 'index' missing" unless arguments[:index]
         raise ArgumentError, "Required argument 'id' missing" unless arguments[:id]
 
+        arguments = arguments.clone
         headers = arguments.delete(:headers) || {}
 
         body = nil
-
-        arguments = arguments.clone
 
         _id = arguments.delete(:id)
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/graph/explore.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/graph/explore.rb
@@ -32,11 +32,10 @@ module Elasticsearch
         def explore(arguments = {})
           raise ArgumentError, "Required argument 'index' missing" unless arguments[:index]
 
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
-          body = arguments.delete(:body)
-
-          arguments = arguments.clone
+          body   = arguments.delete(:body)
 
           _index = arguments.delete(:index)
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/index.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/index.rb
@@ -42,11 +42,10 @@ module Elasticsearch
         raise ArgumentError, "Required argument 'body' missing" unless arguments[:body]
         raise ArgumentError, "Required argument 'index' missing" unless arguments[:index]
 
+        arguments = arguments.clone
         headers = arguments.delete(:headers) || {}
 
         body = arguments.delete(:body)
-
-        arguments = arguments.clone
 
         _id = arguments.delete(:id)
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/index_lifecycle_management/delete_lifecycle.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/index_lifecycle_management/delete_lifecycle.rb
@@ -29,11 +29,10 @@ module Elasticsearch
         def delete_lifecycle(arguments = {})
           raise ArgumentError, "Required argument 'policy' missing" unless arguments[:policy]
 
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
           body = nil
-
-          arguments = arguments.clone
 
           _policy = arguments.delete(:policy)
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/index_lifecycle_management/explain_lifecycle.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/index_lifecycle_management/explain_lifecycle.rb
@@ -31,11 +31,10 @@ module Elasticsearch
         def explain_lifecycle(arguments = {})
           raise ArgumentError, "Required argument 'index' missing" unless arguments[:index]
 
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
-          body = nil
-
-          arguments = arguments.clone
+          body   = nil
 
           _index = arguments.delete(:index)
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/index_lifecycle_management/get_lifecycle.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/index_lifecycle_management/get_lifecycle.rb
@@ -27,11 +27,10 @@ module Elasticsearch
         # @see https://www.elastic.co/guide/en/elasticsearch/reference/current/ilm-get-lifecycle.html
         #
         def get_lifecycle(arguments = {})
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
           body = nil
-
-          arguments = arguments.clone
 
           _policy = arguments.delete(:policy)
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/index_lifecycle_management/get_status.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/index_lifecycle_management/get_status.rb
@@ -26,11 +26,10 @@ module Elasticsearch
         # @see https://www.elastic.co/guide/en/elasticsearch/reference/current/ilm-get-status.html
         #
         def get_status(arguments = {})
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
-          body = nil
-
-          arguments = arguments.clone
+          body   = nil
 
           method = Elasticsearch::API::HTTP_GET
           path   = "_ilm/status"

--- a/elasticsearch-api/lib/elasticsearch/api/actions/index_lifecycle_management/migrate_to_data_tiers.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/index_lifecycle_management/migrate_to_data_tiers.rb
@@ -28,11 +28,10 @@ module Elasticsearch
         # @see https://www.elastic.co/guide/en/elasticsearch/reference/current/ilm-migrate-to-data-tiers.html
         #
         def migrate_to_data_tiers(arguments = {})
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
-          body = arguments.delete(:body)
-
-          arguments = arguments.clone
+          body   = arguments.delete(:body)
 
           method = Elasticsearch::API::HTTP_POST
           path   = "_ilm/migrate_to_data_tiers"

--- a/elasticsearch-api/lib/elasticsearch/api/actions/index_lifecycle_management/move_to_step.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/index_lifecycle_management/move_to_step.rb
@@ -30,11 +30,10 @@ module Elasticsearch
         def move_to_step(arguments = {})
           raise ArgumentError, "Required argument 'index' missing" unless arguments[:index]
 
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
-          body = arguments.delete(:body)
-
-          arguments = arguments.clone
+          body   = arguments.delete(:body)
 
           _index = arguments.delete(:index)
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/index_lifecycle_management/put_lifecycle.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/index_lifecycle_management/put_lifecycle.rb
@@ -30,11 +30,10 @@ module Elasticsearch
         def put_lifecycle(arguments = {})
           raise ArgumentError, "Required argument 'policy' missing" unless arguments[:policy]
 
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
           body = arguments.delete(:body)
-
-          arguments = arguments.clone
 
           _policy = arguments.delete(:policy)
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/index_lifecycle_management/remove_policy.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/index_lifecycle_management/remove_policy.rb
@@ -29,11 +29,10 @@ module Elasticsearch
         def remove_policy(arguments = {})
           raise ArgumentError, "Required argument 'index' missing" unless arguments[:index]
 
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
-          body = nil
-
-          arguments = arguments.clone
+          body   = nil
 
           _index = arguments.delete(:index)
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/index_lifecycle_management/retry.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/index_lifecycle_management/retry.rb
@@ -29,11 +29,10 @@ module Elasticsearch
         def retry(arguments = {})
           raise ArgumentError, "Required argument 'index' missing" unless arguments[:index]
 
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
-          body = nil
-
-          arguments = arguments.clone
+          body   = nil
 
           _index = arguments.delete(:index)
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/index_lifecycle_management/start.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/index_lifecycle_management/start.rb
@@ -26,11 +26,10 @@ module Elasticsearch
         # @see https://www.elastic.co/guide/en/elasticsearch/reference/current/ilm-start.html
         #
         def start(arguments = {})
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
-          body = nil
-
-          arguments = arguments.clone
+          body   = nil
 
           method = Elasticsearch::API::HTTP_POST
           path   = "_ilm/start"

--- a/elasticsearch-api/lib/elasticsearch/api/actions/index_lifecycle_management/stop.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/index_lifecycle_management/stop.rb
@@ -26,11 +26,10 @@ module Elasticsearch
         # @see https://www.elastic.co/guide/en/elasticsearch/reference/current/ilm-stop.html
         #
         def stop(arguments = {})
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
-          body = nil
-
-          arguments = arguments.clone
+          body   = nil
 
           method = Elasticsearch::API::HTTP_POST
           path   = "_ilm/stop"

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/add_block.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/add_block.rb
@@ -36,11 +36,10 @@ module Elasticsearch
           raise ArgumentError, "Required argument 'index' missing" unless arguments[:index]
           raise ArgumentError, "Required argument 'block' missing" unless arguments[:block]
 
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
-          body = nil
-
-          arguments = arguments.clone
+          body   = nil
 
           _index = arguments.delete(:index)
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/analyze.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/analyze.rb
@@ -28,11 +28,10 @@ module Elasticsearch
         # @see https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-analyze.html
         #
         def analyze(arguments = {})
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
-          body = arguments.delete(:body)
-
-          arguments = arguments.clone
+          body   = arguments.delete(:body)
 
           _index = arguments.delete(:index)
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/clear_cache.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/clear_cache.rb
@@ -34,11 +34,10 @@ module Elasticsearch
         # @see https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-clearcache.html
         #
         def clear_cache(arguments = {})
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
-          body = nil
-
-          arguments = arguments.clone
+          body   = nil
 
           _index = arguments.delete(:index)
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/clone.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/clone.rb
@@ -35,11 +35,10 @@ module Elasticsearch
           raise ArgumentError, "Required argument 'index' missing" unless arguments[:index]
           raise ArgumentError, "Required argument 'target' missing" unless arguments[:target]
 
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
-          body = arguments.delete(:body)
-
-          arguments = arguments.clone
+          body   = arguments.delete(:body)
 
           _index = arguments.delete(:index)
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/close.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/close.rb
@@ -35,11 +35,10 @@ module Elasticsearch
         def close(arguments = {})
           raise ArgumentError, "Required argument 'index' missing" unless arguments[:index]
 
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
-          body = nil
-
-          arguments = arguments.clone
+          body   = nil
 
           _index = arguments.delete(:index)
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/create.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/create.rb
@@ -33,11 +33,10 @@ module Elasticsearch
         def create(arguments = {})
           raise ArgumentError, "Required argument 'index' missing" unless arguments[:index]
 
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
-          body = arguments.delete(:body)
-
-          arguments = arguments.clone
+          body   = arguments.delete(:body)
 
           _index = arguments.delete(:index)
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/create_data_stream.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/create_data_stream.rb
@@ -29,11 +29,10 @@ module Elasticsearch
         def create_data_stream(arguments = {})
           raise ArgumentError, "Required argument 'name' missing" unless arguments[:name]
 
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
           body = nil
-
-          arguments = arguments.clone
 
           _name = arguments.delete(:name)
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/data_streams_stats.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/data_streams_stats.rb
@@ -27,11 +27,10 @@ module Elasticsearch
         # @see https://www.elastic.co/guide/en/elasticsearch/reference/master/data-streams.html
         #
         def data_streams_stats(arguments = {})
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
           body = nil
-
-          arguments = arguments.clone
 
           _name = arguments.delete(:name)
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/delete.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/delete.rb
@@ -34,11 +34,10 @@ module Elasticsearch
         def delete(arguments = {})
           raise ArgumentError, "Required argument 'index' missing" unless arguments[:index]
 
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
-          body = nil
-
-          arguments = arguments.clone
+          body   = nil
 
           _index = arguments.delete(:index)
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/delete_alias.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/delete_alias.rb
@@ -33,11 +33,10 @@ module Elasticsearch
           raise ArgumentError, "Required argument 'index' missing" unless arguments[:index]
           raise ArgumentError, "Required argument 'name' missing" unless arguments[:name]
 
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
-          body = nil
-
-          arguments = arguments.clone
+          body   = nil
 
           _index = arguments.delete(:index)
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/delete_data_stream.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/delete_data_stream.rb
@@ -30,11 +30,10 @@ module Elasticsearch
         def delete_data_stream(arguments = {})
           raise ArgumentError, "Required argument 'name' missing" unless arguments[:name]
 
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
           body = nil
-
-          arguments = arguments.clone
 
           _name = arguments.delete(:name)
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/delete_index_template.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/delete_index_template.rb
@@ -31,11 +31,10 @@ module Elasticsearch
         def delete_index_template(arguments = {})
           raise ArgumentError, "Required argument 'name' missing" unless arguments[:name]
 
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
           body = nil
-
-          arguments = arguments.clone
 
           _name = arguments.delete(:name)
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/delete_template.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/delete_template.rb
@@ -31,11 +31,10 @@ module Elasticsearch
         def delete_template(arguments = {})
           raise ArgumentError, "Required argument 'name' missing" unless arguments[:name]
 
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
           body = nil
-
-          arguments = arguments.clone
 
           _name = arguments.delete(:name)
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/disk_usage.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/disk_usage.rb
@@ -38,11 +38,10 @@ module Elasticsearch
         def disk_usage(arguments = {})
           raise ArgumentError, "Required argument 'index' missing" unless arguments[:index]
 
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
-          body = nil
-
-          arguments = arguments.clone
+          body   = nil
 
           _index = arguments.delete(:index)
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/exists.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/exists.rb
@@ -35,11 +35,10 @@ module Elasticsearch
         def exists(arguments = {})
           raise ArgumentError, "Required argument 'index' missing" unless arguments[:index]
 
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
-          body = nil
-
-          arguments = arguments.clone
+          body   = nil
 
           _index = arguments.delete(:index)
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/exists_alias.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/exists_alias.rb
@@ -34,11 +34,10 @@ module Elasticsearch
         def exists_alias(arguments = {})
           raise ArgumentError, "Required argument 'name' missing" unless arguments[:name]
 
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
           body = nil
-
-          arguments = arguments.clone
 
           _name = arguments.delete(:name)
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/exists_index_template.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/exists_index_template.rb
@@ -32,11 +32,10 @@ module Elasticsearch
         def exists_index_template(arguments = {})
           raise ArgumentError, "Required argument 'name' missing" unless arguments[:name]
 
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
           body = nil
-
-          arguments = arguments.clone
 
           _name = arguments.delete(:name)
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/exists_template.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/exists_template.rb
@@ -32,11 +32,10 @@ module Elasticsearch
         def exists_template(arguments = {})
           raise ArgumentError, "Required argument 'name' missing" unless arguments[:name]
 
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
           body = nil
-
-          arguments = arguments.clone
 
           _name = arguments.delete(:name)
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/field_usage_stats.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/field_usage_stats.rb
@@ -37,11 +37,10 @@ module Elasticsearch
         def field_usage_stats(arguments = {})
           raise ArgumentError, "Required argument 'index' missing" unless arguments[:index]
 
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
-          body = nil
-
-          arguments = arguments.clone
+          body   = nil
 
           _index = arguments.delete(:index)
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/flush.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/flush.rb
@@ -32,11 +32,10 @@ module Elasticsearch
         # @see https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-flush.html
         #
         def flush(arguments = {})
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
-          body = nil
-
-          arguments = arguments.clone
+          body   = nil
 
           _index = arguments.delete(:index)
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/forcemerge.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/forcemerge.rb
@@ -34,11 +34,10 @@ module Elasticsearch
         # @see https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-forcemerge.html
         #
         def forcemerge(arguments = {})
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
-          body = nil
-
-          arguments = arguments.clone
+          body   = nil
 
           _index = arguments.delete(:index)
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/get.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/get.rb
@@ -37,11 +37,10 @@ module Elasticsearch
         def get(arguments = {})
           raise ArgumentError, "Required argument 'index' missing" unless arguments[:index]
 
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
-          body = nil
-
-          arguments = arguments.clone
+          body   = nil
 
           _index = arguments.delete(:index)
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/get_alias.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/get_alias.rb
@@ -32,11 +32,10 @@ module Elasticsearch
         # @see https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-aliases.html
         #
         def get_alias(arguments = {})
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
           body = nil
-
-          arguments = arguments.clone
 
           _name = arguments.delete(:name)
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/get_data_stream.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/get_data_stream.rb
@@ -28,11 +28,10 @@ module Elasticsearch
         # @see https://www.elastic.co/guide/en/elasticsearch/reference/master/data-streams.html
         #
         def get_data_stream(arguments = {})
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
           body = nil
-
-          arguments = arguments.clone
 
           _name = arguments.delete(:name)
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/get_field_mapping.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/get_field_mapping.rb
@@ -33,14 +33,13 @@ module Elasticsearch
         # @see https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-get-field-mapping.html
         #
         def get_field_mapping(arguments = {})
+          arguments = arguments.clone
           _fields = arguments.delete(:field) || arguments.delete(:fields)
           raise ArgumentError, "Required argument 'field' missing" unless _fields
 
           headers = arguments.delete(:headers) || {}
 
-          body = nil
-
-          arguments = arguments.clone
+          body   = nil
 
           _index = arguments.delete(:index)
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/get_index_template.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/get_index_template.rb
@@ -30,11 +30,10 @@ module Elasticsearch
         # @see https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-templates.html
         #
         def get_index_template(arguments = {})
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
           body = nil
-
-          arguments = arguments.clone
 
           _name = arguments.delete(:name)
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/get_mapping.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/get_mapping.rb
@@ -32,11 +32,10 @@ module Elasticsearch
         # @see https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-get-mapping.html
         #
         def get_mapping(arguments = {})
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
-          body = nil
-
-          arguments = arguments.clone
+          body   = nil
 
           _index = arguments.delete(:index)
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/get_settings.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/get_settings.rb
@@ -35,11 +35,10 @@ module Elasticsearch
         # @see https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-get-settings.html
         #
         def get_settings(arguments = {})
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
-          body = nil
-
-          arguments = arguments.clone
+          body   = nil
 
           _index = arguments.delete(:index)
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/get_template.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/get_template.rb
@@ -30,11 +30,10 @@ module Elasticsearch
         # @see https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-templates.html
         #
         def get_template(arguments = {})
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
           body = nil
-
-          arguments = arguments.clone
 
           _name = arguments.delete(:name)
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/migrate_to_data_stream.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/migrate_to_data_stream.rb
@@ -29,11 +29,10 @@ module Elasticsearch
         def migrate_to_data_stream(arguments = {})
           raise ArgumentError, "Required argument 'name' missing" unless arguments[:name]
 
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
           body = nil
-
-          arguments = arguments.clone
 
           _name = arguments.delete(:name)
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/modify_data_stream.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/modify_data_stream.rb
@@ -29,11 +29,10 @@ module Elasticsearch
         def modify_data_stream(arguments = {})
           raise ArgumentError, "Required argument 'body' missing" unless arguments[:body]
 
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
-          body = arguments.delete(:body)
-
-          arguments = arguments.clone
+          body   = arguments.delete(:body)
 
           method = Elasticsearch::API::HTTP_POST
           path   = "_data_stream/_modify"

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/open.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/open.rb
@@ -35,11 +35,10 @@ module Elasticsearch
         def open(arguments = {})
           raise ArgumentError, "Required argument 'index' missing" unless arguments[:index]
 
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
-          body = nil
-
-          arguments = arguments.clone
+          body   = nil
 
           _index = arguments.delete(:index)
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/promote_data_stream.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/promote_data_stream.rb
@@ -29,11 +29,10 @@ module Elasticsearch
         def promote_data_stream(arguments = {})
           raise ArgumentError, "Required argument 'name' missing" unless arguments[:name]
 
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
           body = nil
-
-          arguments = arguments.clone
 
           _name = arguments.delete(:name)
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/put_alias.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/put_alias.rb
@@ -34,11 +34,10 @@ module Elasticsearch
           raise ArgumentError, "Required argument 'index' missing" unless arguments[:index]
           raise ArgumentError, "Required argument 'name' missing" unless arguments[:name]
 
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
-          body = arguments.delete(:body)
-
-          arguments = arguments.clone
+          body   = arguments.delete(:body)
 
           _index = arguments.delete(:index)
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/put_index_template.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/put_index_template.rb
@@ -34,11 +34,10 @@ module Elasticsearch
           raise ArgumentError, "Required argument 'body' missing" unless arguments[:body]
           raise ArgumentError, "Required argument 'name' missing" unless arguments[:name]
 
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
           body = arguments.delete(:body)
-
-          arguments = arguments.clone
 
           _name = arguments.delete(:name)
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/put_mapping.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/put_mapping.rb
@@ -37,11 +37,10 @@ module Elasticsearch
           raise ArgumentError, "Required argument 'body' missing" unless arguments[:body]
           raise ArgumentError, "Required argument 'index' missing" unless arguments[:index]
 
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
-          body = arguments.delete(:body)
-
-          arguments = arguments.clone
+          body   = arguments.delete(:body)
 
           _index = arguments.delete(:index)
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/put_settings.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/put_settings.rb
@@ -37,11 +37,10 @@ module Elasticsearch
         def put_settings(arguments = {})
           raise ArgumentError, "Required argument 'body' missing" unless arguments[:body]
 
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
-          body = arguments.delete(:body)
-
-          arguments = arguments.clone
+          body   = arguments.delete(:body)
 
           _index = arguments.delete(:index)
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/put_template.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/put_template.rb
@@ -34,11 +34,10 @@ module Elasticsearch
           raise ArgumentError, "Required argument 'body' missing" unless arguments[:body]
           raise ArgumentError, "Required argument 'name' missing" unless arguments[:name]
 
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
           body = arguments.delete(:body)
-
-          arguments = arguments.clone
 
           _name = arguments.delete(:name)
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/recovery.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/recovery.rb
@@ -29,11 +29,10 @@ module Elasticsearch
         # @see https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-recovery.html
         #
         def recovery(arguments = {})
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
-          body = nil
-
-          arguments = arguments.clone
+          body   = nil
 
           _index = arguments.delete(:index)
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/refresh.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/refresh.rb
@@ -30,11 +30,10 @@ module Elasticsearch
         # @see https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-refresh.html
         #
         def refresh(arguments = {})
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
-          body = nil
-
-          arguments = arguments.clone
+          body   = nil
 
           _index = arguments.delete(:index)
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/reload_search_analyzers.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/reload_search_analyzers.rb
@@ -32,11 +32,10 @@ module Elasticsearch
         def reload_search_analyzers(arguments = {})
           raise ArgumentError, "Required argument 'index' missing" unless arguments[:index]
 
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
-          body = nil
-
-          arguments = arguments.clone
+          body   = nil
 
           _index = arguments.delete(:index)
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/resolve_index.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/resolve_index.rb
@@ -30,11 +30,10 @@ module Elasticsearch
         def resolve_index(arguments = {})
           raise ArgumentError, "Required argument 'name' missing" unless arguments[:name]
 
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
           body = nil
-
-          arguments = arguments.clone
 
           _name = arguments.delete(:name)
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/rollover.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/rollover.rb
@@ -36,11 +36,10 @@ module Elasticsearch
         def rollover(arguments = {})
           raise ArgumentError, "Required argument 'alias' missing" unless arguments[:alias]
 
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
-          body = arguments.delete(:body)
-
-          arguments = arguments.clone
+          body   = arguments.delete(:body)
 
           _alias = arguments.delete(:alias)
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/segments.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/segments.rb
@@ -31,11 +31,10 @@ module Elasticsearch
         # @see https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-segments.html
         #
         def segments(arguments = {})
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
-          body = nil
-
-          arguments = arguments.clone
+          body   = nil
 
           _index = arguments.delete(:index)
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/shard_stores.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/shard_stores.rb
@@ -31,11 +31,10 @@ module Elasticsearch
         # @see https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-shards-stores.html
         #
         def shard_stores(arguments = {})
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
-          body = nil
-
-          arguments = arguments.clone
+          body   = nil
 
           _index = arguments.delete(:index)
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/shrink.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/shrink.rb
@@ -35,11 +35,10 @@ module Elasticsearch
           raise ArgumentError, "Required argument 'index' missing" unless arguments[:index]
           raise ArgumentError, "Required argument 'target' missing" unless arguments[:target]
 
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
-          body = arguments.delete(:body)
-
-          arguments = arguments.clone
+          body   = arguments.delete(:body)
 
           _index = arguments.delete(:index)
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/simulate_index_template.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/simulate_index_template.rb
@@ -33,11 +33,10 @@ module Elasticsearch
         def simulate_index_template(arguments = {})
           raise ArgumentError, "Required argument 'name' missing" unless arguments[:name]
 
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
           body = arguments.delete(:body)
-
-          arguments = arguments.clone
 
           _name = arguments.delete(:name)
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/simulate_template.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/simulate_template.rb
@@ -31,11 +31,10 @@ module Elasticsearch
         # @see https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-templates.html
         #
         def simulate_template(arguments = {})
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
           body = arguments.delete(:body)
-
-          arguments = arguments.clone
 
           _name = arguments.delete(:name)
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/split.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/split.rb
@@ -35,11 +35,10 @@ module Elasticsearch
           raise ArgumentError, "Required argument 'index' missing" unless arguments[:index]
           raise ArgumentError, "Required argument 'target' missing" unless arguments[:target]
 
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
-          body = arguments.delete(:body)
-
-          arguments = arguments.clone
+          body   = arguments.delete(:body)
 
           _index = arguments.delete(:index)
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/stats.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/stats.rb
@@ -37,11 +37,10 @@ module Elasticsearch
         # @see https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-stats.html
         #
         def stats(arguments = {})
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
           body = nil
-
-          arguments = arguments.clone
 
           _metric = arguments.delete(:metric)
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/unfreeze.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/unfreeze.rb
@@ -40,11 +40,10 @@ module Elasticsearch
         def unfreeze(arguments = {})
           raise ArgumentError, "Required argument 'index' missing" unless arguments[:index]
 
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
-          body = nil
-
-          arguments = arguments.clone
+          body   = nil
 
           _index = arguments.delete(:index)
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/update_aliases.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/update_aliases.rb
@@ -31,11 +31,10 @@ module Elasticsearch
         def update_aliases(arguments = {})
           raise ArgumentError, "Required argument 'body' missing" unless arguments[:body]
 
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
-          body = arguments.delete(:body)
-
-          arguments = arguments.clone
+          body   = arguments.delete(:body)
 
           method = Elasticsearch::API::HTTP_POST
           path   = "_aliases"

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/validate_query.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/validate_query.rb
@@ -40,11 +40,10 @@ module Elasticsearch
         # @see https://www.elastic.co/guide/en/elasticsearch/reference/master/search-validate.html
         #
         def validate_query(arguments = {})
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
-          body = arguments.delete(:body)
-
-          arguments = arguments.clone
+          body   = arguments.delete(:body)
 
           _index = arguments.delete(:index)
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/info.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/info.rb
@@ -25,11 +25,10 @@ module Elasticsearch
       # @see https://www.elastic.co/guide/en/elasticsearch/reference/current/index.html
       #
       def info(arguments = {})
+        arguments = arguments.clone
         headers = arguments.delete(:headers) || {}
 
-        body = nil
-
-        arguments = arguments.clone
+        body   = nil
 
         method = Elasticsearch::API::HTTP_GET
         path   = ""

--- a/elasticsearch-api/lib/elasticsearch/api/actions/ingest/delete_pipeline.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/ingest/delete_pipeline.rb
@@ -31,11 +31,10 @@ module Elasticsearch
         def delete_pipeline(arguments = {})
           raise ArgumentError, "Required argument 'id' missing" unless arguments[:id]
 
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
           body = nil
-
-          arguments = arguments.clone
 
           _id = arguments.delete(:id)
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/ingest/geo_ip_stats.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/ingest/geo_ip_stats.rb
@@ -26,11 +26,10 @@ module Elasticsearch
         # @see https://www.elastic.co/guide/en/elasticsearch/reference/master/geoip-stats-api.html
         #
         def geo_ip_stats(arguments = {})
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
-          body = nil
-
-          arguments = arguments.clone
+          body   = nil
 
           method = Elasticsearch::API::HTTP_GET
           path   = "_ingest/geoip/stats"

--- a/elasticsearch-api/lib/elasticsearch/api/actions/ingest/get_pipeline.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/ingest/get_pipeline.rb
@@ -29,11 +29,10 @@ module Elasticsearch
         # @see https://www.elastic.co/guide/en/elasticsearch/reference/master/get-pipeline-api.html
         #
         def get_pipeline(arguments = {})
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
           body = nil
-
-          arguments = arguments.clone
 
           _id = arguments.delete(:id)
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/ingest/processor_grok.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/ingest/processor_grok.rb
@@ -26,11 +26,10 @@ module Elasticsearch
         # @see https://www.elastic.co/guide/en/elasticsearch/reference/master/grok-processor.html#grok-processor-rest-get
         #
         def processor_grok(arguments = {})
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
-          body = nil
-
-          arguments = arguments.clone
+          body   = nil
 
           method = Elasticsearch::API::HTTP_GET
           path   = "_ingest/processor/grok"

--- a/elasticsearch-api/lib/elasticsearch/api/actions/ingest/put_pipeline.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/ingest/put_pipeline.rb
@@ -34,11 +34,10 @@ module Elasticsearch
           raise ArgumentError, "Required argument 'body' missing" unless arguments[:body]
           raise ArgumentError, "Required argument 'id' missing" unless arguments[:id]
 
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
           body = arguments.delete(:body)
-
-          arguments = arguments.clone
 
           _id = arguments.delete(:id)
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/ingest/simulate.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/ingest/simulate.rb
@@ -31,11 +31,10 @@ module Elasticsearch
         def simulate(arguments = {})
           raise ArgumentError, "Required argument 'body' missing" unless arguments[:body]
 
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
           body = arguments.delete(:body)
-
-          arguments = arguments.clone
 
           _id = arguments.delete(:id)
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/knn_search.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/knn_search.rb
@@ -34,11 +34,10 @@ module Elasticsearch
       def knn_search(arguments = {})
         raise ArgumentError, "Required argument 'index' missing" unless arguments[:index]
 
+        arguments = arguments.clone
         headers = arguments.delete(:headers) || {}
 
-        body = arguments.delete(:body)
-
-        arguments = arguments.clone
+        body   = arguments.delete(:body)
 
         _index = arguments.delete(:index)
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/license/delete.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/license/delete.rb
@@ -26,11 +26,10 @@ module Elasticsearch
         # @see https://www.elastic.co/guide/en/elasticsearch/reference/master/delete-license.html
         #
         def delete(arguments = {})
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
-          body = nil
-
-          arguments = arguments.clone
+          body   = nil
 
           method = Elasticsearch::API::HTTP_DELETE
           path   = "_license"

--- a/elasticsearch-api/lib/elasticsearch/api/actions/license/get.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/license/get.rb
@@ -28,11 +28,10 @@ module Elasticsearch
         # @see https://www.elastic.co/guide/en/elasticsearch/reference/master/get-license.html
         #
         def get(arguments = {})
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
-          body = nil
-
-          arguments = arguments.clone
+          body   = nil
 
           method = Elasticsearch::API::HTTP_GET
           path   = "_license"

--- a/elasticsearch-api/lib/elasticsearch/api/actions/license/get_basic_status.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/license/get_basic_status.rb
@@ -26,11 +26,10 @@ module Elasticsearch
         # @see https://www.elastic.co/guide/en/elasticsearch/reference/master/get-basic-status.html
         #
         def get_basic_status(arguments = {})
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
-          body = nil
-
-          arguments = arguments.clone
+          body   = nil
 
           method = Elasticsearch::API::HTTP_GET
           path   = "_license/basic_status"

--- a/elasticsearch-api/lib/elasticsearch/api/actions/license/get_trial_status.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/license/get_trial_status.rb
@@ -26,11 +26,10 @@ module Elasticsearch
         # @see https://www.elastic.co/guide/en/elasticsearch/reference/master/get-trial-status.html
         #
         def get_trial_status(arguments = {})
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
-          body = nil
-
-          arguments = arguments.clone
+          body   = nil
 
           method = Elasticsearch::API::HTTP_GET
           path   = "_license/trial_status"

--- a/elasticsearch-api/lib/elasticsearch/api/actions/license/post.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/license/post.rb
@@ -28,11 +28,10 @@ module Elasticsearch
         # @see https://www.elastic.co/guide/en/elasticsearch/reference/master/update-license.html
         #
         def post(arguments = {})
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
-          body = arguments.delete(:body)
-
-          arguments = arguments.clone
+          body   = arguments.delete(:body)
 
           method = Elasticsearch::API::HTTP_PUT
           path   = "_license"

--- a/elasticsearch-api/lib/elasticsearch/api/actions/license/post_start_basic.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/license/post_start_basic.rb
@@ -27,11 +27,10 @@ module Elasticsearch
         # @see https://www.elastic.co/guide/en/elasticsearch/reference/master/start-basic.html
         #
         def post_start_basic(arguments = {})
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
-          body = nil
-
-          arguments = arguments.clone
+          body   = nil
 
           method = Elasticsearch::API::HTTP_POST
           path   = "_license/start_basic"

--- a/elasticsearch-api/lib/elasticsearch/api/actions/license/post_start_trial.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/license/post_start_trial.rb
@@ -28,11 +28,10 @@ module Elasticsearch
         # @see https://www.elastic.co/guide/en/elasticsearch/reference/master/start-trial.html
         #
         def post_start_trial(arguments = {})
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
-          body = nil
-
-          arguments = arguments.clone
+          body   = nil
 
           method = Elasticsearch::API::HTTP_POST
           path   = "_license/start_trial"

--- a/elasticsearch-api/lib/elasticsearch/api/actions/logstash/delete_pipeline.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/logstash/delete_pipeline.rb
@@ -29,11 +29,10 @@ module Elasticsearch
         def delete_pipeline(arguments = {})
           raise ArgumentError, "Required argument 'id' missing" unless arguments[:id]
 
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
           body = nil
-
-          arguments = arguments.clone
 
           _id = arguments.delete(:id)
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/logstash/get_pipeline.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/logstash/get_pipeline.rb
@@ -29,11 +29,10 @@ module Elasticsearch
         def get_pipeline(arguments = {})
           raise ArgumentError, "Required argument 'id' missing" unless arguments[:id]
 
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
           body = nil
-
-          arguments = arguments.clone
 
           _id = arguments.delete(:id)
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/logstash/put_pipeline.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/logstash/put_pipeline.rb
@@ -31,11 +31,10 @@ module Elasticsearch
           raise ArgumentError, "Required argument 'body' missing" unless arguments[:body]
           raise ArgumentError, "Required argument 'id' missing" unless arguments[:id]
 
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
           body = arguments.delete(:body)
-
-          arguments = arguments.clone
 
           _id = arguments.delete(:id)
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/machine_learning/close_job.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/machine_learning/close_job.rb
@@ -33,11 +33,10 @@ module Elasticsearch
         def close_job(arguments = {})
           raise ArgumentError, "Required argument 'job_id' missing" unless arguments[:job_id]
 
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
           body = arguments.delete(:body)
-
-          arguments = arguments.clone
 
           _job_id = arguments.delete(:job_id)
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/machine_learning/delete_calendar.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/machine_learning/delete_calendar.rb
@@ -29,11 +29,10 @@ module Elasticsearch
         def delete_calendar(arguments = {})
           raise ArgumentError, "Required argument 'calendar_id' missing" unless arguments[:calendar_id]
 
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
           body = nil
-
-          arguments = arguments.clone
 
           _calendar_id = arguments.delete(:calendar_id)
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/machine_learning/delete_calendar_event.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/machine_learning/delete_calendar_event.rb
@@ -31,11 +31,10 @@ module Elasticsearch
           raise ArgumentError, "Required argument 'calendar_id' missing" unless arguments[:calendar_id]
           raise ArgumentError, "Required argument 'event_id' missing" unless arguments[:event_id]
 
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
           body = nil
-
-          arguments = arguments.clone
 
           _calendar_id = arguments.delete(:calendar_id)
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/machine_learning/delete_calendar_job.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/machine_learning/delete_calendar_job.rb
@@ -31,11 +31,10 @@ module Elasticsearch
           raise ArgumentError, "Required argument 'calendar_id' missing" unless arguments[:calendar_id]
           raise ArgumentError, "Required argument 'job_id' missing" unless arguments[:job_id]
 
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
           body = nil
-
-          arguments = arguments.clone
 
           _calendar_id = arguments.delete(:calendar_id)
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/machine_learning/delete_data_frame_analytics.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/machine_learning/delete_data_frame_analytics.rb
@@ -31,11 +31,10 @@ module Elasticsearch
         def delete_data_frame_analytics(arguments = {})
           raise ArgumentError, "Required argument 'id' missing" unless arguments[:id]
 
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
           body = nil
-
-          arguments = arguments.clone
 
           _id = arguments.delete(:id)
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/machine_learning/delete_datafeed.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/machine_learning/delete_datafeed.rb
@@ -30,11 +30,10 @@ module Elasticsearch
         def delete_datafeed(arguments = {})
           raise ArgumentError, "Required argument 'datafeed_id' missing" unless arguments[:datafeed_id]
 
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
           body = nil
-
-          arguments = arguments.clone
 
           _datafeed_id = arguments.delete(:datafeed_id)
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/machine_learning/delete_expired_data.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/machine_learning/delete_expired_data.rb
@@ -30,11 +30,10 @@ module Elasticsearch
         # @see https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-delete-expired-data.html
         #
         def delete_expired_data(arguments = {})
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
           body = arguments.delete(:body)
-
-          arguments = arguments.clone
 
           _job_id = arguments.delete(:job_id)
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/machine_learning/delete_filter.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/machine_learning/delete_filter.rb
@@ -29,11 +29,10 @@ module Elasticsearch
         def delete_filter(arguments = {})
           raise ArgumentError, "Required argument 'filter_id' missing" unless arguments[:filter_id]
 
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
           body = nil
-
-          arguments = arguments.clone
 
           _filter_id = arguments.delete(:filter_id)
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/machine_learning/delete_forecast.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/machine_learning/delete_forecast.rb
@@ -32,11 +32,10 @@ module Elasticsearch
         def delete_forecast(arguments = {})
           raise ArgumentError, "Required argument 'job_id' missing" unless arguments[:job_id]
 
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
           body = nil
-
-          arguments = arguments.clone
 
           _job_id = arguments.delete(:job_id)
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/machine_learning/delete_job.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/machine_learning/delete_job.rb
@@ -31,11 +31,10 @@ module Elasticsearch
         def delete_job(arguments = {})
           raise ArgumentError, "Required argument 'job_id' missing" unless arguments[:job_id]
 
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
           body = nil
-
-          arguments = arguments.clone
 
           _job_id = arguments.delete(:job_id)
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/machine_learning/delete_model_snapshot.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/machine_learning/delete_model_snapshot.rb
@@ -31,11 +31,10 @@ module Elasticsearch
           raise ArgumentError, "Required argument 'job_id' missing" unless arguments[:job_id]
           raise ArgumentError, "Required argument 'snapshot_id' missing" unless arguments[:snapshot_id]
 
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
           body = nil
-
-          arguments = arguments.clone
 
           _job_id = arguments.delete(:job_id)
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/machine_learning/delete_trained_model.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/machine_learning/delete_trained_model.rb
@@ -31,11 +31,10 @@ module Elasticsearch
         def delete_trained_model(arguments = {})
           raise ArgumentError, "Required argument 'model_id' missing" unless arguments[:model_id]
 
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
           body = nil
-
-          arguments = arguments.clone
 
           _model_id = arguments.delete(:model_id)
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/machine_learning/delete_trained_model_alias.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/machine_learning/delete_trained_model_alias.rb
@@ -31,11 +31,10 @@ module Elasticsearch
           raise ArgumentError, "Required argument 'model_id' missing" unless arguments[:model_id]
           raise ArgumentError, "Required argument 'model_alias' missing" unless arguments[:model_alias]
 
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
           body = nil
-
-          arguments = arguments.clone
 
           _model_alias = arguments.delete(:model_alias)
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/machine_learning/estimate_model_memory.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/machine_learning/estimate_model_memory.rb
@@ -29,11 +29,10 @@ module Elasticsearch
         def estimate_model_memory(arguments = {})
           raise ArgumentError, "Required argument 'body' missing" unless arguments[:body]
 
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
-          body = arguments.delete(:body)
-
-          arguments = arguments.clone
+          body   = arguments.delete(:body)
 
           method = Elasticsearch::API::HTTP_POST
           path   = "_ml/anomaly_detectors/_estimate_model_memory"

--- a/elasticsearch-api/lib/elasticsearch/api/actions/machine_learning/evaluate_data_frame.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/machine_learning/evaluate_data_frame.rb
@@ -29,11 +29,10 @@ module Elasticsearch
         def evaluate_data_frame(arguments = {})
           raise ArgumentError, "Required argument 'body' missing" unless arguments[:body]
 
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
-          body = arguments.delete(:body)
-
-          arguments = arguments.clone
+          body   = arguments.delete(:body)
 
           method = Elasticsearch::API::HTTP_POST
           path   = "_ml/data_frame/_evaluate"

--- a/elasticsearch-api/lib/elasticsearch/api/actions/machine_learning/explain_data_frame_analytics.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/machine_learning/explain_data_frame_analytics.rb
@@ -28,11 +28,10 @@ module Elasticsearch
         # @see http://www.elastic.co/guide/en/elasticsearch/reference/current/explain-dfanalytics.html
         #
         def explain_data_frame_analytics(arguments = {})
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
           body = arguments.delete(:body)
-
-          arguments = arguments.clone
 
           _id = arguments.delete(:id)
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/machine_learning/flush_job.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/machine_learning/flush_job.rb
@@ -35,11 +35,10 @@ module Elasticsearch
         def flush_job(arguments = {})
           raise ArgumentError, "Required argument 'job_id' missing" unless arguments[:job_id]
 
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
           body = arguments.delete(:body)
-
-          arguments = arguments.clone
 
           _job_id = arguments.delete(:job_id)
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/machine_learning/forecast.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/machine_learning/forecast.rb
@@ -33,11 +33,10 @@ module Elasticsearch
         def forecast(arguments = {})
           raise ArgumentError, "Required argument 'job_id' missing" unless arguments[:job_id]
 
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
           body = arguments.delete(:body)
-
-          arguments = arguments.clone
 
           _job_id = arguments.delete(:job_id)
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/machine_learning/get_buckets.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/machine_learning/get_buckets.rb
@@ -40,11 +40,10 @@ module Elasticsearch
         def get_buckets(arguments = {})
           raise ArgumentError, "Required argument 'job_id' missing" unless arguments[:job_id]
 
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
           body = arguments.delete(:body)
-
-          arguments = arguments.clone
 
           _job_id = arguments.delete(:job_id)
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/machine_learning/get_calendar_events.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/machine_learning/get_calendar_events.rb
@@ -34,11 +34,10 @@ module Elasticsearch
         def get_calendar_events(arguments = {})
           raise ArgumentError, "Required argument 'calendar_id' missing" unless arguments[:calendar_id]
 
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
           body = nil
-
-          arguments = arguments.clone
 
           _calendar_id = arguments.delete(:calendar_id)
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/machine_learning/get_calendars.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/machine_learning/get_calendars.rb
@@ -30,11 +30,10 @@ module Elasticsearch
         # @see https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-calendar.html
         #
         def get_calendars(arguments = {})
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
           body = arguments.delete(:body)
-
-          arguments = arguments.clone
 
           _calendar_id = arguments.delete(:calendar_id)
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/machine_learning/get_categories.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/machine_learning/get_categories.rb
@@ -34,11 +34,10 @@ module Elasticsearch
         def get_categories(arguments = {})
           raise ArgumentError, "Required argument 'job_id' missing" unless arguments[:job_id]
 
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
           body = arguments.delete(:body)
-
-          arguments = arguments.clone
 
           _job_id = arguments.delete(:job_id)
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/machine_learning/get_data_frame_analytics.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/machine_learning/get_data_frame_analytics.rb
@@ -31,11 +31,10 @@ module Elasticsearch
         # @see https://www.elastic.co/guide/en/elasticsearch/reference/current/get-dfanalytics.html
         #
         def get_data_frame_analytics(arguments = {})
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
           body = nil
-
-          arguments = arguments.clone
 
           _id = arguments.delete(:id)
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/machine_learning/get_data_frame_analytics_stats.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/machine_learning/get_data_frame_analytics_stats.rb
@@ -31,11 +31,10 @@ module Elasticsearch
         # @see https://www.elastic.co/guide/en/elasticsearch/reference/current/get-dfanalytics-stats.html
         #
         def get_data_frame_analytics_stats(arguments = {})
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
           body = nil
-
-          arguments = arguments.clone
 
           _id = arguments.delete(:id)
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/machine_learning/get_datafeed_stats.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/machine_learning/get_datafeed_stats.rb
@@ -28,11 +28,10 @@ module Elasticsearch
         # @see https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-datafeed-stats.html
         #
         def get_datafeed_stats(arguments = {})
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
           body = nil
-
-          arguments = arguments.clone
 
           _datafeed_id = arguments.delete(:datafeed_id)
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/machine_learning/get_datafeeds.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/machine_learning/get_datafeeds.rb
@@ -29,11 +29,10 @@ module Elasticsearch
         # @see https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-datafeed.html
         #
         def get_datafeeds(arguments = {})
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
           body = nil
-
-          arguments = arguments.clone
 
           _datafeed_id = arguments.delete(:datafeed_id)
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/machine_learning/get_filters.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/machine_learning/get_filters.rb
@@ -29,11 +29,10 @@ module Elasticsearch
         # @see https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-filter.html
         #
         def get_filters(arguments = {})
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
           body = nil
-
-          arguments = arguments.clone
 
           _filter_id = arguments.delete(:filter_id)
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/machine_learning/get_influencers.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/machine_learning/get_influencers.rb
@@ -38,11 +38,10 @@ module Elasticsearch
         def get_influencers(arguments = {})
           raise ArgumentError, "Required argument 'job_id' missing" unless arguments[:job_id]
 
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
           body = arguments.delete(:body)
-
-          arguments = arguments.clone
 
           _job_id = arguments.delete(:job_id)
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/machine_learning/get_job_stats.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/machine_learning/get_job_stats.rb
@@ -28,11 +28,10 @@ module Elasticsearch
         # @see https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-job-stats.html
         #
         def get_job_stats(arguments = {})
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
           body = nil
-
-          arguments = arguments.clone
 
           _job_id = arguments.delete(:job_id)
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/machine_learning/get_jobs.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/machine_learning/get_jobs.rb
@@ -29,11 +29,10 @@ module Elasticsearch
         # @see https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-job.html
         #
         def get_jobs(arguments = {})
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
           body = nil
-
-          arguments = arguments.clone
 
           _job_id = arguments.delete(:job_id)
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/machine_learning/get_memory_stats.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/machine_learning/get_memory_stats.rb
@@ -29,11 +29,10 @@ module Elasticsearch
         # @see https://www.elastic.co/guide/en/elasticsearch/reference/current/get-ml-memory.html
         #
         def get_memory_stats(arguments = {})
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
           body = nil
-
-          arguments = arguments.clone
 
           _node_id = arguments.delete(:node_id)
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/machine_learning/get_model_snapshot_upgrade_stats.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/machine_learning/get_model_snapshot_upgrade_stats.rb
@@ -32,11 +32,10 @@ module Elasticsearch
           raise ArgumentError, "Required argument 'job_id' missing" unless arguments[:job_id]
           raise ArgumentError, "Required argument 'snapshot_id' missing" unless arguments[:snapshot_id]
 
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
           body = nil
-
-          arguments = arguments.clone
 
           _job_id = arguments.delete(:job_id)
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/machine_learning/get_model_snapshots.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/machine_learning/get_model_snapshots.rb
@@ -37,11 +37,10 @@ module Elasticsearch
         def get_model_snapshots(arguments = {})
           raise ArgumentError, "Required argument 'job_id' missing" unless arguments[:job_id]
 
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
           body = arguments.delete(:body)
-
-          arguments = arguments.clone
 
           _job_id = arguments.delete(:job_id)
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/machine_learning/get_overall_buckets.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/machine_learning/get_overall_buckets.rb
@@ -37,11 +37,10 @@ module Elasticsearch
         def get_overall_buckets(arguments = {})
           raise ArgumentError, "Required argument 'job_id' missing" unless arguments[:job_id]
 
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
           body = arguments.delete(:body)
-
-          arguments = arguments.clone
 
           _job_id = arguments.delete(:job_id)
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/machine_learning/get_records.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/machine_learning/get_records.rb
@@ -38,11 +38,10 @@ module Elasticsearch
         def get_records(arguments = {})
           raise ArgumentError, "Required argument 'job_id' missing" unless arguments[:job_id]
 
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
           body = arguments.delete(:body)
-
-          arguments = arguments.clone
 
           _job_id = arguments.delete(:job_id)
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/machine_learning/get_trained_models.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/machine_learning/get_trained_models.rb
@@ -35,11 +35,10 @@ module Elasticsearch
         # @see https://www.elastic.co/guide/en/elasticsearch/reference/current/get-trained-models.html
         #
         def get_trained_models(arguments = {})
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
           body = nil
-
-          arguments = arguments.clone
 
           _model_id = arguments.delete(:model_id)
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/machine_learning/get_trained_models_stats.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/machine_learning/get_trained_models_stats.rb
@@ -30,11 +30,10 @@ module Elasticsearch
         # @see https://www.elastic.co/guide/en/elasticsearch/reference/current/get-trained-models-stats.html
         #
         def get_trained_models_stats(arguments = {})
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
           body = nil
-
-          arguments = arguments.clone
 
           _model_id = arguments.delete(:model_id)
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/machine_learning/infer_trained_model_deployment.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/machine_learning/infer_trained_model_deployment.rb
@@ -36,11 +36,10 @@ module Elasticsearch
           raise ArgumentError, "Required argument 'body' missing" unless arguments[:body]
           raise ArgumentError, "Required argument 'model_id' missing" unless arguments[:model_id]
 
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
           body = arguments.delete(:body)
-
-          arguments = arguments.clone
 
           _model_id = arguments.delete(:model_id)
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/machine_learning/info.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/machine_learning/info.rb
@@ -26,11 +26,10 @@ module Elasticsearch
         # @see https://www.elastic.co/guide/en/elasticsearch/reference/current/get-ml-info.html
         #
         def info(arguments = {})
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
-          body = nil
-
-          arguments = arguments.clone
+          body   = nil
 
           method = Elasticsearch::API::HTTP_GET
           path   = "_ml/info"

--- a/elasticsearch-api/lib/elasticsearch/api/actions/machine_learning/open_job.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/machine_learning/open_job.rb
@@ -30,11 +30,10 @@ module Elasticsearch
         def open_job(arguments = {})
           raise ArgumentError, "Required argument 'job_id' missing" unless arguments[:job_id]
 
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
           body = arguments.delete(:body)
-
-          arguments = arguments.clone
 
           _job_id = arguments.delete(:job_id)
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/machine_learning/post_calendar_events.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/machine_learning/post_calendar_events.rb
@@ -31,11 +31,10 @@ module Elasticsearch
           raise ArgumentError, "Required argument 'body' missing" unless arguments[:body]
           raise ArgumentError, "Required argument 'calendar_id' missing" unless arguments[:calendar_id]
 
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
           body = arguments.delete(:body)
-
-          arguments = arguments.clone
 
           _calendar_id = arguments.delete(:calendar_id)
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/machine_learning/post_data.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/machine_learning/post_data.rb
@@ -33,11 +33,10 @@ module Elasticsearch
           raise ArgumentError, "Required argument 'body' missing" unless arguments[:body]
           raise ArgumentError, "Required argument 'job_id' missing" unless arguments[:job_id]
 
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
           body = arguments.delete(:body)
-
-          arguments = arguments.clone
 
           _job_id = arguments.delete(:job_id)
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/machine_learning/preview_data_frame_analytics.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/machine_learning/preview_data_frame_analytics.rb
@@ -28,11 +28,10 @@ module Elasticsearch
         # @see http://www.elastic.co/guide/en/elasticsearch/reference/current/preview-dfanalytics.html
         #
         def preview_data_frame_analytics(arguments = {})
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
           body = arguments.delete(:body)
-
-          arguments = arguments.clone
 
           _id = arguments.delete(:id)
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/machine_learning/preview_datafeed.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/machine_learning/preview_datafeed.rb
@@ -28,11 +28,10 @@ module Elasticsearch
         # @see https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-preview-datafeed.html
         #
         def preview_datafeed(arguments = {})
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
           body = arguments.delete(:body)
-
-          arguments = arguments.clone
 
           _datafeed_id = arguments.delete(:datafeed_id)
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/machine_learning/put_calendar.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/machine_learning/put_calendar.rb
@@ -30,11 +30,10 @@ module Elasticsearch
         def put_calendar(arguments = {})
           raise ArgumentError, "Required argument 'calendar_id' missing" unless arguments[:calendar_id]
 
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
           body = arguments.delete(:body)
-
-          arguments = arguments.clone
 
           _calendar_id = arguments.delete(:calendar_id)
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/machine_learning/put_calendar_job.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/machine_learning/put_calendar_job.rb
@@ -31,11 +31,10 @@ module Elasticsearch
           raise ArgumentError, "Required argument 'calendar_id' missing" unless arguments[:calendar_id]
           raise ArgumentError, "Required argument 'job_id' missing" unless arguments[:job_id]
 
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
           body = nil
-
-          arguments = arguments.clone
 
           _calendar_id = arguments.delete(:calendar_id)
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/machine_learning/put_data_frame_analytics.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/machine_learning/put_data_frame_analytics.rb
@@ -31,11 +31,10 @@ module Elasticsearch
           raise ArgumentError, "Required argument 'body' missing" unless arguments[:body]
           raise ArgumentError, "Required argument 'id' missing" unless arguments[:id]
 
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
           body = arguments.delete(:body)
-
-          arguments = arguments.clone
 
           _id = arguments.delete(:id)
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/machine_learning/put_datafeed.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/machine_learning/put_datafeed.rb
@@ -35,11 +35,10 @@ module Elasticsearch
           raise ArgumentError, "Required argument 'body' missing" unless arguments[:body]
           raise ArgumentError, "Required argument 'datafeed_id' missing" unless arguments[:datafeed_id]
 
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
           body = arguments.delete(:body)
-
-          arguments = arguments.clone
 
           _datafeed_id = arguments.delete(:datafeed_id)
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/machine_learning/put_filter.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/machine_learning/put_filter.rb
@@ -31,11 +31,10 @@ module Elasticsearch
           raise ArgumentError, "Required argument 'body' missing" unless arguments[:body]
           raise ArgumentError, "Required argument 'filter_id' missing" unless arguments[:filter_id]
 
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
           body = arguments.delete(:body)
-
-          arguments = arguments.clone
 
           _filter_id = arguments.delete(:filter_id)
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/machine_learning/put_job.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/machine_learning/put_job.rb
@@ -35,11 +35,10 @@ module Elasticsearch
           raise ArgumentError, "Required argument 'body' missing" unless arguments[:body]
           raise ArgumentError, "Required argument 'job_id' missing" unless arguments[:job_id]
 
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
           body = arguments.delete(:body)
-
-          arguments = arguments.clone
 
           _job_id = arguments.delete(:job_id)
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/machine_learning/put_trained_model.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/machine_learning/put_trained_model.rb
@@ -32,11 +32,10 @@ module Elasticsearch
           raise ArgumentError, "Required argument 'body' missing" unless arguments[:body]
           raise ArgumentError, "Required argument 'model_id' missing" unless arguments[:model_id]
 
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
           body = arguments.delete(:body)
-
-          arguments = arguments.clone
 
           _model_id = arguments.delete(:model_id)
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/machine_learning/put_trained_model_alias.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/machine_learning/put_trained_model_alias.rb
@@ -32,11 +32,10 @@ module Elasticsearch
           raise ArgumentError, "Required argument 'model_id' missing" unless arguments[:model_id]
           raise ArgumentError, "Required argument 'model_alias' missing" unless arguments[:model_alias]
 
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
           body = nil
-
-          arguments = arguments.clone
 
           _model_alias = arguments.delete(:model_alias)
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/machine_learning/put_trained_model_definition_part.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/machine_learning/put_trained_model_definition_part.rb
@@ -37,11 +37,10 @@ module Elasticsearch
           raise ArgumentError, "Required argument 'model_id' missing" unless arguments[:model_id]
           raise ArgumentError, "Required argument 'part' missing" unless arguments[:part]
 
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
           body = arguments.delete(:body)
-
-          arguments = arguments.clone
 
           _model_id = arguments.delete(:model_id)
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/machine_learning/put_trained_model_vocabulary.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/machine_learning/put_trained_model_vocabulary.rb
@@ -35,11 +35,10 @@ module Elasticsearch
           raise ArgumentError, "Required argument 'body' missing" unless arguments[:body]
           raise ArgumentError, "Required argument 'model_id' missing" unless arguments[:model_id]
 
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
           body = arguments.delete(:body)
-
-          arguments = arguments.clone
 
           _model_id = arguments.delete(:model_id)
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/machine_learning/reset_job.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/machine_learning/reset_job.rb
@@ -30,11 +30,10 @@ module Elasticsearch
         def reset_job(arguments = {})
           raise ArgumentError, "Required argument 'job_id' missing" unless arguments[:job_id]
 
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
           body = nil
-
-          arguments = arguments.clone
 
           _job_id = arguments.delete(:job_id)
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/machine_learning/revert_model_snapshot.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/machine_learning/revert_model_snapshot.rb
@@ -33,11 +33,10 @@ module Elasticsearch
           raise ArgumentError, "Required argument 'job_id' missing" unless arguments[:job_id]
           raise ArgumentError, "Required argument 'snapshot_id' missing" unless arguments[:snapshot_id]
 
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
           body = arguments.delete(:body)
-
-          arguments = arguments.clone
 
           _job_id = arguments.delete(:job_id)
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/machine_learning/set_upgrade_mode.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/machine_learning/set_upgrade_mode.rb
@@ -28,11 +28,10 @@ module Elasticsearch
         # @see https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-set-upgrade-mode.html
         #
         def set_upgrade_mode(arguments = {})
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
-          body = nil
-
-          arguments = arguments.clone
+          body   = nil
 
           method = Elasticsearch::API::HTTP_POST
           path   = "_ml/set_upgrade_mode"

--- a/elasticsearch-api/lib/elasticsearch/api/actions/machine_learning/start_data_frame_analytics.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/machine_learning/start_data_frame_analytics.rb
@@ -31,11 +31,10 @@ module Elasticsearch
         def start_data_frame_analytics(arguments = {})
           raise ArgumentError, "Required argument 'id' missing" unless arguments[:id]
 
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
           body = arguments.delete(:body)
-
-          arguments = arguments.clone
 
           _id = arguments.delete(:id)
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/machine_learning/start_datafeed.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/machine_learning/start_datafeed.rb
@@ -33,11 +33,10 @@ module Elasticsearch
         def start_datafeed(arguments = {})
           raise ArgumentError, "Required argument 'datafeed_id' missing" unless arguments[:datafeed_id]
 
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
           body = arguments.delete(:body)
-
-          arguments = arguments.clone
 
           _datafeed_id = arguments.delete(:datafeed_id)
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/machine_learning/start_trained_model_deployment.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/machine_learning/start_trained_model_deployment.rb
@@ -35,11 +35,10 @@ module Elasticsearch
         def start_trained_model_deployment(arguments = {})
           raise ArgumentError, "Required argument 'model_id' missing" unless arguments[:model_id]
 
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
           body = nil
-
-          arguments = arguments.clone
 
           _model_id = arguments.delete(:model_id)
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/machine_learning/stop_data_frame_analytics.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/machine_learning/stop_data_frame_analytics.rb
@@ -33,11 +33,10 @@ module Elasticsearch
         def stop_data_frame_analytics(arguments = {})
           raise ArgumentError, "Required argument 'id' missing" unless arguments[:id]
 
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
           body = arguments.delete(:body)
-
-          arguments = arguments.clone
 
           _id = arguments.delete(:id)
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/machine_learning/stop_datafeed.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/machine_learning/stop_datafeed.rb
@@ -34,11 +34,10 @@ module Elasticsearch
         def stop_datafeed(arguments = {})
           raise ArgumentError, "Required argument 'datafeed_id' missing" unless arguments[:datafeed_id]
 
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
           body = arguments.delete(:body)
-
-          arguments = arguments.clone
 
           _datafeed_id = arguments.delete(:datafeed_id)
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/machine_learning/stop_trained_model_deployment.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/machine_learning/stop_trained_model_deployment.rb
@@ -36,11 +36,10 @@ module Elasticsearch
         def stop_trained_model_deployment(arguments = {})
           raise ArgumentError, "Required argument 'model_id' missing" unless arguments[:model_id]
 
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
           body = arguments.delete(:body)
-
-          arguments = arguments.clone
 
           _model_id = arguments.delete(:model_id)
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/machine_learning/update_data_frame_analytics.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/machine_learning/update_data_frame_analytics.rb
@@ -31,11 +31,10 @@ module Elasticsearch
           raise ArgumentError, "Required argument 'body' missing" unless arguments[:body]
           raise ArgumentError, "Required argument 'id' missing" unless arguments[:id]
 
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
           body = arguments.delete(:body)
-
-          arguments = arguments.clone
 
           _id = arguments.delete(:id)
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/machine_learning/update_datafeed.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/machine_learning/update_datafeed.rb
@@ -35,11 +35,10 @@ module Elasticsearch
           raise ArgumentError, "Required argument 'body' missing" unless arguments[:body]
           raise ArgumentError, "Required argument 'datafeed_id' missing" unless arguments[:datafeed_id]
 
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
           body = arguments.delete(:body)
-
-          arguments = arguments.clone
 
           _datafeed_id = arguments.delete(:datafeed_id)
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/machine_learning/update_filter.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/machine_learning/update_filter.rb
@@ -31,11 +31,10 @@ module Elasticsearch
           raise ArgumentError, "Required argument 'body' missing" unless arguments[:body]
           raise ArgumentError, "Required argument 'filter_id' missing" unless arguments[:filter_id]
 
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
           body = arguments.delete(:body)
-
-          arguments = arguments.clone
 
           _filter_id = arguments.delete(:filter_id)
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/machine_learning/update_job.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/machine_learning/update_job.rb
@@ -31,11 +31,10 @@ module Elasticsearch
           raise ArgumentError, "Required argument 'body' missing" unless arguments[:body]
           raise ArgumentError, "Required argument 'job_id' missing" unless arguments[:job_id]
 
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
           body = arguments.delete(:body)
-
-          arguments = arguments.clone
 
           _job_id = arguments.delete(:job_id)
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/machine_learning/update_model_snapshot.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/machine_learning/update_model_snapshot.rb
@@ -33,11 +33,10 @@ module Elasticsearch
           raise ArgumentError, "Required argument 'job_id' missing" unless arguments[:job_id]
           raise ArgumentError, "Required argument 'snapshot_id' missing" unless arguments[:snapshot_id]
 
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
           body = arguments.delete(:body)
-
-          arguments = arguments.clone
 
           _job_id = arguments.delete(:job_id)
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/machine_learning/upgrade_job_snapshot.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/machine_learning/upgrade_job_snapshot.rb
@@ -33,11 +33,10 @@ module Elasticsearch
           raise ArgumentError, "Required argument 'job_id' missing" unless arguments[:job_id]
           raise ArgumentError, "Required argument 'snapshot_id' missing" unless arguments[:snapshot_id]
 
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
           body = nil
-
-          arguments = arguments.clone
 
           _job_id = arguments.delete(:job_id)
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/machine_learning/validate.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/machine_learning/validate.rb
@@ -29,11 +29,10 @@ module Elasticsearch
         def validate(arguments = {})
           raise ArgumentError, "Required argument 'body' missing" unless arguments[:body]
 
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
-          body = arguments.delete(:body)
-
-          arguments = arguments.clone
+          body   = arguments.delete(:body)
 
           method = Elasticsearch::API::HTTP_POST
           path   = "_ml/anomaly_detectors/_validate"

--- a/elasticsearch-api/lib/elasticsearch/api/actions/machine_learning/validate_detector.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/machine_learning/validate_detector.rb
@@ -29,11 +29,10 @@ module Elasticsearch
         def validate_detector(arguments = {})
           raise ArgumentError, "Required argument 'body' missing" unless arguments[:body]
 
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
-          body = arguments.delete(:body)
-
-          arguments = arguments.clone
+          body   = arguments.delete(:body)
 
           method = Elasticsearch::API::HTTP_POST
           path   = "_ml/anomaly_detectors/_validate/detector"

--- a/elasticsearch-api/lib/elasticsearch/api/actions/mget.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/mget.rb
@@ -37,11 +37,10 @@ module Elasticsearch
       def mget(arguments = {})
         raise ArgumentError, "Required argument 'body' missing" unless arguments[:body]
 
+        arguments = arguments.clone
         headers = arguments.delete(:headers) || {}
 
-        body = arguments.delete(:body)
-
-        arguments = arguments.clone
+        body   = arguments.delete(:body)
 
         _index = arguments.delete(:index)
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/migration/deprecations.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/migration/deprecations.rb
@@ -27,11 +27,10 @@ module Elasticsearch
         # @see https://www.elastic.co/guide/en/elasticsearch/reference/current/migration-api-deprecation.html
         #
         def deprecations(arguments = {})
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
-          body = nil
-
-          arguments = arguments.clone
+          body   = nil
 
           _index = arguments.delete(:index)
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/migration/get_feature_upgrade_status.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/migration/get_feature_upgrade_status.rb
@@ -26,11 +26,10 @@ module Elasticsearch
         # @see https://www.elastic.co/guide/en/elasticsearch/reference/current/migration-api-feature-upgrade.html
         #
         def get_feature_upgrade_status(arguments = {})
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
-          body = nil
-
-          arguments = arguments.clone
+          body   = nil
 
           method = Elasticsearch::API::HTTP_GET
           path   = "_migration/system_features"

--- a/elasticsearch-api/lib/elasticsearch/api/actions/migration/post_feature_upgrade.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/migration/post_feature_upgrade.rb
@@ -26,11 +26,10 @@ module Elasticsearch
         # @see https://www.elastic.co/guide/en/elasticsearch/reference/current/migration-api-feature-upgrade.html
         #
         def post_feature_upgrade(arguments = {})
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
-          body = nil
-
-          arguments = arguments.clone
+          body   = nil
 
           method = Elasticsearch::API::HTTP_POST
           path   = "_migration/system_features"

--- a/elasticsearch-api/lib/elasticsearch/api/actions/monitoring/bulk.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/monitoring/bulk.rb
@@ -39,11 +39,10 @@ module Elasticsearch
         def bulk(arguments = {})
           raise ArgumentError, "Required argument 'body' missing" unless arguments[:body]
 
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
           body = arguments.delete(:body)
-
-          arguments = arguments.clone
 
           _type = arguments.delete(:type)
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/msearch.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/msearch.rb
@@ -36,11 +36,10 @@ module Elasticsearch
       def msearch(arguments = {})
         raise ArgumentError, "Required argument 'body' missing" unless arguments[:body]
 
+        arguments = arguments.clone
         headers = arguments.delete(:headers) || {}
 
-        body = arguments.delete(:body)
-
-        arguments = arguments.clone
+        body   = arguments.delete(:body)
 
         _index = arguments.delete(:index)
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/msearch_template.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/msearch_template.rb
@@ -34,11 +34,10 @@ module Elasticsearch
       def msearch_template(arguments = {})
         raise ArgumentError, "Required argument 'body' missing" unless arguments[:body]
 
+        arguments = arguments.clone
         headers = arguments.delete(:headers) || {}
 
-        body = arguments.delete(:body)
-
-        arguments = arguments.clone
+        body   = arguments.delete(:body)
 
         _index = arguments.delete(:index)
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/mtermvectors.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/mtermvectors.rb
@@ -39,6 +39,7 @@ module Elasticsearch
       # @see https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-multi-termvectors.html
       #
       def mtermvectors(arguments = {})
+        arguments = arguments.clone
         headers = arguments.delete(:headers) || {}
 
         body = if (ids = arguments.delete(:ids))
@@ -46,8 +47,6 @@ module Elasticsearch
                else
                  arguments.delete(:body)
                end
-
-        arguments = arguments.clone
 
         _index = arguments.delete(:index)
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/nodes/clear_repositories_metering_archive.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/nodes/clear_repositories_metering_archive.rb
@@ -37,11 +37,10 @@ module Elasticsearch
           raise ArgumentError,
                 "Required argument 'max_archive_version' missing" unless arguments[:max_archive_version]
 
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
           body = nil
-
-          arguments = arguments.clone
 
           _node_id = arguments.delete(:node_id)
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/nodes/get_repositories_metering_info.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/nodes/get_repositories_metering_info.rb
@@ -33,11 +33,10 @@ module Elasticsearch
         def get_repositories_metering_info(arguments = {})
           raise ArgumentError, "Required argument 'node_id' missing" unless arguments[:node_id]
 
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
           body = nil
-
-          arguments = arguments.clone
 
           _node_id = arguments.delete(:node_id)
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/nodes/hot_threads.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/nodes/hot_threads.rb
@@ -34,11 +34,10 @@ module Elasticsearch
         # @see https://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-nodes-hot-threads.html
         #
         def hot_threads(arguments = {})
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
           body = nil
-
-          arguments = arguments.clone
 
           _node_id = arguments.delete(:node_id)
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/nodes/info.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/nodes/info.rb
@@ -30,11 +30,10 @@ module Elasticsearch
         # @see https://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-nodes-info.html
         #
         def info(arguments = {})
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
           body = nil
-
-          arguments = arguments.clone
 
           _node_id = arguments.delete(:node_id)
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/nodes/reload_secure_settings.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/nodes/reload_secure_settings.rb
@@ -29,11 +29,10 @@ module Elasticsearch
         # @see https://www.elastic.co/guide/en/elasticsearch/reference/master/secure-settings.html#reloadable-secure-settings
         #
         def reload_secure_settings(arguments = {})
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
           body = arguments.delete(:body)
-
-          arguments = arguments.clone
 
           _node_id = arguments.delete(:node_id)
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/nodes/stats.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/nodes/stats.rb
@@ -38,11 +38,10 @@ module Elasticsearch
         # @see https://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-nodes-stats.html
         #
         def stats(arguments = {})
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
           body = nil
-
-          arguments = arguments.clone
 
           _node_id = arguments.delete(:node_id)
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/nodes/usage.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/nodes/usage.rb
@@ -29,11 +29,10 @@ module Elasticsearch
         # @see https://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-nodes-usage.html
         #
         def usage(arguments = {})
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
           body = nil
-
-          arguments = arguments.clone
 
           _node_id = arguments.delete(:node_id)
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/open_point_in_time.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/open_point_in_time.rb
@@ -33,11 +33,10 @@ module Elasticsearch
       def open_point_in_time(arguments = {})
         raise ArgumentError, "Required argument 'index' missing" unless arguments[:index]
 
+        arguments = arguments.clone
         headers = arguments.delete(:headers) || {}
 
-        body = nil
-
-        arguments = arguments.clone
+        body   = nil
 
         _index = arguments.delete(:index)
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/ping.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/ping.rb
@@ -25,11 +25,10 @@ module Elasticsearch
       # @see https://www.elastic.co/guide/en/elasticsearch/reference/current/index.html
       #
       def ping(arguments = {})
+        arguments = arguments.clone
         headers = arguments.delete(:headers) || {}
 
-        body = nil
-
-        arguments = arguments.clone
+        body   = nil
 
         method = Elasticsearch::API::HTTP_HEAD
         path   = ""

--- a/elasticsearch-api/lib/elasticsearch/api/actions/put_script.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/put_script.rb
@@ -33,11 +33,10 @@ module Elasticsearch
         raise ArgumentError, "Required argument 'body' missing" unless arguments[:body]
         raise ArgumentError, "Required argument 'id' missing" unless arguments[:id]
 
+        arguments = arguments.clone
         headers = arguments.delete(:headers) || {}
 
         body = arguments.delete(:body)
-
-        arguments = arguments.clone
 
         _id = arguments.delete(:id)
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/rank_eval.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/rank_eval.rb
@@ -33,11 +33,10 @@ module Elasticsearch
       def rank_eval(arguments = {})
         raise ArgumentError, "Required argument 'body' missing" unless arguments[:body]
 
+        arguments = arguments.clone
         headers = arguments.delete(:headers) || {}
 
-        body = arguments.delete(:body)
-
-        arguments = arguments.clone
+        body   = arguments.delete(:body)
 
         _index = arguments.delete(:index)
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/reindex.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/reindex.rb
@@ -38,11 +38,10 @@ module Elasticsearch
       def reindex(arguments = {})
         raise ArgumentError, "Required argument 'body' missing" unless arguments[:body]
 
+        arguments = arguments.clone
         headers = arguments.delete(:headers) || {}
 
-        body = arguments.delete(:body)
-
-        arguments = arguments.clone
+        body   = arguments.delete(:body)
 
         method = Elasticsearch::API::HTTP_POST
         path   = "_reindex"

--- a/elasticsearch-api/lib/elasticsearch/api/actions/reindex_rethrottle.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/reindex_rethrottle.rb
@@ -29,11 +29,10 @@ module Elasticsearch
       def reindex_rethrottle(arguments = {})
         raise ArgumentError, "Required argument 'task_id' missing" unless arguments[:task_id]
 
+        arguments = arguments.clone
         headers = arguments.delete(:headers) || {}
 
         body = nil
-
-        arguments = arguments.clone
 
         _task_id = arguments.delete(:task_id)
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/render_search_template.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/render_search_template.rb
@@ -27,11 +27,10 @@ module Elasticsearch
       # @see https://www.elastic.co/guide/en/elasticsearch/reference/current/render-search-template-api.html
       #
       def render_search_template(arguments = {})
+        arguments = arguments.clone
         headers = arguments.delete(:headers) || {}
 
         body = arguments.delete(:body)
-
-        arguments = arguments.clone
 
         _id = arguments.delete(:id)
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/rollup/delete_job.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/rollup/delete_job.rb
@@ -33,11 +33,10 @@ module Elasticsearch
         def delete_job(arguments = {})
           raise ArgumentError, "Required argument 'id' missing" unless arguments[:id]
 
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
           body = nil
-
-          arguments = arguments.clone
 
           _id = arguments.delete(:id)
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/rollup/get_jobs.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/rollup/get_jobs.rb
@@ -31,11 +31,10 @@ module Elasticsearch
         # @see https://www.elastic.co/guide/en/elasticsearch/reference/master/rollup-get-job.html
         #
         def get_jobs(arguments = {})
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
           body = nil
-
-          arguments = arguments.clone
 
           _id = arguments.delete(:id)
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/rollup/get_rollup_caps.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/rollup/get_rollup_caps.rb
@@ -31,11 +31,10 @@ module Elasticsearch
         # @see https://www.elastic.co/guide/en/elasticsearch/reference/master/rollup-get-rollup-caps.html
         #
         def get_rollup_caps(arguments = {})
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
           body = nil
-
-          arguments = arguments.clone
 
           _id = arguments.delete(:id)
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/rollup/get_rollup_index_caps.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/rollup/get_rollup_index_caps.rb
@@ -33,11 +33,10 @@ module Elasticsearch
         def get_rollup_index_caps(arguments = {})
           raise ArgumentError, "Required argument 'index' missing" unless arguments[:index]
 
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
-          body = nil
-
-          arguments = arguments.clone
+          body   = nil
 
           _index = arguments.delete(:index)
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/rollup/put_job.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/rollup/put_job.rb
@@ -35,11 +35,10 @@ module Elasticsearch
           raise ArgumentError, "Required argument 'body' missing" unless arguments[:body]
           raise ArgumentError, "Required argument 'id' missing" unless arguments[:id]
 
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
           body = arguments.delete(:body)
-
-          arguments = arguments.clone
 
           _id = arguments.delete(:id)
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/rollup/rollup.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/rollup/rollup.rb
@@ -37,11 +37,10 @@ module Elasticsearch
           raise ArgumentError, "Required argument 'index' missing" unless arguments[:index]
           raise ArgumentError, "Required argument 'rollup_index' missing" unless arguments[:rollup_index]
 
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
-          body = arguments.delete(:body)
-
-          arguments = arguments.clone
+          body   = arguments.delete(:body)
 
           _index = arguments.delete(:index)
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/rollup/rollup_search.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/rollup/rollup_search.rb
@@ -37,11 +37,10 @@ module Elasticsearch
           raise ArgumentError, "Required argument 'body' missing" unless arguments[:body]
           raise ArgumentError, "Required argument 'index' missing" unless arguments[:index]
 
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
-          body = arguments.delete(:body)
-
-          arguments = arguments.clone
+          body   = arguments.delete(:body)
 
           _index = arguments.delete(:index)
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/rollup/start_job.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/rollup/start_job.rb
@@ -33,11 +33,10 @@ module Elasticsearch
         def start_job(arguments = {})
           raise ArgumentError, "Required argument 'id' missing" unless arguments[:id]
 
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
           body = nil
-
-          arguments = arguments.clone
 
           _id = arguments.delete(:id)
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/rollup/stop_job.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/rollup/stop_job.rb
@@ -35,11 +35,10 @@ module Elasticsearch
         def stop_job(arguments = {})
           raise ArgumentError, "Required argument 'id' missing" unless arguments[:id]
 
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
           body = nil
-
-          arguments = arguments.clone
 
           _id = arguments.delete(:id)
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/scripts_painless_execute.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/scripts_painless_execute.rb
@@ -30,11 +30,10 @@ module Elasticsearch
       # @see https://www.elastic.co/guide/en/elasticsearch/painless/master/painless-execute-api.html
       #
       def scripts_painless_execute(arguments = {})
+        arguments = arguments.clone
         headers = arguments.delete(:headers) || {}
 
-        body = arguments.delete(:body)
-
-        arguments = arguments.clone
+        body   = arguments.delete(:body)
 
         method = if body
                    Elasticsearch::API::HTTP_POST

--- a/elasticsearch-api/lib/elasticsearch/api/actions/scroll.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/scroll.rb
@@ -34,11 +34,10 @@ module Elasticsearch
       # @see https://www.elastic.co/guide/en/elasticsearch/reference/master/search-request-body.html#request-body-search-scroll
       #
       def scroll(arguments = {})
+        arguments = arguments.clone
         headers = arguments.delete(:headers) || {}
 
         body = arguments.delete(:body)
-
-        arguments = arguments.clone
 
         _scroll_id = arguments.delete(:scroll_id)
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/search.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/search.rb
@@ -70,11 +70,11 @@ module Elasticsearch
       # @see https://www.elastic.co/guide/en/elasticsearch/reference/master/search-search.html
       #
       def search(arguments = {})
+        arguments = arguments.clone
         headers = arguments.delete(:headers) || {}
 
         body = arguments.delete(:body)
 
-        arguments = arguments.clone
         arguments[:index] = UNDERSCORE_ALL if !arguments[:index] && arguments[:type]
 
         _index = arguments.delete(:index)

--- a/elasticsearch-api/lib/elasticsearch/api/actions/search_mvt.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/search_mvt.rb
@@ -47,11 +47,10 @@ module Elasticsearch
         raise ArgumentError, "Required argument 'x' missing" unless arguments[:x]
         raise ArgumentError, "Required argument 'y' missing" unless arguments[:y]
 
+        arguments = arguments.clone
         headers = arguments.delete(:headers) || {}
 
-        body = arguments.delete(:body)
-
-        arguments = arguments.clone
+        body   = arguments.delete(:body)
 
         _index = arguments.delete(:index)
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/search_shards.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/search_shards.rb
@@ -32,11 +32,10 @@ module Elasticsearch
       # @see https://www.elastic.co/guide/en/elasticsearch/reference/master/search-shards.html
       #
       def search_shards(arguments = {})
+        arguments = arguments.clone
         headers = arguments.delete(:headers) || {}
 
-        body = nil
-
-        arguments = arguments.clone
+        body   = nil
 
         _index = arguments.delete(:index)
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/search_template.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/search_template.rb
@@ -42,11 +42,10 @@ module Elasticsearch
       def search_template(arguments = {})
         raise ArgumentError, "Required argument 'body' missing" unless arguments[:body]
 
+        arguments = arguments.clone
         headers = arguments.delete(:headers) || {}
 
-        body = arguments.delete(:body)
-
-        arguments = arguments.clone
+        body   = arguments.delete(:body)
 
         _index = arguments.delete(:index)
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/searchable_snapshots/cache_stats.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/searchable_snapshots/cache_stats.rb
@@ -31,11 +31,10 @@ module Elasticsearch
         # @see https://www.elastic.co/guide/en/elasticsearch/reference/master/searchable-snapshots-apis.html
         #
         def cache_stats(arguments = {})
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
           body = nil
-
-          arguments = arguments.clone
 
           _node_id = arguments.delete(:node_id)
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/searchable_snapshots/clear_cache.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/searchable_snapshots/clear_cache.rb
@@ -34,11 +34,10 @@ module Elasticsearch
         # @see https://www.elastic.co/guide/en/elasticsearch/reference/master/searchable-snapshots-apis.html
         #
         def clear_cache(arguments = {})
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
-          body = nil
-
-          arguments = arguments.clone
+          body   = nil
 
           _index = arguments.delete(:index)
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/searchable_snapshots/mount.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/searchable_snapshots/mount.rb
@@ -36,11 +36,10 @@ module Elasticsearch
           raise ArgumentError, "Required argument 'repository' missing" unless arguments[:repository]
           raise ArgumentError, "Required argument 'snapshot' missing" unless arguments[:snapshot]
 
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
           body = arguments.delete(:body)
-
-          arguments = arguments.clone
 
           _repository = arguments.delete(:repository)
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/searchable_snapshots/stats.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/searchable_snapshots/stats.rb
@@ -28,11 +28,10 @@ module Elasticsearch
         # @see https://www.elastic.co/guide/en/elasticsearch/reference/master/searchable-snapshots-apis.html
         #
         def stats(arguments = {})
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
-          body = nil
-
-          arguments = arguments.clone
+          body   = nil
 
           _index = arguments.delete(:index)
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/security/activate_user_profile.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/security/activate_user_profile.rb
@@ -33,11 +33,10 @@ module Elasticsearch
         def activate_user_profile(arguments = {})
           raise ArgumentError, "Required argument 'body' missing" unless arguments[:body]
 
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
-          body = arguments.delete(:body)
-
-          arguments = arguments.clone
+          body   = arguments.delete(:body)
 
           method = Elasticsearch::API::HTTP_POST
           path   = "_security/profile/_activate"

--- a/elasticsearch-api/lib/elasticsearch/api/actions/security/authenticate.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/security/authenticate.rb
@@ -26,11 +26,10 @@ module Elasticsearch
         # @see https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-authenticate.html
         #
         def authenticate(arguments = {})
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
-          body = nil
-
-          arguments = arguments.clone
+          body   = nil
 
           method = Elasticsearch::API::HTTP_GET
           path   = "_security/_authenticate"

--- a/elasticsearch-api/lib/elasticsearch/api/actions/security/change_password.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/security/change_password.rb
@@ -31,11 +31,10 @@ module Elasticsearch
         def change_password(arguments = {})
           raise ArgumentError, "Required argument 'body' missing" unless arguments[:body]
 
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
           body = arguments.delete(:body)
-
-          arguments = arguments.clone
 
           _username = arguments.delete(:username)
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/security/clear_api_key_cache.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/security/clear_api_key_cache.rb
@@ -29,11 +29,10 @@ module Elasticsearch
         def clear_api_key_cache(arguments = {})
           raise ArgumentError, "Required argument 'ids' missing" unless arguments[:ids]
 
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
-          body = nil
-
-          arguments = arguments.clone
+          body   = nil
 
           _ids = arguments.delete(:ids)
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/security/clear_cached_privileges.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/security/clear_cached_privileges.rb
@@ -29,11 +29,10 @@ module Elasticsearch
         def clear_cached_privileges(arguments = {})
           raise ArgumentError, "Required argument 'application' missing" unless arguments[:application]
 
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
           body = nil
-
-          arguments = arguments.clone
 
           _application = arguments.delete(:application)
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/security/clear_cached_realms.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/security/clear_cached_realms.rb
@@ -30,11 +30,10 @@ module Elasticsearch
         def clear_cached_realms(arguments = {})
           raise ArgumentError, "Required argument 'realms' missing" unless arguments[:realms]
 
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
           body = nil
-
-          arguments = arguments.clone
 
           _realms = arguments.delete(:realms)
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/security/clear_cached_roles.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/security/clear_cached_roles.rb
@@ -29,11 +29,10 @@ module Elasticsearch
         def clear_cached_roles(arguments = {})
           raise ArgumentError, "Required argument 'name' missing" unless arguments[:name]
 
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
           body = nil
-
-          arguments = arguments.clone
 
           _name = arguments.delete(:name)
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/security/clear_cached_service_tokens.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/security/clear_cached_service_tokens.rb
@@ -33,11 +33,10 @@ module Elasticsearch
           raise ArgumentError, "Required argument 'service' missing" unless arguments[:service]
           raise ArgumentError, "Required argument 'name' missing" unless arguments[:name]
 
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
           body = nil
-
-          arguments = arguments.clone
 
           _namespace = arguments.delete(:namespace)
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/security/create_api_key.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/security/create_api_key.rb
@@ -30,11 +30,10 @@ module Elasticsearch
         def create_api_key(arguments = {})
           raise ArgumentError, "Required argument 'body' missing" unless arguments[:body]
 
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
-          body = arguments.delete(:body)
-
-          arguments = arguments.clone
+          body   = arguments.delete(:body)
 
           method = Elasticsearch::API::HTTP_PUT
           path   = "_security/api_key"

--- a/elasticsearch-api/lib/elasticsearch/api/actions/security/create_service_token.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/security/create_service_token.rb
@@ -33,11 +33,10 @@ module Elasticsearch
           raise ArgumentError, "Required argument 'namespace' missing" unless arguments[:namespace]
           raise ArgumentError, "Required argument 'service' missing" unless arguments[:service]
 
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
           body = nil
-
-          arguments = arguments.clone
 
           _namespace = arguments.delete(:namespace)
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/security/delete_privileges.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/security/delete_privileges.rb
@@ -32,11 +32,10 @@ module Elasticsearch
           raise ArgumentError, "Required argument 'application' missing" unless arguments[:application]
           raise ArgumentError, "Required argument 'name' missing" unless arguments[:name]
 
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
           body = nil
-
-          arguments = arguments.clone
 
           _application = arguments.delete(:application)
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/security/delete_role.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/security/delete_role.rb
@@ -30,11 +30,10 @@ module Elasticsearch
         def delete_role(arguments = {})
           raise ArgumentError, "Required argument 'name' missing" unless arguments[:name]
 
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
           body = nil
-
-          arguments = arguments.clone
 
           _name = arguments.delete(:name)
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/security/delete_role_mapping.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/security/delete_role_mapping.rb
@@ -30,11 +30,10 @@ module Elasticsearch
         def delete_role_mapping(arguments = {})
           raise ArgumentError, "Required argument 'name' missing" unless arguments[:name]
 
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
           body = nil
-
-          arguments = arguments.clone
 
           _name = arguments.delete(:name)
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/security/delete_service_token.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/security/delete_service_token.rb
@@ -34,11 +34,10 @@ module Elasticsearch
           raise ArgumentError, "Required argument 'service' missing" unless arguments[:service]
           raise ArgumentError, "Required argument 'name' missing" unless arguments[:name]
 
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
           body = nil
-
-          arguments = arguments.clone
 
           _namespace = arguments.delete(:namespace)
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/security/delete_user.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/security/delete_user.rb
@@ -30,11 +30,10 @@ module Elasticsearch
         def delete_user(arguments = {})
           raise ArgumentError, "Required argument 'username' missing" unless arguments[:username]
 
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
           body = nil
-
-          arguments = arguments.clone
 
           _username = arguments.delete(:username)
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/security/disable_user.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/security/disable_user.rb
@@ -30,11 +30,10 @@ module Elasticsearch
         def disable_user(arguments = {})
           raise ArgumentError, "Required argument 'username' missing" unless arguments[:username]
 
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
           body = nil
-
-          arguments = arguments.clone
 
           _username = arguments.delete(:username)
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/security/enable_user.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/security/enable_user.rb
@@ -30,11 +30,10 @@ module Elasticsearch
         def enable_user(arguments = {})
           raise ArgumentError, "Required argument 'username' missing" unless arguments[:username]
 
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
           body = nil
-
-          arguments = arguments.clone
 
           _username = arguments.delete(:username)
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/security/enroll_kibana.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/security/enroll_kibana.rb
@@ -26,11 +26,10 @@ module Elasticsearch
         # @see https://www.elastic.co/guide/en/elasticsearch/reference/master/security-api-kibana-enrollment.html
         #
         def enroll_kibana(arguments = {})
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
-          body = nil
-
-          arguments = arguments.clone
+          body   = nil
 
           method = Elasticsearch::API::HTTP_GET
           path   = "_security/enroll/kibana"

--- a/elasticsearch-api/lib/elasticsearch/api/actions/security/enroll_node.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/security/enroll_node.rb
@@ -26,11 +26,10 @@ module Elasticsearch
         # @see https://www.elastic.co/guide/en/elasticsearch/reference/master/security-api-node-enrollment.html
         #
         def enroll_node(arguments = {})
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
-          body = nil
-
-          arguments = arguments.clone
+          body   = nil
 
           method = Elasticsearch::API::HTTP_GET
           path   = "_security/enroll/node"

--- a/elasticsearch-api/lib/elasticsearch/api/actions/security/get_api_key.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/security/get_api_key.rb
@@ -31,11 +31,10 @@ module Elasticsearch
         # @see https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-get-api-key.html
         #
         def get_api_key(arguments = {})
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
-          body = nil
-
-          arguments = arguments.clone
+          body   = nil
 
           method = Elasticsearch::API::HTTP_GET
           path   = "_security/api_key"

--- a/elasticsearch-api/lib/elasticsearch/api/actions/security/get_builtin_privileges.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/security/get_builtin_privileges.rb
@@ -26,11 +26,10 @@ module Elasticsearch
         # @see https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-get-builtin-privileges.html
         #
         def get_builtin_privileges(arguments = {})
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
-          body = nil
-
-          arguments = arguments.clone
+          body   = nil
 
           method = Elasticsearch::API::HTTP_GET
           path   = "_security/privilege/_builtin"

--- a/elasticsearch-api/lib/elasticsearch/api/actions/security/get_privileges.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/security/get_privileges.rb
@@ -28,11 +28,10 @@ module Elasticsearch
         # @see https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-get-privileges.html
         #
         def get_privileges(arguments = {})
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
           body = nil
-
-          arguments = arguments.clone
 
           _application = arguments.delete(:application)
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/security/get_role.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/security/get_role.rb
@@ -27,11 +27,10 @@ module Elasticsearch
         # @see https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-get-role.html
         #
         def get_role(arguments = {})
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
           body = nil
-
-          arguments = arguments.clone
 
           _name = arguments.delete(:name)
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/security/get_role_mapping.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/security/get_role_mapping.rb
@@ -27,11 +27,10 @@ module Elasticsearch
         # @see https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-get-role-mapping.html
         #
         def get_role_mapping(arguments = {})
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
           body = nil
-
-          arguments = arguments.clone
 
           _name = arguments.delete(:name)
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/security/get_service_accounts.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/security/get_service_accounts.rb
@@ -28,11 +28,10 @@ module Elasticsearch
         # @see https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-get-service-accounts.html
         #
         def get_service_accounts(arguments = {})
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
           body = nil
-
-          arguments = arguments.clone
 
           _namespace = arguments.delete(:namespace)
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/security/get_service_credentials.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/security/get_service_credentials.rb
@@ -31,11 +31,10 @@ module Elasticsearch
           raise ArgumentError, "Required argument 'namespace' missing" unless arguments[:namespace]
           raise ArgumentError, "Required argument 'service' missing" unless arguments[:service]
 
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
           body = nil
-
-          arguments = arguments.clone
 
           _namespace = arguments.delete(:namespace)
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/security/get_token.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/security/get_token.rb
@@ -29,11 +29,10 @@ module Elasticsearch
         def get_token(arguments = {})
           raise ArgumentError, "Required argument 'body' missing" unless arguments[:body]
 
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
-          body = arguments.delete(:body)
-
-          arguments = arguments.clone
+          body   = arguments.delete(:body)
 
           method = Elasticsearch::API::HTTP_POST
           path   = "_security/oauth2/token"

--- a/elasticsearch-api/lib/elasticsearch/api/actions/security/get_user.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/security/get_user.rb
@@ -27,11 +27,10 @@ module Elasticsearch
         # @see https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-get-user.html
         #
         def get_user(arguments = {})
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
           body = nil
-
-          arguments = arguments.clone
 
           _username = arguments.delete(:username)
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/security/get_user_privileges.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/security/get_user_privileges.rb
@@ -26,11 +26,10 @@ module Elasticsearch
         # @see https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-get-user-privileges.html
         #
         def get_user_privileges(arguments = {})
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
-          body = nil
-
-          arguments = arguments.clone
+          body   = nil
 
           method = Elasticsearch::API::HTTP_GET
           path   = "_security/user/_privileges"

--- a/elasticsearch-api/lib/elasticsearch/api/actions/security/get_user_profile.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/security/get_user_profile.rb
@@ -34,11 +34,10 @@ module Elasticsearch
         def get_user_profile(arguments = {})
           raise ArgumentError, "Required argument 'uid' missing" unless arguments[:uid]
 
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
-          body = nil
-
-          arguments = arguments.clone
+          body   = nil
 
           _uid = arguments.delete(:uid)
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/security/grant_api_key.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/security/grant_api_key.rb
@@ -30,11 +30,10 @@ module Elasticsearch
         def grant_api_key(arguments = {})
           raise ArgumentError, "Required argument 'body' missing" unless arguments[:body]
 
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
-          body = arguments.delete(:body)
-
-          arguments = arguments.clone
+          body   = arguments.delete(:body)
 
           method = Elasticsearch::API::HTTP_POST
           path   = "_security/api_key/grant"

--- a/elasticsearch-api/lib/elasticsearch/api/actions/security/has_privileges.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/security/has_privileges.rb
@@ -30,11 +30,10 @@ module Elasticsearch
         def has_privileges(arguments = {})
           raise ArgumentError, "Required argument 'body' missing" unless arguments[:body]
 
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
           body = arguments.delete(:body)
-
-          arguments = arguments.clone
 
           _user = arguments.delete(:user)
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/security/invalidate_api_key.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/security/invalidate_api_key.rb
@@ -29,11 +29,10 @@ module Elasticsearch
         def invalidate_api_key(arguments = {})
           raise ArgumentError, "Required argument 'body' missing" unless arguments[:body]
 
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
-          body = arguments.delete(:body)
-
-          arguments = arguments.clone
+          body   = arguments.delete(:body)
 
           method = Elasticsearch::API::HTTP_DELETE
           path   = "_security/api_key"

--- a/elasticsearch-api/lib/elasticsearch/api/actions/security/invalidate_token.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/security/invalidate_token.rb
@@ -29,11 +29,10 @@ module Elasticsearch
         def invalidate_token(arguments = {})
           raise ArgumentError, "Required argument 'body' missing" unless arguments[:body]
 
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
-          body = arguments.delete(:body)
-
-          arguments = arguments.clone
+          body   = arguments.delete(:body)
 
           method = Elasticsearch::API::HTTP_DELETE
           path   = "_security/oauth2/token"

--- a/elasticsearch-api/lib/elasticsearch/api/actions/security/oidc_authenticate.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/security/oidc_authenticate.rb
@@ -29,11 +29,10 @@ module Elasticsearch
         def oidc_authenticate(arguments = {})
           raise ArgumentError, "Required argument 'body' missing" unless arguments[:body]
 
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
-          body = arguments.delete(:body)
-
-          arguments = arguments.clone
+          body   = arguments.delete(:body)
 
           method = Elasticsearch::API::HTTP_POST
           path   = "_security/oidc/authenticate"

--- a/elasticsearch-api/lib/elasticsearch/api/actions/security/oidc_logout.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/security/oidc_logout.rb
@@ -29,11 +29,10 @@ module Elasticsearch
         def oidc_logout(arguments = {})
           raise ArgumentError, "Required argument 'body' missing" unless arguments[:body]
 
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
-          body = arguments.delete(:body)
-
-          arguments = arguments.clone
+          body   = arguments.delete(:body)
 
           method = Elasticsearch::API::HTTP_POST
           path   = "_security/oidc/logout"

--- a/elasticsearch-api/lib/elasticsearch/api/actions/security/oidc_prepare_authentication.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/security/oidc_prepare_authentication.rb
@@ -29,11 +29,10 @@ module Elasticsearch
         def oidc_prepare_authentication(arguments = {})
           raise ArgumentError, "Required argument 'body' missing" unless arguments[:body]
 
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
-          body = arguments.delete(:body)
-
-          arguments = arguments.clone
+          body   = arguments.delete(:body)
 
           method = Elasticsearch::API::HTTP_POST
           path   = "_security/oidc/prepare"

--- a/elasticsearch-api/lib/elasticsearch/api/actions/security/put_privileges.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/security/put_privileges.rb
@@ -30,11 +30,10 @@ module Elasticsearch
         def put_privileges(arguments = {})
           raise ArgumentError, "Required argument 'body' missing" unless arguments[:body]
 
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
-          body = arguments.delete(:body)
-
-          arguments = arguments.clone
+          body   = arguments.delete(:body)
 
           method = Elasticsearch::API::HTTP_PUT
           path   = "_security/privilege"

--- a/elasticsearch-api/lib/elasticsearch/api/actions/security/put_role.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/security/put_role.rb
@@ -32,11 +32,10 @@ module Elasticsearch
           raise ArgumentError, "Required argument 'body' missing" unless arguments[:body]
           raise ArgumentError, "Required argument 'name' missing" unless arguments[:name]
 
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
           body = arguments.delete(:body)
-
-          arguments = arguments.clone
 
           _name = arguments.delete(:name)
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/security/put_role_mapping.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/security/put_role_mapping.rb
@@ -32,11 +32,10 @@ module Elasticsearch
           raise ArgumentError, "Required argument 'body' missing" unless arguments[:body]
           raise ArgumentError, "Required argument 'name' missing" unless arguments[:name]
 
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
           body = arguments.delete(:body)
-
-          arguments = arguments.clone
 
           _name = arguments.delete(:name)
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/security/put_user.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/security/put_user.rb
@@ -32,11 +32,10 @@ module Elasticsearch
           raise ArgumentError, "Required argument 'body' missing" unless arguments[:body]
           raise ArgumentError, "Required argument 'username' missing" unless arguments[:username]
 
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
           body = arguments.delete(:body)
-
-          arguments = arguments.clone
 
           _username = arguments.delete(:username)
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/security/query_api_keys.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/security/query_api_keys.rb
@@ -27,11 +27,10 @@ module Elasticsearch
         # @see https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-query-api-key.html
         #
         def query_api_keys(arguments = {})
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
-          body = arguments.delete(:body)
-
-          arguments = arguments.clone
+          body   = arguments.delete(:body)
 
           method = if body
                      Elasticsearch::API::HTTP_POST

--- a/elasticsearch-api/lib/elasticsearch/api/actions/security/saml_authenticate.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/security/saml_authenticate.rb
@@ -29,11 +29,10 @@ module Elasticsearch
         def saml_authenticate(arguments = {})
           raise ArgumentError, "Required argument 'body' missing" unless arguments[:body]
 
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
-          body = arguments.delete(:body)
-
-          arguments = arguments.clone
+          body   = arguments.delete(:body)
 
           method = Elasticsearch::API::HTTP_POST
           path   = "_security/saml/authenticate"

--- a/elasticsearch-api/lib/elasticsearch/api/actions/security/saml_complete_logout.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/security/saml_complete_logout.rb
@@ -29,11 +29,10 @@ module Elasticsearch
         def saml_complete_logout(arguments = {})
           raise ArgumentError, "Required argument 'body' missing" unless arguments[:body]
 
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
-          body = arguments.delete(:body)
-
-          arguments = arguments.clone
+          body   = arguments.delete(:body)
 
           method = Elasticsearch::API::HTTP_POST
           path   = "_security/saml/complete_logout"

--- a/elasticsearch-api/lib/elasticsearch/api/actions/security/saml_invalidate.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/security/saml_invalidate.rb
@@ -29,11 +29,10 @@ module Elasticsearch
         def saml_invalidate(arguments = {})
           raise ArgumentError, "Required argument 'body' missing" unless arguments[:body]
 
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
-          body = arguments.delete(:body)
-
-          arguments = arguments.clone
+          body   = arguments.delete(:body)
 
           method = Elasticsearch::API::HTTP_POST
           path   = "_security/saml/invalidate"

--- a/elasticsearch-api/lib/elasticsearch/api/actions/security/saml_logout.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/security/saml_logout.rb
@@ -29,11 +29,10 @@ module Elasticsearch
         def saml_logout(arguments = {})
           raise ArgumentError, "Required argument 'body' missing" unless arguments[:body]
 
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
-          body = arguments.delete(:body)
-
-          arguments = arguments.clone
+          body   = arguments.delete(:body)
 
           method = Elasticsearch::API::HTTP_POST
           path   = "_security/saml/logout"

--- a/elasticsearch-api/lib/elasticsearch/api/actions/security/saml_prepare_authentication.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/security/saml_prepare_authentication.rb
@@ -29,11 +29,10 @@ module Elasticsearch
         def saml_prepare_authentication(arguments = {})
           raise ArgumentError, "Required argument 'body' missing" unless arguments[:body]
 
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
-          body = arguments.delete(:body)
-
-          arguments = arguments.clone
+          body   = arguments.delete(:body)
 
           method = Elasticsearch::API::HTTP_POST
           path   = "_security/saml/prepare"

--- a/elasticsearch-api/lib/elasticsearch/api/actions/security/saml_service_provider_metadata.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/security/saml_service_provider_metadata.rb
@@ -29,11 +29,10 @@ module Elasticsearch
         def saml_service_provider_metadata(arguments = {})
           raise ArgumentError, "Required argument 'realm_name' missing" unless arguments[:realm_name]
 
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
           body = nil
-
-          arguments = arguments.clone
 
           _realm_name = arguments.delete(:realm_name)
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/security/update_user_profile_data.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/security/update_user_profile_data.rb
@@ -45,8 +45,8 @@ module Elasticsearch
 
           _uid = arguments.delete(:uid)
 
-          method = Elasticsearch::API::HTTP_POST
-          path   = "_security/profile/_data/#{Utils.__listify(_uid)}"
+          method = Elasticsearch::API::HTTP_PUT
+          path   = "_security/profile/#{Utils.__listify(_uid)}/_data"
           params = Utils.process_params(arguments)
 
           Elasticsearch::API::Response.new(

--- a/elasticsearch-api/lib/elasticsearch/api/actions/security/update_user_profile_data.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/security/update_user_profile_data.rb
@@ -38,11 +38,10 @@ module Elasticsearch
           raise ArgumentError, "Required argument 'body' missing" unless arguments[:body]
           raise ArgumentError, "Required argument 'uid' missing" unless arguments[:uid]
 
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
-          body = arguments.delete(:body)
-
-          arguments = arguments.clone
+          body   = arguments.delete(:body)
 
           _uid = arguments.delete(:uid)
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/shutdown/delete_node.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/shutdown/delete_node.rb
@@ -29,11 +29,10 @@ module Elasticsearch
         def delete_node(arguments = {})
           raise ArgumentError, "Required argument 'node_id' missing" unless arguments[:node_id]
 
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
           body = nil
-
-          arguments = arguments.clone
 
           _node_id = arguments.delete(:node_id)
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/shutdown/get_node.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/shutdown/get_node.rb
@@ -27,11 +27,10 @@ module Elasticsearch
         # @see https://www.elastic.co/guide/en/elasticsearch/reference/current
         #
         def get_node(arguments = {})
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
           body = nil
-
-          arguments = arguments.clone
 
           _node_id = arguments.delete(:node_id)
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/shutdown/put_node.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/shutdown/put_node.rb
@@ -31,11 +31,10 @@ module Elasticsearch
           raise ArgumentError, "Required argument 'body' missing" unless arguments[:body]
           raise ArgumentError, "Required argument 'node_id' missing" unless arguments[:node_id]
 
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
           body = arguments.delete(:body)
-
-          arguments = arguments.clone
 
           _node_id = arguments.delete(:node_id)
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/snapshot/cleanup_repository.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/snapshot/cleanup_repository.rb
@@ -31,11 +31,10 @@ module Elasticsearch
         def cleanup_repository(arguments = {})
           raise ArgumentError, "Required argument 'repository' missing" unless arguments[:repository]
 
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
           body = nil
-
-          arguments = arguments.clone
 
           _repository = arguments.delete(:repository)
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/snapshot/clone.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/snapshot/clone.rb
@@ -36,11 +36,10 @@ module Elasticsearch
           raise ArgumentError, "Required argument 'snapshot' missing" unless arguments[:snapshot]
           raise ArgumentError, "Required argument 'target_snapshot' missing" unless arguments[:target_snapshot]
 
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
           body = arguments.delete(:body)
-
-          arguments = arguments.clone
 
           _repository = arguments.delete(:repository)
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/snapshot/create.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/snapshot/create.rb
@@ -34,11 +34,10 @@ module Elasticsearch
           raise ArgumentError, "Required argument 'repository' missing" unless arguments[:repository]
           raise ArgumentError, "Required argument 'snapshot' missing" unless arguments[:snapshot]
 
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
           body = arguments.delete(:body)
-
-          arguments = arguments.clone
 
           _repository = arguments.delete(:repository)
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/snapshot/create_repository.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/snapshot/create_repository.rb
@@ -34,11 +34,10 @@ module Elasticsearch
           raise ArgumentError, "Required argument 'body' missing" unless arguments[:body]
           raise ArgumentError, "Required argument 'repository' missing" unless arguments[:repository]
 
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
           body = arguments.delete(:body)
-
-          arguments = arguments.clone
 
           _repository = arguments.delete(:repository)
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/snapshot/delete.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/snapshot/delete.rb
@@ -32,11 +32,10 @@ module Elasticsearch
           raise ArgumentError, "Required argument 'repository' missing" unless arguments[:repository]
           raise ArgumentError, "Required argument 'snapshot' missing" unless arguments[:snapshot]
 
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
           body = nil
-
-          arguments = arguments.clone
 
           _repository = arguments.delete(:repository)
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/snapshot/delete_repository.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/snapshot/delete_repository.rb
@@ -31,11 +31,10 @@ module Elasticsearch
         def delete_repository(arguments = {})
           raise ArgumentError, "Required argument 'repository' missing" unless arguments[:repository]
 
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
           body = nil
-
-          arguments = arguments.clone
 
           _repository = arguments.delete(:repository)
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/snapshot/get.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/snapshot/get.rb
@@ -36,11 +36,10 @@ module Elasticsearch
           raise ArgumentError, "Required argument 'repository' missing" unless arguments[:repository]
           raise ArgumentError, "Required argument 'snapshot' missing" unless arguments[:snapshot]
 
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
           body = nil
-
-          arguments = arguments.clone
 
           _repository = arguments.delete(:repository)
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/snapshot/get_repository.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/snapshot/get_repository.rb
@@ -29,11 +29,10 @@ module Elasticsearch
         # @see https://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html
         #
         def get_repository(arguments = {})
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
           body = nil
-
-          arguments = arguments.clone
 
           _repository = arguments.delete(:repository)
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/snapshot/repository_analyze.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/snapshot/repository_analyze.rb
@@ -40,11 +40,10 @@ module Elasticsearch
         def repository_analyze(arguments = {})
           raise ArgumentError, "Required argument 'repository' missing" unless arguments[:repository]
 
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
           body = nil
-
-          arguments = arguments.clone
 
           _repository = arguments.delete(:repository)
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/snapshot/restore.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/snapshot/restore.rb
@@ -34,11 +34,10 @@ module Elasticsearch
           raise ArgumentError, "Required argument 'repository' missing" unless arguments[:repository]
           raise ArgumentError, "Required argument 'snapshot' missing" unless arguments[:snapshot]
 
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
           body = arguments.delete(:body)
-
-          arguments = arguments.clone
 
           _repository = arguments.delete(:repository)
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/snapshot/status.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/snapshot/status.rb
@@ -30,11 +30,10 @@ module Elasticsearch
         # @see https://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html
         #
         def status(arguments = {})
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
           body = nil
-
-          arguments = arguments.clone
 
           _repository = arguments.delete(:repository)
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/snapshot/verify_repository.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/snapshot/verify_repository.rb
@@ -31,11 +31,10 @@ module Elasticsearch
         def verify_repository(arguments = {})
           raise ArgumentError, "Required argument 'repository' missing" unless arguments[:repository]
 
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
           body = nil
-
-          arguments = arguments.clone
 
           _repository = arguments.delete(:repository)
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/snapshot_lifecycle_management/delete_lifecycle.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/snapshot_lifecycle_management/delete_lifecycle.rb
@@ -29,11 +29,10 @@ module Elasticsearch
         def delete_lifecycle(arguments = {})
           raise ArgumentError, "Required argument 'policy_id' missing" unless arguments[:policy_id]
 
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
           body = nil
-
-          arguments = arguments.clone
 
           _policy_id = arguments.delete(:policy_id)
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/snapshot_lifecycle_management/execute_lifecycle.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/snapshot_lifecycle_management/execute_lifecycle.rb
@@ -29,11 +29,10 @@ module Elasticsearch
         def execute_lifecycle(arguments = {})
           raise ArgumentError, "Required argument 'policy_id' missing" unless arguments[:policy_id]
 
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
           body = nil
-
-          arguments = arguments.clone
 
           _policy_id = arguments.delete(:policy_id)
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/snapshot_lifecycle_management/execute_retention.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/snapshot_lifecycle_management/execute_retention.rb
@@ -26,11 +26,10 @@ module Elasticsearch
         # @see https://www.elastic.co/guide/en/elasticsearch/reference/current/slm-api-execute-retention.html
         #
         def execute_retention(arguments = {})
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
-          body = nil
-
-          arguments = arguments.clone
+          body   = nil
 
           method = Elasticsearch::API::HTTP_POST
           path   = "_slm/_execute_retention"

--- a/elasticsearch-api/lib/elasticsearch/api/actions/snapshot_lifecycle_management/get_lifecycle.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/snapshot_lifecycle_management/get_lifecycle.rb
@@ -27,11 +27,10 @@ module Elasticsearch
         # @see https://www.elastic.co/guide/en/elasticsearch/reference/current/slm-api-get-policy.html
         #
         def get_lifecycle(arguments = {})
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
           body = nil
-
-          arguments = arguments.clone
 
           _policy_id = arguments.delete(:policy_id)
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/snapshot_lifecycle_management/get_stats.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/snapshot_lifecycle_management/get_stats.rb
@@ -26,11 +26,10 @@ module Elasticsearch
         # @see https://www.elastic.co/guide/en/elasticsearch/reference/master/slm-api-get-stats.html
         #
         def get_stats(arguments = {})
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
-          body = nil
-
-          arguments = arguments.clone
+          body   = nil
 
           method = Elasticsearch::API::HTTP_GET
           path   = "_slm/stats"

--- a/elasticsearch-api/lib/elasticsearch/api/actions/snapshot_lifecycle_management/get_status.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/snapshot_lifecycle_management/get_status.rb
@@ -26,11 +26,10 @@ module Elasticsearch
         # @see https://www.elastic.co/guide/en/elasticsearch/reference/current/slm-api-get-status.html
         #
         def get_status(arguments = {})
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
-          body = nil
-
-          arguments = arguments.clone
+          body   = nil
 
           method = Elasticsearch::API::HTTP_GET
           path   = "_slm/status"

--- a/elasticsearch-api/lib/elasticsearch/api/actions/snapshot_lifecycle_management/put_lifecycle.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/snapshot_lifecycle_management/put_lifecycle.rb
@@ -30,11 +30,10 @@ module Elasticsearch
         def put_lifecycle(arguments = {})
           raise ArgumentError, "Required argument 'policy_id' missing" unless arguments[:policy_id]
 
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
           body = arguments.delete(:body)
-
-          arguments = arguments.clone
 
           _policy_id = arguments.delete(:policy_id)
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/snapshot_lifecycle_management/start.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/snapshot_lifecycle_management/start.rb
@@ -26,11 +26,10 @@ module Elasticsearch
         # @see https://www.elastic.co/guide/en/elasticsearch/reference/current/slm-api-start.html
         #
         def start(arguments = {})
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
-          body = nil
-
-          arguments = arguments.clone
+          body   = nil
 
           method = Elasticsearch::API::HTTP_POST
           path   = "_slm/start"

--- a/elasticsearch-api/lib/elasticsearch/api/actions/snapshot_lifecycle_management/stop.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/snapshot_lifecycle_management/stop.rb
@@ -26,11 +26,10 @@ module Elasticsearch
         # @see https://www.elastic.co/guide/en/elasticsearch/reference/current/slm-api-stop.html
         #
         def stop(arguments = {})
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
-          body = nil
-
-          arguments = arguments.clone
+          body   = nil
 
           method = Elasticsearch::API::HTTP_POST
           path   = "_slm/stop"

--- a/elasticsearch-api/lib/elasticsearch/api/actions/sql/clear_cursor.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/sql/clear_cursor.rb
@@ -29,11 +29,10 @@ module Elasticsearch
         def clear_cursor(arguments = {})
           raise ArgumentError, "Required argument 'body' missing" unless arguments[:body]
 
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
-          body = arguments.delete(:body)
-
-          arguments = arguments.clone
+          body   = arguments.delete(:body)
 
           method = Elasticsearch::API::HTTP_POST
           path   = "_sql/close"

--- a/elasticsearch-api/lib/elasticsearch/api/actions/sql/delete_async.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/sql/delete_async.rb
@@ -29,11 +29,10 @@ module Elasticsearch
         def delete_async(arguments = {})
           raise ArgumentError, "Required argument 'id' missing" unless arguments[:id]
 
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
           body = nil
-
-          arguments = arguments.clone
 
           _id = arguments.delete(:id)
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/sql/get_async.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/sql/get_async.rb
@@ -33,11 +33,10 @@ module Elasticsearch
         def get_async(arguments = {})
           raise ArgumentError, "Required argument 'id' missing" unless arguments[:id]
 
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
           body = nil
-
-          arguments = arguments.clone
 
           _id = arguments.delete(:id)
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/sql/get_async_status.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/sql/get_async_status.rb
@@ -29,11 +29,10 @@ module Elasticsearch
         def get_async_status(arguments = {})
           raise ArgumentError, "Required argument 'id' missing" unless arguments[:id]
 
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
           body = nil
-
-          arguments = arguments.clone
 
           _id = arguments.delete(:id)
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/sql/query.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/sql/query.rb
@@ -30,11 +30,10 @@ module Elasticsearch
         def query(arguments = {})
           raise ArgumentError, "Required argument 'body' missing" unless arguments[:body]
 
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
-          body = arguments.delete(:body)
-
-          arguments = arguments.clone
+          body   = arguments.delete(:body)
 
           method = Elasticsearch::API::HTTP_POST
           path   = "_sql"

--- a/elasticsearch-api/lib/elasticsearch/api/actions/sql/translate.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/sql/translate.rb
@@ -29,11 +29,10 @@ module Elasticsearch
         def translate(arguments = {})
           raise ArgumentError, "Required argument 'body' missing" unless arguments[:body]
 
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
-          body = arguments.delete(:body)
-
-          arguments = arguments.clone
+          body   = arguments.delete(:body)
 
           method = Elasticsearch::API::HTTP_POST
           path   = "_sql/translate"

--- a/elasticsearch-api/lib/elasticsearch/api/actions/ssl/certificates.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/ssl/certificates.rb
@@ -26,11 +26,10 @@ module Elasticsearch
         # @see https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-ssl.html
         #
         def certificates(arguments = {})
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
-          body = nil
-
-          arguments = arguments.clone
+          body   = nil
 
           method = Elasticsearch::API::HTTP_GET
           path   = "_ssl/certificates"

--- a/elasticsearch-api/lib/elasticsearch/api/actions/tasks/cancel.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/tasks/cancel.rb
@@ -35,11 +35,10 @@ module Elasticsearch
         # @see https://www.elastic.co/guide/en/elasticsearch/reference/master/tasks.html
         #
         def cancel(arguments = {})
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
           body = nil
-
-          arguments = arguments.clone
 
           _task_id = arguments.delete(:task_id)
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/tasks/get.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/tasks/get.rb
@@ -33,11 +33,10 @@ module Elasticsearch
         # @see https://www.elastic.co/guide/en/elasticsearch/reference/master/tasks.html
         #
         def get(arguments = {})
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
           body = nil
-
-          arguments = arguments.clone
 
           _task_id = arguments.delete(:task_id)
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/tasks/list.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/tasks/list.rb
@@ -37,11 +37,10 @@ module Elasticsearch
         # @see https://www.elastic.co/guide/en/elasticsearch/reference/master/tasks.html
         #
         def list(arguments = {})
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
-          body = nil
-
-          arguments = arguments.clone
+          body   = nil
 
           method = Elasticsearch::API::HTTP_GET
           path   = "_tasks"

--- a/elasticsearch-api/lib/elasticsearch/api/actions/terms_enum.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/terms_enum.rb
@@ -29,11 +29,10 @@ module Elasticsearch
       def terms_enum(arguments = {})
         raise ArgumentError, "Required argument 'index' missing" unless arguments[:index]
 
+        arguments = arguments.clone
         headers = arguments.delete(:headers) || {}
 
-        body = arguments.delete(:body)
-
-        arguments = arguments.clone
+        body   = arguments.delete(:body)
 
         _index = arguments.delete(:index)
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/termvectors.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/termvectors.rb
@@ -41,11 +41,10 @@ module Elasticsearch
       def termvectors(arguments = {})
         raise ArgumentError, "Required argument 'index' missing" unless arguments[:index]
 
+        arguments = arguments.clone
         headers = arguments.delete(:headers) || {}
 
-        body = arguments.delete(:body)
-
-        arguments = arguments.clone
+        body   = arguments.delete(:body)
 
         _index = arguments.delete(:index)
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/text_structure/find_structure.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/text_structure/find_structure.rb
@@ -43,11 +43,10 @@ module Elasticsearch
         def find_structure(arguments = {})
           raise ArgumentError, "Required argument 'body' missing" unless arguments[:body]
 
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
-          body = arguments.delete(:body)
-
-          arguments = arguments.clone
+          body   = arguments.delete(:body)
 
           method = Elasticsearch::API::HTTP_POST
           path   = "_text_structure/find_structure"

--- a/elasticsearch-api/lib/elasticsearch/api/actions/transform/delete_transform.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/transform/delete_transform.rb
@@ -31,11 +31,10 @@ module Elasticsearch
         def delete_transform(arguments = {})
           raise ArgumentError, "Required argument 'transform_id' missing" unless arguments[:transform_id]
 
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
           body = nil
-
-          arguments = arguments.clone
 
           _transform_id = arguments.delete(:transform_id)
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/transform/get_transform.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/transform/get_transform.rb
@@ -31,11 +31,10 @@ module Elasticsearch
         # @see https://www.elastic.co/guide/en/elasticsearch/reference/current/get-transform.html
         #
         def get_transform(arguments = {})
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
           body = nil
-
-          arguments = arguments.clone
 
           _transform_id = arguments.delete(:transform_id)
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/transform/get_transform_stats.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/transform/get_transform_stats.rb
@@ -32,11 +32,10 @@ module Elasticsearch
         def get_transform_stats(arguments = {})
           raise ArgumentError, "Required argument 'transform_id' missing" unless arguments[:transform_id]
 
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
           body = nil
-
-          arguments = arguments.clone
 
           _transform_id = arguments.delete(:transform_id)
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/transform/preview_transform.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/transform/preview_transform.rb
@@ -29,11 +29,10 @@ module Elasticsearch
         # @see https://www.elastic.co/guide/en/elasticsearch/reference/current/preview-transform.html
         #
         def preview_transform(arguments = {})
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
           body = arguments.delete(:body)
-
-          arguments = arguments.clone
 
           _transform_id = arguments.delete(:transform_id)
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/transform/put_transform.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/transform/put_transform.rb
@@ -33,11 +33,10 @@ module Elasticsearch
           raise ArgumentError, "Required argument 'body' missing" unless arguments[:body]
           raise ArgumentError, "Required argument 'transform_id' missing" unless arguments[:transform_id]
 
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
           body = arguments.delete(:body)
-
-          arguments = arguments.clone
 
           _transform_id = arguments.delete(:transform_id)
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/transform/reset_transform.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/transform/reset_transform.rb
@@ -31,11 +31,10 @@ module Elasticsearch
         def reset_transform(arguments = {})
           raise ArgumentError, "Required argument 'transform_id' missing" unless arguments[:transform_id]
 
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
           body = nil
-
-          arguments = arguments.clone
 
           _transform_id = arguments.delete(:transform_id)
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/transform/start_transform.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/transform/start_transform.rb
@@ -30,11 +30,10 @@ module Elasticsearch
         def start_transform(arguments = {})
           raise ArgumentError, "Required argument 'transform_id' missing" unless arguments[:transform_id]
 
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
           body = nil
-
-          arguments = arguments.clone
 
           _transform_id = arguments.delete(:transform_id)
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/transform/stop_transform.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/transform/stop_transform.rb
@@ -34,11 +34,10 @@ module Elasticsearch
         def stop_transform(arguments = {})
           raise ArgumentError, "Required argument 'transform_id' missing" unless arguments[:transform_id]
 
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
           body = nil
-
-          arguments = arguments.clone
 
           _transform_id = arguments.delete(:transform_id)
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/transform/update_transform.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/transform/update_transform.rb
@@ -33,11 +33,10 @@ module Elasticsearch
           raise ArgumentError, "Required argument 'body' missing" unless arguments[:body]
           raise ArgumentError, "Required argument 'transform_id' missing" unless arguments[:transform_id]
 
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
           body = arguments.delete(:body)
-
-          arguments = arguments.clone
 
           _transform_id = arguments.delete(:transform_id)
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/transform/upgrade_transforms.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/transform/upgrade_transforms.rb
@@ -28,11 +28,10 @@ module Elasticsearch
         # @see https://www.elastic.co/guide/en/elasticsearch/reference/current/upgrade-transforms.html
         #
         def upgrade_transforms(arguments = {})
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
-          body = nil
-
-          arguments = arguments.clone
+          body   = nil
 
           method = Elasticsearch::API::HTTP_POST
           path   = "_transform/_upgrade"

--- a/elasticsearch-api/lib/elasticsearch/api/actions/update.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/update.rb
@@ -44,11 +44,10 @@ module Elasticsearch
         raise ArgumentError, "Required argument 'index' missing" unless arguments[:index]
         raise ArgumentError, "Required argument 'id' missing" unless arguments[:id]
 
+        arguments = arguments.clone
         headers = arguments.delete(:headers) || {}
 
         body = arguments.delete(:body)
-
-        arguments = arguments.clone
 
         _id = arguments.delete(:id)
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/update_by_query.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/update_by_query.rb
@@ -61,11 +61,10 @@ module Elasticsearch
       def update_by_query(arguments = {})
         raise ArgumentError, "Required argument 'index' missing" unless arguments[:index]
 
+        arguments = arguments.clone
         headers = arguments.delete(:headers) || {}
 
-        body = arguments.delete(:body)
-
-        arguments = arguments.clone
+        body   = arguments.delete(:body)
 
         _index = arguments.delete(:index)
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/update_by_query_rethrottle.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/update_by_query_rethrottle.rb
@@ -29,11 +29,10 @@ module Elasticsearch
       def update_by_query_rethrottle(arguments = {})
         raise ArgumentError, "Required argument 'task_id' missing" unless arguments[:task_id]
 
+        arguments = arguments.clone
         headers = arguments.delete(:headers) || {}
 
         body = nil
-
-        arguments = arguments.clone
 
         _task_id = arguments.delete(:task_id)
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/watcher/ack_watch.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/watcher/ack_watch.rb
@@ -30,11 +30,10 @@ module Elasticsearch
         def ack_watch(arguments = {})
           raise ArgumentError, "Required argument 'watch_id' missing" unless arguments[:watch_id]
 
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
           body = nil
-
-          arguments = arguments.clone
 
           _watch_id = arguments.delete(:watch_id)
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/watcher/activate_watch.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/watcher/activate_watch.rb
@@ -29,11 +29,10 @@ module Elasticsearch
         def activate_watch(arguments = {})
           raise ArgumentError, "Required argument 'watch_id' missing" unless arguments[:watch_id]
 
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
           body = nil
-
-          arguments = arguments.clone
 
           _watch_id = arguments.delete(:watch_id)
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/watcher/deactivate_watch.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/watcher/deactivate_watch.rb
@@ -29,11 +29,10 @@ module Elasticsearch
         def deactivate_watch(arguments = {})
           raise ArgumentError, "Required argument 'watch_id' missing" unless arguments[:watch_id]
 
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
           body = nil
-
-          arguments = arguments.clone
 
           _watch_id = arguments.delete(:watch_id)
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/watcher/delete_watch.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/watcher/delete_watch.rb
@@ -29,11 +29,10 @@ module Elasticsearch
         def delete_watch(arguments = {})
           raise ArgumentError, "Required argument 'id' missing" unless arguments[:id]
 
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
           body = nil
-
-          arguments = arguments.clone
 
           _id = arguments.delete(:id)
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/watcher/execute_watch.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/watcher/execute_watch.rb
@@ -29,11 +29,10 @@ module Elasticsearch
         # @see https://www.elastic.co/guide/en/elasticsearch/reference/current/watcher-api-execute-watch.html
         #
         def execute_watch(arguments = {})
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
           body = arguments.delete(:body)
-
-          arguments = arguments.clone
 
           _id = arguments.delete(:id)
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/watcher/get_watch.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/watcher/get_watch.rb
@@ -29,11 +29,10 @@ module Elasticsearch
         def get_watch(arguments = {})
           raise ArgumentError, "Required argument 'id' missing" unless arguments[:id]
 
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
           body = nil
-
-          arguments = arguments.clone
 
           _id = arguments.delete(:id)
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/watcher/put_watch.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/watcher/put_watch.rb
@@ -34,11 +34,10 @@ module Elasticsearch
         def put_watch(arguments = {})
           raise ArgumentError, "Required argument 'id' missing" unless arguments[:id]
 
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
           body = arguments.delete(:body)
-
-          arguments = arguments.clone
 
           _id = arguments.delete(:id)
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/watcher/query_watches.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/watcher/query_watches.rb
@@ -27,11 +27,10 @@ module Elasticsearch
         # @see https://www.elastic.co/guide/en/elasticsearch/reference/current/watcher-api-query-watches.html
         #
         def query_watches(arguments = {})
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
-          body = arguments.delete(:body)
-
-          arguments = arguments.clone
+          body   = arguments.delete(:body)
 
           method = if body
                      Elasticsearch::API::HTTP_POST

--- a/elasticsearch-api/lib/elasticsearch/api/actions/watcher/start.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/watcher/start.rb
@@ -26,11 +26,10 @@ module Elasticsearch
         # @see https://www.elastic.co/guide/en/elasticsearch/reference/current/watcher-api-start.html
         #
         def start(arguments = {})
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
-          body = nil
-
-          arguments = arguments.clone
+          body   = nil
 
           method = Elasticsearch::API::HTTP_POST
           path   = "_watcher/_start"

--- a/elasticsearch-api/lib/elasticsearch/api/actions/watcher/stats.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/watcher/stats.rb
@@ -28,11 +28,10 @@ module Elasticsearch
         # @see https://www.elastic.co/guide/en/elasticsearch/reference/current/watcher-api-stats.html
         #
         def stats(arguments = {})
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
           body = nil
-
-          arguments = arguments.clone
 
           _metric = arguments.delete(:metric)
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/watcher/stop.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/watcher/stop.rb
@@ -26,11 +26,10 @@ module Elasticsearch
         # @see https://www.elastic.co/guide/en/elasticsearch/reference/current/watcher-api-stop.html
         #
         def stop(arguments = {})
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
-          body = nil
-
-          arguments = arguments.clone
+          body   = nil
 
           method = Elasticsearch::API::HTTP_POST
           path   = "_watcher/_stop"

--- a/elasticsearch-api/lib/elasticsearch/api/actions/xpack/info.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/xpack/info.rb
@@ -28,11 +28,10 @@ module Elasticsearch
         # @see https://www.elastic.co/guide/en/elasticsearch/reference/current/info-api.html
         #
         def info(arguments = {})
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
-          body = nil
-
-          arguments = arguments.clone
+          body   = nil
 
           method = Elasticsearch::API::HTTP_GET
           path   = "_xpack"

--- a/elasticsearch-api/lib/elasticsearch/api/actions/xpack/usage.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/xpack/usage.rb
@@ -27,11 +27,10 @@ module Elasticsearch
         # @see https://www.elastic.co/guide/en/elasticsearch/reference/current/usage-api.html
         #
         def usage(arguments = {})
+          arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
-          body = nil
-
-          arguments = arguments.clone
+          body   = nil
 
           method = Elasticsearch::API::HTTP_GET
           path   = "_xpack/usage"

--- a/elasticsearch-api/spec/unit_tests_platinum/unit/security/update_user_profile_data_test.rb
+++ b/elasticsearch-api/spec/unit_tests_platinum/unit/security/update_user_profile_data_test.rb
@@ -25,8 +25,8 @@ module Elasticsearch
 
         should 'perform correct request' do
           subject.expects(:perform_request).with do |method, url, params, body|
-            assert_equal('POST', method)
-            assert_equal('_security/profile/_data/1', url)
+            assert_equal('PUT', method)
+            assert_equal('_security/profile/1/_data', url)
             assert_equal({}, params)
             assert_equal(body, {})
             true

--- a/elasticsearch-api/utils/thor/templates/_method_setup.erb
+++ b/elasticsearch-api/utils/thor/templates/_method_setup.erb
@@ -16,7 +16,6 @@
 # specific language governing permissions and limitations
 # under the License.
 %>
-<%= '  '*(@namespace_depth+4) %>arguments = arguments.clone
 <%- if @method_name == 'search' -%>
   arguments[:index] = UNDERSCORE_ALL if ! arguments[:index] && arguments[:type]
 <%- end -%>

--- a/elasticsearch-api/utils/thor/templates/method.erb
+++ b/elasticsearch-api/utils/thor/templates/method.erb
@@ -33,12 +33,14 @@ module Elasticsearch
   <%= '  '*(@namespace_depth+2) %>end
 <%- else -%>
   <%- if @method_name == 'get_field_mapping' %>
+    arguments = arguments.clone
     _fields = arguments.delete(:field) || arguments.delete(:fields)
     raise ArgumentError, "Required argument 'field' missing" unless _fields
   <%- else -%>
     <%- @required_parts.each do |required| %><%# Arguments -%>
       <%= '  '*(@namespace_depth+3) + "raise ArgumentError, \"Required argument '#{required}' missing\" unless arguments[:#{required}]" + "\n" -%>
     <%- end -%>
+    arguments = arguments.clone
     <%- end -%>
     headers = arguments.delete(:headers) || {}
     <%- #Body %>


### PR DESCRIPTION
When updating the code generator for 8.x, the order of `arguments.clone` in the generated code was changed. This would make it so that we would modify the arguments before cloning them, which is undesired.

Addresses https://github.com/elastic/elasticsearch-ruby/issues/1727