### PR TITLE
[DOCS] Updates example docs generator to eval the code

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,8 +17,8 @@
 
 source 'https://rubygems.org'
 
-gem 'elasticsearch-api',        path: File.expand_path('../elasticsearch-api', __FILE__),        require: false
-gem 'elasticsearch',            path: File.expand_path('../elasticsearch', __FILE__),            require: false
+gem 'elasticsearch-api', path: File.expand_path('../elasticsearch-api', __FILE__), require: false
+gem 'elasticsearch',     path: File.expand_path('../elasticsearch', __FILE__), require: false
 
 gem 'ansi'
 gem 'cane'

--- a/rake_tasks/doc_generator.rake
+++ b/rake_tasks/doc_generator.rake
@@ -48,6 +48,8 @@ namespace :docs do
   end
 
   def generate_docs(entry)
+    require 'elasticsearch'
+
     filename = "#{entry['digest']}.asciidoc"
     unless entry['parsed_source'].empty?
       api = entry['parsed_source'].first['api']
@@ -132,7 +134,6 @@ end
 # Test module to run the generated code
 #
 module TestDocs
-  require 'elasticsearch'
   @formatter = -> (_, d, _, msg) { "#{d}: #{msg}" }
 
   def self.perform(code, filename)

--- a/rake_tasks/doc_generator.rake
+++ b/rake_tasks/doc_generator.rake
@@ -31,12 +31,16 @@ namespace :docs do
     Dir.mkdir(TARGET_DIR)
 
     entries = json_data.select { |d| d['lang'] == 'console' }
+    start_time = Time.now.to_i
     entries.each_with_index do |entry, index|
       percentage = index * 100 / entries.length
-      print "\r" + ("\e[A\e[K") if index > 0
-      puts "Generating file #{index + 1} of #{entries.length} - #{percentage}% complete"
+      hourglass = index.even? ? '⌛ ' : '⏳ '
+      print "\r" + ("\e[A\e[K" * 4) if index > 0
+      puts "📝 Generating file #{index + 1} of #{entries.length} - #{percentage}% complete"
+      puts hourglass + '▩' * (percentage / 2) + '⬚' * (50 - percentage / 2) + ' ' + hourglass
       generate_docs(entry)
     end
+    puts "Finished generating #{entries.length} files in #{Time.now.to_i - start_time} seconds"
   end
 
   def json_data
@@ -138,7 +142,7 @@ module TestDocs
     logger = Logger.new('log/docs-generation-elasticsearch.log')
     logger.formatter = @formatter
     logger.info("Located in #{filename}: #{e.message}\n")
-  rescue ArgumentError => e
+  rescue ArgumentError, NoMethodError => e
     logger = Logger.new('log/docs-generation-client.log')
     logger.formatter = @formatter
     logger.info("Located in #{filename}: #{e.message}\n")

--- a/rake_tasks/elasticsearch_tasks.rake
+++ b/rake_tasks/elasticsearch_tasks.rake
@@ -15,8 +15,6 @@
 # specific language governing permissions and limitations
 # under the License.
 
-ELASTICSEARCH_PATH = "#{CURRENT_PATH}/tmp/elasticsearch".freeze
-
 namespace :elasticsearch do
   desc 'Wait for elasticsearch cluster to be in green state'
   task :wait_for_green do


### PR DESCRIPTION
This update adds a test module which instantiates an Elasticsearch client and runs `eval` on the generated example code. It catches exceptions for both Elasticsearch responses and client responses, logging them to different files:

- logs/docs-generation-elasticsearch.log
- logs/docs-generation-client.log

This way we can generate the code, run it and check if there are errors in the documentation, the client or the code generation.

It generates all the available examples and mutes all outputs in the console, replacing it with a progress status.

![file-generation](https://user-images.githubusercontent.com/689327/228466442-9323d23d-9b67-4cbe-88ac-c337d60ddc9a.gif)