### PR TITLE
Add missing elastic/transport require in api_response_spec.rb

### DIFF
--- a/elasticsearch-api/spec/elasticsearch/api/api_response_spec.rb
+++ b/elasticsearch-api/spec/elasticsearch/api/api_response_spec.rb
@@ -16,6 +16,7 @@
 # under the License.
 
 require 'spec_helper'
+require 'elastic/transport'
 
 describe Elasticsearch::API::Response do
   let(:response_body) do


### PR DESCRIPTION
When running `rake test:unit` in `./elasticsearch-api` directory I see failing tests in the output:

```
Finished in 0.3177 seconds (files took 5.11 seconds to load)
526 examples, 4 failures

Failed examples:

rspec ./spec/elasticsearch/api/api_response_spec.rb:44 # Elasticsearch::API::Response behaves like a Hash
rspec ./spec/elasticsearch/api/api_response_spec.rb:53 # Elasticsearch::API::Response returns a status
rspec ./spec/elasticsearch/api/api_response_spec.rb:57 # Elasticsearch::API::Response returns the headers
rspec ./spec/elasticsearch/api/api_response_spec.rb:61 # Elasticsearch::API::Response returns the body which
```

The error message that's seen in the tests is the following:

```
uninitialized constant Elastic::Transport
```

This PR aims at fixing it by including the missing `require` statement in the beginning of `elasticsearch-api/spec/elasticsearch/api/api_response_spec.rb` file.