### PR TITLE
[API] Updates generator to use params for APIs using ignore_404

### DIFF
--- a/elasticsearch-api/lib/elasticsearch/api/actions/clear_scroll.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/clear_scroll.rb
@@ -48,11 +48,19 @@ module Elasticsearch
                  else
                    "_search/scroll"
                  end
-        params = {}
+        params = Utils.process_params(arguments)
 
-        Elasticsearch::API::Response.new(
-          perform_request(method, path, params, body, headers)
-        )
+        if Array(arguments[:ignore]).include?(404)
+          Utils.__rescue_from_not_found {
+            Elasticsearch::API::Response.new(
+              perform_request(method, path, params, body, headers)
+            )
+          }
+        else
+          Elasticsearch::API::Response.new(
+            perform_request(method, path, params, body, headers)
+          )
+        end
       end
     end
   end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/security/get_role.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/security/get_role.rb
@@ -43,7 +43,7 @@ module Elasticsearch
                    else
                      "_security/role"
                    end
-          params = {}
+          params = Utils.process_params(arguments)
 
           if Array(arguments[:ignore]).include?(404)
             Utils.__rescue_from_not_found {

--- a/elasticsearch-api/lib/elasticsearch/api/actions/watcher/delete_watch.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/watcher/delete_watch.rb
@@ -41,7 +41,7 @@ module Elasticsearch
 
           method = Elasticsearch::API::HTTP_DELETE
           path   = "_watcher/watch/#{Utils.__listify(_id)}"
-          params = {}
+          params = Utils.process_params(arguments)
 
           if Array(arguments[:ignore]).include?(404)
             Utils.__rescue_from_not_found {

--- a/elasticsearch-api/utils/thor/generator/endpoint_specifics.rb
+++ b/elasticsearch-api/utils/thor/generator/endpoint_specifics.rb
@@ -33,18 +33,19 @@ module Elasticsearch
       # Endpoints that need Utils.__rescue_from_not_found if the ignore
       # parameter is included
       COMPLEX_IGNORE_404 = %w[
+        clear_scroll
         delete
         get
-        indices.flush_synced
-        indices.delete_template
         indices.delete
+        indices.delete_template
+        indices.flush_synced
         security.get_role
         security.get_user
-        snapshot.status
+        snapshot.delete
+        snapshot.delete_repository
         snapshot.get
         snapshot.get_repository
-        snapshot.delete_repository
-        snapshot.delete
+        snapshot.status
         update
         watcher.delete_watch
       ].freeze

--- a/elasticsearch-api/utils/thor/templates/_method_setup.erb
+++ b/elasticsearch-api/utils/thor/templates/_method_setup.erb
@@ -27,7 +27,7 @@
   endpoint = arguments.delete(:endpoint) || '_termvectors'
 <%- end -%>
 <%= '  '*(@namespace_depth+4) %>path   = <%= @http_path %>
-<%- unless @params.empty? -%>
+<%- if !@params.empty? || needs_ignore_404?(@endpoint_name) || needs_complex_ignore_404?(@endpoint_name)-%>
   <%= '  '*(@namespace_depth+4) %>params = Utils.process_params(arguments)
 <%- else -%>
   <%= '  '*(@namespace_depth+4) %>params = {}


### PR DESCRIPTION
Adds option to use `ignore: 404` in `clear_scroll`. As a side fix, it also fixes `security.get_role` and `watcher.delete_watch` which also supported the feature to ignore 404, but the parameters were coming empty, so they'd return a boolean instead of the Response from Elasticsearch.

Related to #2067 