### PR TITLE
[DOCS] Adds logo to the landing page hero image and changes tagline

### DIFF
--- a/docs/index-custom-title-page.html
+++ b/docs/index-custom-title-page.html
@@ -60,7 +60,7 @@
         <h2>Documentation</h2>
       </p>
       <p>
-        The official Ruby client provides a low-level client for communicating with an Elasticsearch cluster.
+        The official Ruby client provides one-to-one mapping with Elasticsearch REST APIs.
       </p>
       <p>
         <a href="https://www.elastic.co/guide/en/elasticsearch/client/ruby-api/current/ruby-install.html">
@@ -69,7 +69,7 @@
       </p>
     </div>
     <div class="col-md-6 col-12">
-      <img class="w-100" src="https://images.contentstack.io/v3/assets/bltefdd0b53724fa2ce/blta0a3d914dc5d8070/641d7fac80a10d107c7294e8/ruby-es-lp-hero.png" />
+      <img class="w-100" src="https://images.contentstack.io/v3/assets/bltefdd0b53724fa2ce/blt4f322d51b4812e0a/64255eebde06a31192f4399a/ES_Ruby_landing_page.png" />
     </div>
   </div>
 
@@ -174,3 +174,5 @@
   </div>
 
   <p class="my-4"><a href="https://www.elastic.co/guide/index.html">View all Elastic docs</a></p>
+
+  <p class="my-4"><small>The Ruby logo available <a href="https://www.ruby-lang.org/en/about/logo/">here</a> is released under the Creative Commons <a href="https://creativecommons.org/licenses/by-sa/2.5/"> Attribution-Share Alike 2.5 License</a>.</small></p>


### PR DESCRIPTION
## Overview

This PR:
* uses a new hero image for the landing page that contains the official Ruby logo,
* adds a line about the logo license to the bottom of the page,
* changes the tagline of the page.

### Preview

[Ruby client landing page](https://elasticsearch-ruby_2046.docs-preview.app.elstc.co/guide/en/elasticsearch/client/ruby-api/master/index.html)