### PR TITLE
Update transport 7.17

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -15,8 +15,6 @@ steps:
           - "3.2"
           - "3.1"
           - "3.0"
-          - "2.7"
-          - "2.6"
         stack_version:
           - 7.17-SNAPSHOT
       adjustments:
@@ -28,14 +26,6 @@ steps:
         - with:
             suite: "platinum"
             ruby: "3.0"
-          skip: true
-        - with:
-            suite: "platinum"
-            ruby: "2.7"
-          skip: true
-        - with:
-            suite: "platinum"
-            ruby: "2.6"
           skip: true
         # Compatibility tests for 8.x:
         - with:

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -29,11 +29,11 @@ steps:
           skip: true
         # Compatibility tests for 8.x:
         - with:
-            stack_version: "8.8-SNAPSHOT"
+            stack_version: "8.9.1-SNAPSHOT"
             suite: "free"
             ruby: "3.2"
         - with:
-            stack_version: "8.8-SNAPSHOT"
+            stack_version: "8.9.1-SNAPSHOT"
             suite: "platinum"
             ruby: "3.2"
     command: ./.buildkite/run-tests.sh

--- a/.github/workflows/7.17-8.x.yml
+++ b/.github/workflows/7.17-8.x.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: [ '3.1' ]
+        ruby: [ '3.2' ]
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/7.17-8.x.yml
+++ b/.github/workflows/7.17-8.x.yml
@@ -26,7 +26,7 @@ jobs:
         sudo sysctl -w vm.max_map_count=262144
     - uses: elastic/elastic-github-actions/elasticsearch@master
       with:
-        stack-version: 8.8-SNAPSHOT
+        stack-version: 8.9-SNAPSHOT
         security-enabled: false
     - uses: ruby/setup-ruby@v1
       with:

--- a/.github/workflows/7.17.yml
+++ b/.github/workflows/7.17.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: [ '2.6', '2.7', '3.0', '3.1', 'jruby-9.3' ]
+        ruby: [ '3.0', '3.1', '3.2', 'jruby-9.3', 'jruby-9.4' ]
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 7.17.8
+
+- Patch releases back to being detached from Elastic stack releases.
+- Tested compatibility with Elasticsearch v7.17 APIs.
+- Tested versions of Ruby for 7.17.8: Ruby (MRI) 2.7, 3.0, 3.1, 3.2, JRuby 9.3, JRuby 9.4.
+- Bugfix in elasticsearch-transport: Fixes enforcing UTF-8 in Response body, causing an error when the string is frozen, particularly when using webmock: [issue #63](https://github.com/elastic/elastic-transport-ruby/issues/63).
+
 ## 7.17.7
 
 - Compatibility with Elasticsearch v7.17.7 APIs.

--- a/api-spec-testing/wipe_cluster.rb
+++ b/api-spec-testing/wipe_cluster.rb
@@ -170,7 +170,8 @@ module Elasticsearch
           '.snapshot-blob-cache', '.deprecation-indexing-template',
           '.deprecation-indexing-mappings', '.deprecation-indexing-settings',
           'security-index-template', 'data-streams-mappings',
-          'behavioral_analytics-events-mappings', 'behavioral_analytics-events-settings'
+          'behavioral_analytics-events-mappings', 'behavioral_analytics-events-settings',
+          'ecs@dynamic_templates'
         ].freeze
 
         def xpack_template?(template)

--- a/docs/release_notes/717.asciidoc
+++ b/docs/release_notes/717.asciidoc
@@ -2,6 +2,16 @@
 === 7.17 Release notes
 
 [discrete]
+[[release_notes_7178]]
+=== 7.17.8 Release notes
+
+- Patch releases back to being detached from Elastic stack releases.
+- Tested compatibility with latest releases of Elasticsearch v7.17 APIs.
+- Tested versions of Ruby for 7.17.8: Ruby (MRI) 2.7, 3.0, 3.1, 3.2, JRuby 9.3, JRuby 9.4.
+- Bugfix in elasticsearch-transport: Fixes enforcing UTF-8 in Response body, causing an error when the string is frozen, particularly when using webmock: https://github.com/elastic/elastic-transport-ruby/issues/63[issue #63].
+
+
+[discrete]
 [[release_notes_7177]]
 === 7.17.7 Release notes
 

--- a/elasticsearch-api/lib/elasticsearch/api/version.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/version.rb
@@ -17,6 +17,6 @@
 
 module Elasticsearch
   module API
-    VERSION = '7.17.12'.freeze
+    VERSION = '7.17.8'.freeze
   end
 end

--- a/elasticsearch-transport/lib/elasticsearch/transport/transport/response.rb
+++ b/elasticsearch-transport/lib/elasticsearch/transport/transport/response.rb
@@ -28,7 +28,7 @@ module Elasticsearch
         # @param headers [Hash]    Response headers
         def initialize(status, body, headers={})
           @status, @body, @headers = status, body, headers
-          @body = body.force_encoding('UTF-8') if body.respond_to?(:force_encoding)
+          @body = body.force_encoding('UTF-8') if body.respond_to?(:force_encoding) && !body.frozen?
         end
       end
 

--- a/elasticsearch-transport/lib/elasticsearch/transport/version.rb
+++ b/elasticsearch-transport/lib/elasticsearch/transport/version.rb
@@ -17,6 +17,6 @@
 
 module Elasticsearch
   module Transport
-    VERSION = '7.17.12'.freeze
+    VERSION = '7.17.8'.freeze
   end
 end

--- a/elasticsearch-xpack/lib/elasticsearch/xpack/version.rb
+++ b/elasticsearch-xpack/lib/elasticsearch/xpack/version.rb
@@ -17,6 +17,6 @@
 
 module Elasticsearch
   module XPack
-    VERSION = '7.17.12'.freeze
+    VERSION = '7.17.8'.freeze
   end
 end

--- a/elasticsearch-xpack/spec/skipped_tests_8.yml
+++ b/elasticsearch-xpack/spec/skipped_tests_8.yml
@@ -154,6 +154,27 @@
 -
   :file: 'token/11_invalidation.yml'
   :description: 'Test invalidate refresh token return statuses'
-
-
-
+-
+  :file: 'analytics/boxplot.yml'
+  :description: '*'
+-
+  :file: 'analytics/moving_percentile.yml'
+  :description: 'Basic Search TDigest'
+-
+  :file: 'ml/evaluate_data_frame.yml'
+  :description: 'Test outlier_detection auc_roc'
+-
+  :file: 'ml/evaluate_data_frame.yml'
+  :description: 'Test outlier_detection auc_roc given actual_field is int'
+-
+  :file: 'ml/evaluate_data_frame.yml'
+  :description: 'Test outlier_detection auc_roc include curve'
+-
+  :file: 'ml/evaluate_data_frame.yml'
+  :description: 'Test outlier_detection auc_roc with default top_classes_field'
+-
+  :file: 'ml/evaluate_data_frame.yml'
+  :description: 'Test classification auc_roc'
+-
+  :file: 'ml/evaluate_data_frame.yml'
+  :description: 'Test classification auc_roc with default top_classes_field'

--- a/elasticsearch/elasticsearch.gemspec
+++ b/elasticsearch/elasticsearch.gemspec
@@ -45,8 +45,8 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = '>= 2.4'
 
-  s.add_dependency 'elasticsearch-transport', '7.17.12'
-  s.add_dependency 'elasticsearch-api',       '7.17.12'
+  s.add_dependency 'elasticsearch-transport', '7.17.8'
+  s.add_dependency 'elasticsearch-api',       '7.17.8'
 
   s.add_development_dependency 'bundler'
   s.add_development_dependency 'byebug' unless defined?(JRUBY_VERSION) || defined?(Rubinius)

--- a/elasticsearch/lib/elasticsearch/version.rb
+++ b/elasticsearch/lib/elasticsearch/version.rb
@@ -16,5 +16,5 @@
 # under the License.
 
 module Elasticsearch
-  VERSION = '7.17.12'.freeze
+  VERSION = '7.17.8'.freeze
 end


### PR DESCRIPTION
General updates for `7.17` and `7.17.8` release with backport in `elasticsearch-transport` from [pull request 64](https://github.com/elastic/elastic-transport-ruby/pull/64).