### PR TITLE
Use POST when service account token name is not present

### DIFF
--- a/elasticsearch-api/lib/elasticsearch/api/actions/security/create_service_token.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/security/create_service_token.rb
@@ -47,12 +47,13 @@ module Elasticsearch
 
           _name = arguments.delete(:name)
 
-          method = Elasticsearch::API::HTTP_PUT
-          path   = if _namespace && _service && _name
-                     "_security/service/#{Utils.__listify(_namespace)}/#{Utils.__listify(_service)}/credential/token/#{Utils.__listify(_name)}"
-                   else
-                     "_security/service/#{Utils.__listify(_namespace)}/#{Utils.__listify(_service)}/credential/token"
-                   end
+          if _namespace && _service && _name
+            method = Elasticsearch::API::HTTP_PUT
+            path = "_security/service/#{Utils.__listify(_namespace)}/#{Utils.__listify(_service)}/credential/token/#{Utils.__listify(_name)}"
+          else
+            method = Elasticsearch::API::HTTP_POST
+            path = "_security/service/#{Utils.__listify(_namespace)}/#{Utils.__listify(_service)}/credential/token"
+          end
           params = Utils.process_params(arguments)
 
           Elasticsearch::API::Response.new(

--- a/elasticsearch-api/spec/elasticsearch/api/actions/security/create_service_token_spec.rb
+++ b/elasticsearch-api/spec/elasticsearch/api/actions/security/create_service_token_spec.rb
@@ -18,14 +18,29 @@
 require 'spec_helper'
 
 describe 'client#security#create_service_token' do
+  let(:expected_path) { '_security/service/foo/bar/credential/token' }
+  let(:expected_request_method) { 'POST' }
   let(:expected_args) do
     [
-      'PUT',
-      '_security/service/foo/bar/credential/token',
+      expected_request_method,
+      expected_path,
       {},
       nil,
       {}
     ]
+  end
+
+  context 'with token name' do
+    let(:expected_request_method) { 'PUT' }
+    let(:token_name) { 'test-token' }
+    let(:expected_path) { "#{super()}/#{token_name}" }
+    it 'performs the request' do
+      expect(
+        client_double.security.create_service_token(
+          namespace: 'foo', service: 'bar', name: token_name
+        )
+      ).to be_a Elasticsearch::API::Response
+    end
   end
 
   it 'performs the request' do


### PR DESCRIPTION
When a service account token is created, and no name is specified, the method to use is POST instead of PUT. PUT returns a 405 message:

```bash
curl -u [redacted] -X PUT http://localhost:9200/_security/service/elastic/enterprise-search-server/credential/token
```
```json
{"error":"Incorrect HTTP method for uri [/_security/service/elastic/enterprise-search-server/credential/token] and method [PUT], allowed: [POST]","status":405} 
```

While POST creates the service account token:
```bash
curl -u [redacted] -X POST http://localhost:9200/_security/service/elastic/enterprise-search-server/credential/token
```
```json
{"created":true,"token":{"name":"token_bgy1gYQB5WUVQc9_TiIn","value":[redacted]}}
```
