### PR TITLE
[Gem] Updates elastic-transport dependency

### DIFF
--- a/elasticsearch/elasticsearch.gemspec
+++ b/elasticsearch/elasticsearch.gemspec
@@ -45,7 +45,7 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = '>= 2.5'
 
-  s.add_dependency 'elastic-transport', '8.0.0'
+  s.add_dependency 'elastic-transport', '~> 8.0'
   s.add_dependency 'elasticsearch-api', '8.2.2'
 
   s.add_development_dependency 'bundler'


### PR DESCRIPTION
Sets the version to `'~> 8.0'` to include patch releases.