### PR TITLE
[DOCS] Updates advanced config docs url

### DIFF
--- a/docs/advanced-config.asciidoc
+++ b/docs/advanced-config.asciidoc
@@ -165,7 +165,7 @@ client.search(index: 'myindex', q: 'title:test', headers: {user_agent: "My App"}
 
 The X-Opaque-Id header allows to track certain calls, or associate certain tasks 
 with the client that started them (refer to 
-https://www.elastic.co/guide/en/elasticsearch/reference/master/tasks.html#_identifying_running_tasks[the documentation]). 
+https://www.elastic.co/guide/en/elasticsearch/reference/current/tasks.html#_identifying_running_tasks[the documentation]). 
 To use this feature, you need to set an id for `opaque_id` on the client on each 
 request. Example:
 


### PR DESCRIPTION
Fixes doc build error:
```
advanced-config.html contains broken links to:
 - en/elasticsearch/reference/master/tasks.html
```

Needs to be ported to:
- [x] 7.17 https://github.com/elastic/elasticsearch-ruby/pull/1892
- [x] 8.0 https://github.com/elastic/elasticsearch-ruby/pull/1893
- [x] 8.1 https://github.com/elastic/elasticsearch-ruby/pull/1894
- [x] 8.2 https://github.com/elastic/elasticsearch-ruby/pull/1895
- [x] 8.3 https://github.com/elastic/elasticsearch-ruby/pull/1896