### PR TITLE
Updated project metadata to use group email address

### DIFF
--- a/elasticsearch-api/elasticsearch-api.gemspec
+++ b/elasticsearch-api/elasticsearch-api.gemspec
@@ -23,8 +23,8 @@ require 'elasticsearch/api/version'
 Gem::Specification.new do |s|
   s.name          = 'elasticsearch-api'
   s.version       = Elasticsearch::API::VERSION
-  s.authors       = ['Karel Minarik', 'Emily Stolfo', 'Fernando Briano']
-  s.email         = ['clients-team@elastic.co']
+  s.authors       = ['Elastic Client Library Maintainers']
+  s.email         = ['client-libs@elastic.co']
   s.summary       = 'Ruby API for Elasticsearch.'
   s.homepage      = 'https://www.elastic.co/guide/en/elasticsearch/client/ruby-api/current/index.html'
   s.license       = 'Apache-2.0'

--- a/elasticsearch/elasticsearch.gemspec
+++ b/elasticsearch/elasticsearch.gemspec
@@ -22,8 +22,8 @@ require 'elasticsearch/version'
 Gem::Specification.new do |s|
   s.name          = 'elasticsearch'
   s.version       = Elasticsearch::VERSION
-  s.authors       = ['Karel Minarik', 'Emily Stolfo', 'Fernando Briano']
-  s.email         = ['clients-team@elastic.co']
+  s.authors       = ['Elastic Client Library Maintainers']
+  s.email         = ['client-libs@elastic.co']
   s.summary       = 'Ruby integrations for Elasticsearch'
   s.homepage      = 'https://www.elastic.co/guide/en/elasticsearch/client/ruby-api/current/index.html'
   s.license       = 'Apache-2.0'


### PR DESCRIPTION
This PR removes individual names and email addresses and replaces those with the new (external) [group email address](mailto:client-libs@elastic.co).