### PR TITLE
Adds Client Helpers

### DIFF
--- a/docs/helpers.asciidoc
+++ b/docs/helpers.asciidoc
@@ -1,34 +1,34 @@
 [[Helpers]]
 == Client Helpers
 
-The Elasticsearch Ruby client includes some useful helpers for a more comfortable experience with some APIs.
+The {es} Ruby client includes some useful helpers for a more comfortable experience with some APIs.
 
 === Bulk Helper
 
-This helper aims to provide a nicer developer experience when using the Bulk API. At its simplest, you can send it a collection of Hashes in an Array, and it will bulk ingest them into Elasticsearch.
+This helper provides a better developer experience when using the Bulk API. At its simplest, you can send it a collection of hashes in an array, and it will bulk ingest them into {es}.
 
-To use the BulkHelper, you need to require it in your code:
+To use the BulkHelper, require it in your code:
 
 [source,ruby]
 ----
 require 'elasticsearch/helpers/bulk_helper'
 ----
 
-You need to instantiate a BulkHelper with a client, and an index:
+Instantiate a BulkHelper with a client, and an index:
 [source,ruby]
 ----
 client = Elasticsearch::Client.new
 bulk_helper = Elasticsearch::Helpers::BulkHelper.new(client, index)
 ----
 
-This helper will work on the index you pass in during initialization, but you can change the index any time in your code:
+This helper works on the index you pass in during initialization, but you can change the index at any time in your code:
 
 [source,ruby]
 ----
 bulk_helper.index = 'new_index'
 ----
 
-If you want to index a collection of documents, you can use the `ingest` method:
+If you want to index a collection of documents, use the `ingest` method:
 
 [source,ruby]
 ----
@@ -40,7 +40,7 @@ documents = [
 bulk_helper.ingest(documents)
 ----
 
-If you're ingesting a large set of data and want to separate the documents into smaller pieces before sending them to Elasticsearch, you can use the `slice` parameter.
+If you're ingesting a large set of data and want to separate the documents into smaller pieces before sending them to {es}, use the `slice` parameter.
 
 [source,ruby]
 ----
@@ -49,7 +49,7 @@ bulk_helper.ingest(documents, { slice: 2 })
 
 This way the data will be sent in two different bulk requests.
 
-You can also send the parameters you would send to the Bulk API in the query parameters or body. The method signature is `ingest(docs, params = {}, body = {}, &block)`. The method can be called with a block, that will yield the response object from calling the Bulk API and the documents sent in the request:
+You can also include the parameters you would send to the Bulk API either in the query parameters or in the request body. The method signature is `ingest(docs, params = {}, body = {}, &block)`. Additionally, the method can be called with a block, that will provide access to the response object received from calling the Bulk API and the documents sent in the request:
 
 [source,ruby]
 ----
@@ -61,14 +61,14 @@ helper.ingest(documents) { |_, docs| puts "Ingested #{docs.count} documents" }
 
 This helper provides an easy way to get results from a Scroll.
 
-To use the ScrollHelper, you need to require it in your code:
+To use the ScrollHelper, require it in your code:
 
 [source,ruby]
 ----
 require 'elasticsearch/helpers/scroll_helper'
 ----
 
-You need to instantiate a ScrollHelper with a client, an index, and a body (with the scroll API parameters) which will be used in every following scroll request:
+Instantiate a ScrollHelper with a client, an index, and a body (with the scroll API parameters) which will be used in every following scroll request:
 
 [source,ruby]
 ----
@@ -78,17 +78,19 @@ scroll_helper = Elasticsearch::Helpers::ScrollHelper.new(client, index, body)
 
 There are two ways to get the results from a scroll using the helper.
 
-You can iterate over a scroll using the methods in `Enumerable` such as `each` and `map`:
-
+1. You can iterate over a scroll using the methods in `Enumerable` such as `each` and `map`:
++
+--
 [source,ruby]
 ----
 scroll_helper.each do |item|
   puts item
 end
 ----
-
-You can fetch results by page, with the `results` function:
-
+--
+2. You can fetch results by page, with the `results` function:
++
+--
 [source,ruby]
 ----
 my_documents = []
@@ -97,3 +99,4 @@ while !(documents = scroll_helper.results).empty?
 end
 scroll_helper.clear
 ----
+--

--- a/docs/helpers.asciidoc
+++ b/docs/helpers.asciidoc
@@ -59,4 +59,41 @@ helper.ingest(documents) { |_, docs| puts "Ingested #{docs.count} documents" }
 
 === Scroll Helper
 
-=== Point in Time Helper
+This helper provides an easy way to get results from a Scroll.
+
+To use the ScrollHelper, you need to require it in your code:
+
+[source,ruby]
+----
+require 'elasticsearch/helpers/scroll_helper'
+----
+
+You need to instantiate a ScrollHelper with a client, an index, and a body (with the scroll API parameters) which will be used in every following scroll request:
+
+[source,ruby]
+----
+client = Elasticsearch::Client.new
+scroll_helper = Elasticsearch::Helpers::ScrollHelper.new(client, index, body)
+----
+
+There are two ways to get the results from a scroll using the helper.
+
+You can iterate over a scroll using the methods in `Enumerable` such as `each` and `map`:
+
+[source,ruby]
+----
+scroll_helper.each do |item|
+  puts item
+end
+----
+
+You can fetch results by page, with the `results` function:
+
+[source,ruby]
+----
+my_documents = []
+while !(documents = scroll_helper.results).empty?
+  my_documents << documents
+end
+scroll_helper.clear
+----

--- a/docs/helpers.asciidoc
+++ b/docs/helpers.asciidoc
@@ -56,6 +56,23 @@ You can also include the parameters you would send to the Bulk API either in the
 helper.ingest(documents) { |_, docs| puts "Ingested #{docs.count} documents" }
 ----
 
+You can update and delete documents with the BulkHelper too. To delete a set of documents, you can send an array of document ids:
+
+[source,ruby]
+----
+ids = ['shm0I4gB6LpJd9ljO9mY', 'sxm0I4gB6LpJd9ljO9mY', 'tBm0I4gB6LpJd9ljO9mY', 'tRm0I4gB6LpJd9ljO9mY', 'thm0I4gB6LpJd9ljO9mY', 'txm0I4gB6LpJd9ljO9mY', 'uBm0I4gB6LpJd9ljO9mY', 'uRm0I4gB6LpJd9ljO9mY', 'uhm0I4gB6LpJd9ljO9mY', 'uxm0I4gB6LpJd9ljO9mY']
+helper.delete(ids)
+----
+
+To update documents, you can send the array of documents with their respective ids:
+[source,ruby]
+----
+documents = [
+  {name: 'updated name 1', id: 'AxkFJYgB6LpJd9ljOtr7'},
+  {name: 'updated name 2', 'BBkFJYgB6LpJd9ljOtr7'}
+]
+helper.update(documents)
+----
 
 === Scroll Helper
 

--- a/docs/helpers.asciidoc
+++ b/docs/helpers.asciidoc
@@ -1,0 +1,62 @@
+[[Helpers]]
+== Client Helpers
+
+The Elasticsearch Ruby client includes some useful helpers for a more comfortable experience with some APIs.
+
+=== Bulk Helper
+
+This helper aims to provide a nicer developer experience when using the Bulk API. At its simplest, you can send it a collection of Hashes in an Array, and it will bulk ingest them into Elasticsearch.
+
+To use the BulkHelper, you need to require it in your code:
+
+[source,ruby]
+----
+require 'elasticsearch/helpers/bulk_helper'
+----
+
+You need to instantiate a BulkHelper with a client, and an index:
+[source,ruby]
+----
+client = Elasticsearch::Client.new
+bulk_helper = Elasticsearch::Helpers::BulkHelper.new(client, index)
+----
+
+This helper will work on the index you pass in during initialization, but you can change the index any time in your code:
+
+[source,ruby]
+----
+bulk_helper.index = 'new_index'
+----
+
+If you want to index a collection of documents, you can use the `ingest` method:
+
+[source,ruby]
+----
+documents = [
+  { name: 'document1', date: '2024-05-16' },
+  { name: 'document2', date: '2023-12-19' },
+  { name: 'document3', date: '2024-07-07' }
+]
+bulk_helper.ingest(documents)
+----
+
+If you're ingesting a large set of data and want to separate the documents into smaller pieces before sending them to Elasticsearch, you can use the `slice` parameter.
+
+[source,ruby]
+----
+bulk_helper.ingest(documents, { slice: 2 })
+----
+
+This way the data will be sent in two different bulk requests.
+
+You can also send the parameters you would send to the Bulk API in the query parameters or body. The method signature is `ingest(docs, params = {}, body = {}, &block)`. The method can be called with a block, that will yield the response object from calling the Bulk API and the documents sent in the request:
+
+[source,ruby]
+----
+helper.ingest(documents) { |_, docs| puts "Ingested #{docs.count} documents" }
+----
+
+
+=== Scroll Helper
+
+=== Point in Time Helper

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -20,4 +20,6 @@ include::integrations.asciidoc[]
 
 include::examples.asciidoc[]
 
+include::helpers.asciidoc[]
+
 include::release_notes/index.asciidoc[]

--- a/elasticsearch/bin/elastic_ruby_console
+++ b/elasticsearch/bin/elastic_ruby_console
@@ -2,9 +2,11 @@
 
 $LOAD_PATH.unshift(File.expand_path('../../elasticsearch/lib', __dir__))
 $LOAD_PATH.unshift(File.expand_path('../../elasticsearch-api/lib', __dir__))
+$LOAD_PATH.unshift(File.expand_path('../../elasticsearch/lib/elasticsearch/helpers', __dir__))
 
 require 'elasticsearch'
 require 'elasticsearch-api'
+require 'elasticsearch/helpers/bulk_helper'
 
 include Elasticsearch
 

--- a/elasticsearch/lib/elasticsearch/helpers/bulk_helper.rb
+++ b/elasticsearch/lib/elasticsearch/helpers/bulk_helper.rb
@@ -25,8 +25,8 @@ module Elasticsearch
 
       # Create a BulkHelper
       #
-      # @param [Elasticsearch::Client] client (Required) - Instance of Elasticsearch client to use.
-      # @param [String] index (Required) - Index on which to perform the Bulk actions.
+      # @param [Elasticsearch::Client] client Instance of Elasticsearch client to use.
+      # @param [String] index Index on which to perform the Bulk actions.
       # @param [Hash] params Parameters to re-use in every bulk call
       #
       def initialize(client, index, params = {})

--- a/elasticsearch/lib/elasticsearch/helpers/bulk_helper.rb
+++ b/elasticsearch/lib/elasticsearch/helpers/bulk_helper.rb
@@ -20,6 +20,7 @@ module Elasticsearch
     # Elasticsearch Client Helper for the Bulk API
     #
     # @see https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-bulk.html
+    #
     class BulkHelper
       attr_accessor :index
 

--- a/elasticsearch/lib/elasticsearch/helpers/bulk_helper.rb
+++ b/elasticsearch/lib/elasticsearch/helpers/bulk_helper.rb
@@ -1,0 +1,49 @@
+# Licensed to Elasticsearch B.V. under one or more contributor
+# license agreements. See the NOTICE file distributed with
+# this work for additional information regarding copyright
+# ownership. Elasticsearch B.V. licenses this file to you under
+# the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+module Elasticsearch
+  module Helpers
+    class BulkHelper
+      def initialize(client:, index:, params: {})
+        @client = client
+        @index = index
+        @params = params
+      end
+
+      def ingest(docs, params = {})
+        ingest_docs = docs.map do |doc|
+          { index: { _index: @index, data: doc} }
+        end
+        @client.bulk({ body: ingest_docs }.merge(params.merge(@params)))
+      end
+
+      def delete(ids, params = {})
+        to_delete = ids.map do |id|
+          { delete: { _index: @index, _id: id} }
+        end
+        @client.bulk({ body: to_delete }.merge(params.merge(@params)))
+      end
+
+      def update(docs, params = {})
+        ingest_docs = docs.map do |doc|
+          { update: { _index: @index, _id: doc.delete('id'), data: { doc: doc } } }
+        end
+        @client.bulk({ body: ingest_docs }.merge(params.merge(@params)))
+      end
+    end
+  end
+end

--- a/elasticsearch/lib/elasticsearch/helpers/bulk_helper.rb
+++ b/elasticsearch/lib/elasticsearch/helpers/bulk_helper.rb
@@ -25,9 +25,7 @@ module Elasticsearch
       end
 
       def ingest(docs, params = {}, &block)
-        ingest_docs = docs.map do |doc|
-          { index: { _index: @index, data: doc} }
-        end
+        ingest_docs = docs.map { |doc| { index: { _index: @index, data: doc} } }
         if (slice = params.delete(:slice))
           ingest_docs.each_slice(slice) do |items|
             ingest(items, params, &block)
@@ -39,10 +37,8 @@ module Elasticsearch
       end
 
       def delete(ids, params = {})
-        to_delete = ids.map do |id|
-          { delete: { _index: @index, _id: id} }
-        end
-        @client.bulk({ body: to_delete }.merge(params.merge(@params)))
+        delete_docs = ids.map { |id| { delete: { _index: @index, _id: id} } }
+        @client.bulk({ body: delete_docs }.merge(params.merge(@params)))
       end
 
       def update(docs, params = {})

--- a/elasticsearch/lib/elasticsearch/helpers/scroll_helper.rb
+++ b/elasticsearch/lib/elasticsearch/helpers/scroll_helper.rb
@@ -1,0 +1,73 @@
+# Licensed to Elasticsearch B.V. under one or more contributor
+# license agreements. See the NOTICE file distributed with
+# this work for additional information regarding copyright
+# ownership. Elasticsearch B.V. licenses this file to you under
+# the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+module Elasticsearch
+  module Helpers
+    class ScrollHelper
+      include Enumerable
+
+      def initialize(client, index, body, scroll = '1m')
+        @index = index
+        @client = client
+        @scroll = scroll
+        @body = body
+        @docs = []
+      end
+
+      def each(&block)
+        refresh_docs
+        for doc in @docs do
+          refresh_docs
+          yield doc
+        end
+        clear
+        @docs = []
+      end
+
+      def results
+        if @scroll_id
+          @client.scroll(body: {scroll: @scroll, scroll_id: @scroll_id})['hits']['hits']
+        else
+          initial_search
+        end
+      rescue Elastic::Transport::Transport::Errors::NotFound => e
+        if e.message.match?('search_context_missing_exception')
+          initial_search
+        else
+          raise e
+        end
+      end
+
+      private
+
+      def refresh_docs
+        @docs << results
+        @docs.flatten!
+      end
+
+      def initial_search
+        response = @client.search(index: @index, scroll: @scroll, body: @body)
+        @scroll_id = response['_scroll_id']
+        response['hits']['hits']
+      end
+
+      def clear
+        @client.clear_scroll(body: { scroll_id: @scroll_id })
+      end
+    end
+  end
+end

--- a/elasticsearch/lib/elasticsearch/helpers/scroll_helper.rb
+++ b/elasticsearch/lib/elasticsearch/helpers/scroll_helper.rb
@@ -17,6 +17,10 @@
 
 module Elasticsearch
   module Helpers
+    # Elasticsearch Client Helper for the Scroll API
+    #
+    # @see https://www.elastic.co/guide/en/elasticsearch/reference/current/scroll-api.html
+    #
     class ScrollHelper
       include Enumerable
 

--- a/elasticsearch/spec/integration/helpers/bulk_helper_spec.rb
+++ b/elasticsearch/spec/integration/helpers/bulk_helper_spec.rb
@@ -1,0 +1,84 @@
+# Licensed to Elasticsearch B.V. under one or more contributor
+# license agreements. See the NOTICE file distributed with
+# this work for additional information regarding copyright
+# ownership. Elasticsearch B.V. licenses this file to you under
+# the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+ELASTICSEARCH_URL = ENV['TEST_ES_SERVER'] || "http://localhost:#{(ENV['PORT'] || 9200)}"
+raise URI::InvalidURIError unless ELASTICSEARCH_URL =~ /\A#{URI::DEFAULT_PARSER.make_regexp}\z/
+
+require 'spec_helper'
+require 'elasticsearch/helpers/bulk_helper'
+
+context 'Elasticsearch client helpers' do
+  context 'Bulk helper' do
+    let(:client) do
+      Elasticsearch::Client.new(
+        host: ELASTICSEARCH_URL,
+        user: 'elastic',
+        password: 'changeme'
+      )
+    end
+    let(:index) { 'bulk_animals' }
+    let(:params) { { refresh: 'wait_for' } }
+    let(:bulk_helper) { Elasticsearch::Helpers::BulkHelper.new(index: index, client: client, params: params) }
+    let(:docs) do
+      [
+        { scientific_name: 'Lama guanicoe', name:'Guanaco' },
+        { scientific_name: 'Tayassu pecari', name:'White-lipped peccary' },
+        { scientific_name: 'Snycerus caffer', name:'Buffalo, african' },
+        { scientific_name: 'Coluber constrictor', name:'Snake, racer' },
+        { scientific_name: 'Thalasseus maximus', name:'Royal tern' },
+        { scientific_name: 'Centrocercus urophasianus', name:'Hen, sage' },
+        { scientific_name: 'Sitta canadensis', name:'Nuthatch, red-breasted' },
+        { scientific_name: 'Aegypius tracheliotus', name:'Vulture, lappet-faced' },
+        { scientific_name: 'Bucephala clangula', name:'Common goldeneye' },
+        { scientific_name: 'Felis pardalis', name:'Ocelot' }
+      ]
+    end
+
+    after do
+      client.indices.delete(index: index, ignore: 404)
+    end
+
+    it 'ingests' do
+      response = bulk_helper.ingest(docs)
+      expect(response.status).to eq(200)
+    end
+
+    it 'updates' do
+      docs = [
+        { scientific_name: 'Otocyon megalotos', name: 'Bat-eared fox' },
+        { scientific_name: 'Herpestes javanicus', name: 'Small Indian mongoose' }
+      ]
+      bulk_helper.ingest(docs)
+      # Get the ingested documents, add id and modify them to update them:
+      animals = client.search(index: index)['hits']['hits']
+      # Add id to each doc
+      docs = animals.map { |animal| animal['_source'].merge({'id' => animal['_id'] }) }
+      docs.map { |doc| doc['scientific_name'].upcase! }
+      response = bulk_helper.update(docs)
+      expect(response.status).to eq(200)
+      expect(response['items'].map { |i| i['update']['result'] }.uniq.first).to eq('updated')
+    end
+
+    it 'deletes' do
+      response = bulk_helper.ingest(docs)
+      ids = response.body['items'].map { |a| a['index']['_id'] }
+      response = bulk_helper.delete(ids)
+      expect(response.status).to eq 200
+      expect(response['items'].map { |item| item['delete']['result'] }.uniq.first).to eq('deleted')
+      expect(client.count(index: index)['count']).to eq(0)
+    end
+  end
+end

--- a/elasticsearch/spec/integration/helpers/scroll_helper_spec.rb
+++ b/elasticsearch/spec/integration/helpers/scroll_helper_spec.rb
@@ -1,0 +1,91 @@
+# Licensed to Elasticsearch B.V. under one or more contributor
+# license agreements. See the NOTICE file distributed with
+# this work for additional information regarding copyright
+# ownership. Elasticsearch B.V. licenses this file to you under
+# the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+ELASTICSEARCH_URL = ENV['TEST_ES_SERVER'] || "http://localhost:#{(ENV['PORT'] || 9200)}"
+raise URI::InvalidURIError unless ELASTICSEARCH_URL =~ /\A#{URI::DEFAULT_PARSER.make_regexp}\z/
+
+require 'spec_helper'
+require 'elasticsearch/helpers/scroll_helper'
+
+context 'Elasticsearch client helpers' do
+  let(:client) do
+    Elasticsearch::Client.new(
+      host: ELASTICSEARCH_URL,
+      user: 'elastic',
+      password: 'changeme'
+    )
+  end
+  let(:index) { 'books' }
+  let(:body) { { size: 12, query: { match_all: {} } } }
+  let(:scroll_helper) { Elasticsearch::Helpers::ScrollHelper.new(client, index, body) }
+
+  before do
+    documents = [
+      { index: { _index: index, data: {name: "Leviathan Wakes", "author": "James S.A. Corey", "release_date": "2011-06-02", "page_count": 561} } },
+      { index: { _index: index, data: {name: "Hyperion", "author": "Dan Simmons", "release_date": "1989-05-26", "page_count": 482} } },
+      { index: { _index: index, data: {name: "Dune", "author": "Frank Herbert", "release_date": "1965-06-01", "page_count": 604} } },
+      { index: { _index: index, data: {name: "Dune Messiah", "author": "Frank Herbert", "release_date": "1969-10-15", "page_count": 331} } },
+      { index: { _index: index, data: {name: "Children of Dune", "author": "Frank Herbert", "release_date": "1976-04-21", "page_count": 408} } },
+      { index: { _index: index, data: {name: "God Emperor of Dune", "author": "Frank Herbert", "release_date": "1981-05-28", "page_count": 454} } },
+      { index: { _index: index, data: {name: "Consider Phlebas", "author": "Iain M. Banks", "release_date": "1987-04-23", "page_count": 471} } },
+      { index: { _index: index, data: {name: "Pandora's Star", "author": "Peter F. Hamilton", "release_date": "2004-03-02", "page_count": 768} } },
+      { index: { _index: index, data: {name: "Revelation Space", "author": "Alastair Reynolds", "release_date": "2000-03-15", "page_count": 585} } },
+      { index: { _index: index, data: {name: "A Fire Upon the Deep", "author": "Vernor Vinge", "release_date": "1992-06-01", "page_count": 613} } },
+      { index: { _index: index, data: {name: "Ender's Game", "author": "Orson Scott Card", "release_date": "1985-06-01", "page_count": 324} } },
+      { index: { _index: index, data: {name: "1984", "author": "George Orwell", "release_date": "1985-06-01", "page_count": 328} } },
+      { index: { _index: index, data: {name: "Fahrenheit 451", "author": "Ray Bradbury", "release_date": "1953-10-15", "page_count": 227} } },
+      { index: { _index: index, data: {name: "Brave New World", "author": "Aldous Huxley", "release_date": "1932-06-01", "page_count": 268} } },
+      { index: { _index: index, data: {name: "Foundation", "author": "Isaac Asimov", "release_date": "1951-06-01", "page_count": 224} } },
+      { index: { _index: index, data: {name: "The Giver", "author": "Lois Lowry", "release_date": "1993-04-26", "page_count": 208} } },
+      { index: { _index: index, data: {name: "Slaughterhouse-Five", "author": "Kurt Vonnegut", "release_date": "1969-06-01", "page_count": 275} } },
+      { index: { _index: index, data: {name: "The Hitchhiker's Guide to the Galaxy", "author": "Douglas Adams", "release_date": "1979-10-12", "page_count": 180} } },
+      { index: { _index: index, data: {name: "Snow Crash", "author": "Neal Stephenson", "release_date": "1992-06-01", "page_count": 470} } },
+      { index: { _index: index, data: {name: "Neuromancer", "author": "William Gibson", "release_date": "1984-07-01", "page_count": 271} } },
+      { index: { _index: index, data: {name: "The Handmaid's Tale", "author": "Margaret Atwood", "release_date": "1985-06-01", "page_count": 311} } },
+      { index: { _index: index, data: {name: "Starship Troopers", "author": "Robert A. Heinlein", "release_date": "1959-12-01", "page_count": 335} } },
+      { index: { _index: index, data: {name: "The Left Hand of Darkness", "author": "Ursula K. Le Guin", "release_date": "1969-06-01", "page_count": 304} } },
+      { index: { _index: index, data: {name: "The Moon is a Harsh Mistress", "author": "Robert A. Heinlein", "release_date": "1966-04-01", "page_count": 288 } } }
+    ]
+    client.bulk(body: documents, refresh: 'wait_for')
+  end
+
+  after do
+    client.indices.delete(index: index)
+  end
+
+  it 'instantiates a scroll helper' do
+    expect(scroll_helper).to be_an_instance_of Elasticsearch::Helpers::ScrollHelper
+  end
+
+  it 'searches an index' do
+    my_documents = []
+    while !(documents = scroll_helper.results).empty?
+      my_documents << documents
+    end
+
+    expect(my_documents.flatten.size).to eq 24
+  end
+
+  it 'uses enumerable' do
+    count = 0
+    scroll_helper.each { |a| count += 1 }
+    expect(count).to eq 24
+    expect(scroll_helper).to respond_to(:count)
+    expect(scroll_helper).to respond_to(:reject)
+    expect(scroll_helper).to respond_to(:uniq)
+    expect(scroll_helper.map { |a| a['_id'] }.uniq.count).to eq 24
+  end
+end


### PR DESCRIPTION
This Pull request adds a **BulkHelper** and a **ScrollHelper**:

# Bulk Helper

This helper aims to provide a nicer developer experience when using the Bulk API. At its simplest, you can send it a collection of Hashes in an Array, and it will bulk ingest them into Elasticsearch. To use the BulkHelper, you need to require it in your code:

```ruby
require 'elasticsearch/helpers/bulk_helper'
```

You need to instantiate a BulkHelper with a client, and an index:
```ruby
client = Elasticsearch::Client.new
bulk_helper = Elasticsearch::Helpers::BulkHelper.new(client, index)
```

This helper will work on the index you pass in during initialization, but you can change the index any time in your code:

```ruby
bulk_helper.index = 'new_index'
```

If you want to index a collection of documents, you can use the `ingest` method:

```ruby
documents = [
  { name: 'document1', date: '2024-05-16' },
  { name: 'document2', date: '2023-12-19' },
  { name: 'document3', date: '2024-07-07' }
]
bulk_helper.ingest(documents)
```

If you're ingesting a large set of data and want to separate the documents into smaller pieces before sending them to Elasticsearch, you can use the `slice` parameter.

```ruby
bulk_helper.ingest(documents, { slice: 2 })
```

In this case, the data will be sent in two different bulk requests.

You can also send the parameters you would send to the Bulk API in the query parameters or body. The method signature is `ingest(docs, params = {}, body = {}, &block)`. The method can be called with a block, that will yield the response object from calling the Bulk API and the documents sent in the request.

```ruby
helper.ingest(documents) { |_, docs| puts "Ingested #{docs.count} documents" }
```

# Scroll Helper

This helper provides an easy way to get results from a Scroll.

To use the ScrollHelper, you need to require it in your code:

```ruby
require 'elasticsearch/helpers/scroll_helper'
```

You need to instantiate a ScrollHelper with a client, an index, and a body (with the scroll API parameters) which will be used in every following scroll request:

```ruby
client = Elasticsearch::Client.new
scroll_helper = Elasticsearch::Helpers::ScrollHelper.new(client, index, body)
```

There are two ways to get the results from a scroll using the helper.

You can iterate over a scroll using the methods in `Enumerable` such as `each` and `map`:

```ruby
scroll_helper.each do |item|
  puts item
end
```

You can fetch results by page, with the `results` function:

```ruby
my_documents = []
while !(documents = scroll_helper.results).empty?
  my_documents << documents
end
scroll_helper.clear
```
