### PR TITLE
[BACKPORT #1941] [GEM] Fixes bug instantiating client with api_key and transport_options

### DIFF
--- a/elasticsearch/lib/elasticsearch.rb
+++ b/elasticsearch/lib/elasticsearch.rb
@@ -144,9 +144,8 @@ module Elasticsearch
       if (headers = arguments.dig(:transport_options, :headers))
         headers.merge!(authorization)
       else
-        arguments[:transport_options] = {
-          headers: authorization
-        }
+        arguments[:transport_options] ||= {}
+        arguments[:transport_options].merge!({ headers: authorization })
       end
     end
 

--- a/elasticsearch/spec/unit/api_key_spec.rb
+++ b/elasticsearch/spec/unit/api_key_spec.rb
@@ -57,7 +57,7 @@ describe Elasticsearch::Client do
       end
     end
 
-    context 'when other headers where specified' do
+    context 'when other headers were specified' do
       let(:client) do
         described_class.new(
           api_key: 'elasticsearch_api_key',
@@ -69,6 +69,42 @@ describe Elasticsearch::Client do
         header = client.transport.connections.first.connection.headers
         expect(header['Authorization']).to eq('ApiKey elasticsearch_api_key')
         expect(header['X-Test-Header']).to eq('test')
+      end
+    end
+
+    context 'when sending transport_options but no headers were specified' do
+      let(:client) do
+        described_class.new(
+          api_key: 'elasticsearch_api_key',
+          transport_options: { ssl: { verify: false } }
+        )
+      end
+
+      it 'Adds the ApiKey header to the connection and keeps the options' do
+        header = client.transport.connections.first.connection.headers
+        expect(header['Authorization']).to eq('ApiKey elasticsearch_api_key')
+        expect(client.transport.options[:transport_options]).to include({ ssl: { verify: false } })
+        expect(client.transport.options[:transport_options][:headers]).to include('Authorization' => 'ApiKey elasticsearch_api_key')
+      end
+    end
+
+    context 'when other headers and options were specified' do
+      let(:client) do
+        described_class.new(
+          api_key: 'elasticsearch_api_key',
+          transport_options: {
+            headers: { 'x-test-header' => 'test' },
+            ssl: { verify: false }
+          }
+        )
+      end
+
+      it 'Adds the ApiKey header to the connection and keeps the header' do
+        header = client.transport.connections.first.connection.headers
+        expect(header['X-Test-Header']).to eq('test')
+        expect(header['Authorization']).to eq('ApiKey elasticsearch_api_key')
+        expect(client.transport.options[:transport_options]).to include({ ssl: { verify: false } })
+        expect(client.transport.options[:transport_options][:headers]).to include('Authorization' => 'ApiKey elasticsearch_api_key')
       end
     end
 


### PR DESCRIPTION
Backports #1941 

When passing in `api_key` and `transport_options` that don't include headers to the client, the api_key code would overwrite the arguments passed in for `transport_options`. This code fixes this, checking if there are transport options and merging the auth headers with that instead.

Fixes #1940