### PR TITLE
[DOCS] Updates docs URL in 7.15 Release Notes

### DIFF
--- a/docs/release_notes/715.asciidoc
+++ b/docs/release_notes/715.asciidoc
@@ -9,7 +9,7 @@
 
 [discrete]
 ==== API
-- New experimental endpoints: `indices.disk_usage`. `indices.field_usage_stats`, `nodes.clear_repositories_metering_archive`, `get_repositories_metering_info`, https://www.elastic.co/guide/en/elasticsearch/reference/master/search-vector-tile-api.html[`search_mvt`]
+- New experimental endpoints: `indices.disk_usage`. `indices.field_usage_stats`, `nodes.clear_repositories_metering_archive`, `get_repositories_metering_info`, https://www.elastic.co/guide/en/elasticsearch/reference/7.15/search-vector-tile-api.html[`search_mvt`]
 - The `index` parameter is now required for `open_point_in_time`.
 - The `index_metric` parameter in `nodes.stats` adds the `shards` option.
 


### PR DESCRIPTION
Fixes doc build error:
```
release_notes_715.html contains broken links to:
   - en/elasticsearch/reference/master/search-vector-tile-api.html
```

Needs to be backported to:
- [x] 7.16 https://github.com/elastic/elasticsearch-ruby/pull/1897
- [x] 7.17 https://github.com/elastic/elasticsearch-ruby/pull/1892
- [x] 8.0 https://github.com/elastic/elasticsearch-ruby/pull/1893
- [x] 8.1 https://github.com/elastic/elasticsearch-ruby/pull/1894
- [x] 8.2 https://github.com/elastic/elasticsearch-ruby/pull/1895
- [x] 8.3 https://github.com/elastic/elasticsearch-ruby/pull/1896
- [x] 8.4 https://github.com/elastic/elasticsearch-ruby/pull/1898
- [x] 8.5 https://github.com/elastic/elasticsearch-ruby/pull/1899