### PR TITLE
[8.0] Updates docs for doc build

### DIFF
--- a/docs/advanced-config.asciidoc
+++ b/docs/advanced-config.asciidoc
@@ -165,7 +165,7 @@ client.search(index: 'myindex', q: 'title:test', headers: {user_agent: "My App"}
 
 The X-Opaque-Id header allows to track certain calls, or associate certain tasks 
 with the client that started them (refer to 
-https://www.elastic.co/guide/en/elasticsearch/reference/master/tasks.html#_identifying_running_tasks[the documentation]). 
+https://www.elastic.co/guide/en/elasticsearch/reference/current/tasks.html#_identifying_running_tasks[the documentation]). 
 To use this feature, you need to set an id for `opaque_id` on the client on each 
 request. Example:
 

--- a/docs/release_notes/715.asciidoc
+++ b/docs/release_notes/715.asciidoc
@@ -9,7 +9,7 @@
 
 [discrete]
 ==== API
-- New experimental endpoints: `indices.disk_usage`. `indices.field_usage_stats`, `nodes.clear_repositories_metering_archive`, `get_repositories_metering_info`, https://www.elastic.co/guide/en/elasticsearch/reference/master/search-vector-tile-api.html[`search_mvt`]
+- New experimental endpoints: `indices.disk_usage`. `indices.field_usage_stats`, `nodes.clear_repositories_metering_archive`, `get_repositories_metering_info`, https://www.elastic.co/guide/en/elasticsearch/reference/7.15/search-vector-tile-api.html[`search_mvt`]
 - The `index` parameter is now required for `open_point_in_time`.
 - The `index_metric` parameter in `nodes.stats` adds the `shards` option.
 


### PR DESCRIPTION
Ports https://github.com/elastic/elasticsearch-ruby/pull/1891 and https://github.com/elastic/elasticsearch-ruby/pull/1890