### PR TITLE
[DOCS] Updates the getting started button link on the landing page. #2144

### DIFF
--- a/docs/index-custom-title-page.html
+++ b/docs/index-custom-title-page.html
@@ -63,7 +63,7 @@
         The official Ruby client provides one-to-one mapping with Elasticsearch REST APIs.
       </p>
       <p>
-        <a href="https://www.elastic.co/guide/en/elasticsearch/client/ruby-api/current/ruby-install.html">
+        <a href="https://www.elastic.co/guide/en/elasticsearch/client/ruby-api/current/getting-started-ruby.html">
           <button class="btn btn-primary">Get started</button>
         </a>
       </p>


### PR DESCRIPTION
Backports https://github.com/elastic/elasticsearch-ruby/pull/2144