### PR TITLE
Bumps to version 8.1.3

### DIFF
--- a/elasticsearch-api/lib/elasticsearch/api/version.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/version.rb
@@ -17,6 +17,6 @@
 
 module Elasticsearch
   module API
-    VERSION = '8.1.2'.freeze
+    VERSION = '8.1.3'.freeze
   end
 end

--- a/elasticsearch/elasticsearch.gemspec
+++ b/elasticsearch/elasticsearch.gemspec
@@ -46,7 +46,7 @@ Gem::Specification.new do |s|
   s.required_ruby_version = '>= 2.5'
 
   s.add_dependency 'elastic-transport', '8.0.0'
-  s.add_dependency 'elasticsearch-api', '8.1.2'
+  s.add_dependency 'elasticsearch-api', '8.1.3'
 
   s.add_development_dependency 'bundler'
   s.add_development_dependency 'byebug' unless defined?(JRUBY_VERSION) || defined?(Rubinius)

--- a/elasticsearch/lib/elasticsearch/version.rb
+++ b/elasticsearch/lib/elasticsearch/version.rb
@@ -16,5 +16,5 @@
 # under the License.
 
 module Elasticsearch
-  VERSION = '8.1.2'.freeze
+  VERSION = '8.1.3'.freeze
 end


### PR DESCRIPTION
Same as https://github.com/elastic/elasticsearch-ruby/commit/81eef0d2af6c66f984a0eebe40f06cb42e7fadf0 but with `8.1.3`