### PR TITLE
[DOCS] Correct the description of the default value for retry_on_failure

### DIFF
--- a/docs/advanced-config.asciidoc
+++ b/docs/advanced-config.asciidoc
@@ -232,7 +232,7 @@ failed request on a different host:
 Elasticsearch::Client.new(hosts: ['localhost:9200', 'localhost:9201'], retry_on_failure: true)
 ```
 
-By default, the client retries the request 3 times. You can specify how many 
+By default, the client does not retry the request. You can specify how many 
 times to retry before it raises an exception by passing a number to 
 `retry_on_failure`:
 


### PR DESCRIPTION
## Overview
I noticed a discrepancy in the documentation regarding the default value of the `retry_on_failure` configuration.
The documentation currently states that the default value is `3 times`, but upon checking [the source code](https://github.com/elastic/elastic-transport-ruby/blob/6a4d0d07e077aed4ea5c80de80b7ceb5f8eb251d/lib/elastic/transport/client.rb#L129
), it's actually set to `false`.

This PR corrects the description of the default value `for retry_on_failure`.

As an additional note, [the basic configuration page](https://www.elastic.co/guide/en/elasticsearch/client/ruby-api/current/basic-config.html) has the correct default values.

### Preview
[advanced-config.asciidoc](https://github.com/rince/elasticsearch-ruby/blob/2c3b703b09bc589b76987d0cb1a94f19a7dc0eb0/docs/advanced-config.asciidoc#retrying-on-failures)