### PR TITLE
Backports #1914: Update Ruby client examples

### DIFF
--- a/docs/examples.asciidoc
+++ b/docs/examples.asciidoc
@@ -52,7 +52,7 @@ client.get(index: 'books', id: id)
 
 Assume you have the following document:
 
-```
+```ruby
 book = {"name": "Foundation", "author": "Isaac Asimov", "release_date": "1951-06-01", "page_count": 224}
 ```
 
@@ -166,7 +166,7 @@ The `field` parameter is a common parameter, so it can be passed in directly in
 the following way:
 
 ```ruby
-client.search(index: 'books', q: 'dune', field: 'name')
+client.search(index: 'books', q: 'dune')
 ```
 
 You can do the same by using body request parameters:


### PR DESCRIPTION
* One of the code blocks didn't include the word `ruby`,  causing it to be a different color and difficult to read
* One of the examples raised an error: "illegal_argument_exception","reason":"request [/books/_search]
  contains unrecognized parameter: [field]"