### PR TITLE
Transport testing

### DIFF
--- a/.buildkite/Dockerfile
+++ b/.buildkite/Dockerfile
@@ -12,6 +12,7 @@ ARG QUIET=${QUIET:-true}
 ARG CI=${CI:-false}
 ENV QUIET=$QUIET
 ENV CI=$CI
+ARG TRANSPORT_VERSION=${TRANSPORT_VERSION:-8}
 
 # Install required tools
 RUN apt-get -q update \

--- a/.buildkite/functions/wait-for-container.sh
+++ b/.buildkite/functions/wait-for-container.sh
@@ -14,7 +14,7 @@ function wait_for_container {
     echo ""
     docker inspect -f "{{range .State.Health.Log}}{{.Output}}{{end}}" ${1}
     echo -e "\033[34;1mINFO:\033[0m waiting for node $1 to be up\033[0m"
-    sleep 2;
+    sleep 5;
   done;
 
   # Always show logs if the container is running, this is very useful both on CI as well as while developing

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,11 +1,12 @@
 steps:
-  - label: ":elasticsearch: :ruby: ES Ruby ({{ matrix.ruby }}) Test Suite: {{ matrix.suite }}"
+  - label: ":ruby: v{{ matrix.ruby }} :phone: Transport: {{ matrix.transport }} :elasticsearch: Suite: {{ matrix.suite }}"
     agents:
       provider: "gcp"
     env:
       RUBY_VERSION: "{{ matrix.ruby }}"
       TEST_SUITE: "{{ matrix.suite }}"
       STACK_VERSION: 8.10.0-SNAPSHOT
+      TRANSPORT_VERSION: "{{ matrix.transport }}"
     matrix:
       setup:
         suite:
@@ -15,6 +16,8 @@ steps:
           - "3.2"
           - "3.1"
           - "3.0"
+        transport:
+          - "8.2"
       # Only run platinum once for the latest Ruby. You can use lots of combinations, check the
       # documentation on https://buildkite.com/docs/pipelines/build-matrix for more information.
       adjustments:
@@ -26,6 +29,18 @@ steps:
             suite: "platinum"
             ruby: "3.0"
           skip: true
+        - with:
+            suite: "free"
+            ruby: "3.2"
+            transport: "8.0"
+        - with:
+            suite: "free"
+            ruby: "3.2"
+            transport: "8.1"
+        - with:
+            suite: "free"
+            ruby: "3.2"
+            transport: "main"
     command: ./.buildkite/run-tests.sh
     # I'm publishing test results to HTML and JUnit in this directory and this directive makes them
     # available in the Artifacts tab of a build in Buildkite.

--- a/.buildkite/run-client.sh
+++ b/.buildkite/run-client.sh
@@ -7,12 +7,14 @@ set -euo pipefail
 repo=`pwd`
 
 export RUBY_VERSION=${RUBY_VERSION:-3.1}
+export TRANSPORT_VERSION=${TRANSPORT_VERSION:-8}
 
 echo "--- :ruby: Building Docker image"
 docker build \
        --file $script_path/Dockerfile \
        --tag elastic/elasticsearch-ruby \
        --build-arg RUBY_VERSION=$RUBY_VERSION \
+       --build-arg TRANSPORT_VERSION=$TRANSPORT_VERSION \
        .
 
 mkdir -p elasticsearch-api/tmp
@@ -26,6 +28,7 @@ docker run \
        --env "TEST_SUITE=${TEST_SUITE}" \
        --env "ELASTIC_USER=elastic" \
        --env "BUILDKITE=true" \
+       --env "TRANSPORT_VERSION=${TRANSPORT_VERSION}" \
        --volume $repo:/usr/src/app \
        --name elasticsearch-ruby \
        --rm \

--- a/.buildkite/run-tests.sh
+++ b/.buildkite/run-tests.sh
@@ -11,5 +11,4 @@ set -euo pipefail
 echo "--- :elasticsearch: Starting Elasticsearch"
 DETACH=true bash $script_path/run-elasticsearch.sh
 
-echo "+++ :ruby: Run Client"
 bash $script_path/run-client.sh

--- a/elasticsearch-api/spec/rest_api/rest_api_yaml_spec.rb
+++ b/elasticsearch-api/spec/rest_api/rest_api_yaml_spec.rb
@@ -22,6 +22,8 @@ require_relative './run_rspec_matchers'
 LOGGER = Logger.new($stdout)
 
 describe 'Rest API YAML tests' do
+  LOGGER.info "Elastic Transport version: #{Elastic::Transport::VERSION}"
+
   if REST_API_YAML_FILES.empty?
     LOGGER.error 'No test files found!'
     LOGGER.info 'Use rake rake elasticsearch:download_artifacts in the root directory of the project to download the test artifacts.'

--- a/elasticsearch/Gemfile
+++ b/elasticsearch/Gemfile
@@ -25,3 +25,7 @@ gemspec
 if File.exist? File.expand_path('../elasticsearch-api/elasticsearch-api.gemspec', __dir__)
   gem 'elasticsearch-api', path: File.expand_path('../elasticsearch-api', __dir__), require: false
 end
+
+if ENV['TRANSPORT_VERSION'] == 'main'
+  gem 'elastic-transport', git: 'https://github.com/elastic/elastic-transport-ruby.git', branch: 'main'
+end

--- a/elasticsearch/elasticsearch.gemspec
+++ b/elasticsearch/elasticsearch.gemspec
@@ -45,7 +45,15 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = '>= 2.5'
 
-  s.add_dependency 'elastic-transport', '~> 8'
+  transport_version = ENV.fetch('TRANSPORT_VERSION', '8')
+  if ['8', 'main'].include? transport_version
+    s.add_dependency 'elastic-transport', '~> 8'
+  else
+    major_version = transport_version.gsub(/[0-9]+$/, '')
+    next_minor_version = transport_version.gsub(/[0-9]+\./, '').to_i + 1
+    s.add_dependency 'elastic-transport', "~> #{transport_version}", "< #{major_version}#{next_minor_version}"
+  end
+
   s.add_dependency 'elasticsearch-api', '8.11.0'
 
   s.add_development_dependency 'bundler'


### PR DESCRIPTION
This Pull Requests adds integration testing with the different available releases of `elastic-transport`: `8.0.x`, `8.1.x`, `8.2.x` and `main`.

The full test matrix is now:
- `free` test suite: 
  - Ruby `3.0`, `3.1` and `3.2` with the latest stable release of `elastic-transport`.
  - Elastic Transport versions `8.0`, `8.1`, `8.2` and `main` with the latest release of Ruby.
- `platinum` test suite with the latest stable Ruby and elastic-transport releases. 

![image](https://github.com/elastic/elasticsearch-ruby/assets/689327/d84abdc1-6b6d-407b-b4d8-8da267c4db6a)
