### PR TITLE
Enable elasticsearch-transport v7 to use Faraday >=2

### DIFF
--- a/.github/workflows/7.17.yml
+++ b/.github/workflows/7.17.yml
@@ -40,7 +40,7 @@ jobs:
     - name: elasticsearch
       run: cd elasticsearch && bundle exec rake test:all
     - name: elasticsearch-transport faraday1
-      run: cd elasticsearch-transport && bundle install && bundle exec rake test:all
+      run: cd elasticsearch-transport && bundle install && bundle exec rake test:faraday1:all
       env:
         BUNDLE_GEMFILE: 'Gemfile-faraday1.gemfile'
     - name: elasticsearch-transport faraday2

--- a/.github/workflows/7.17.yml
+++ b/.github/workflows/7.17.yml
@@ -39,7 +39,11 @@ jobs:
         rake bundle:install
     - name: elasticsearch
       run: cd elasticsearch && bundle exec rake test:all
-    - name: elasticsearch-transport
+    - name: elasticsearch-transport faraday1
+      run: cd elasticsearch-transport && bundle install && bundle exec rake test:all
+      env:
+        BUNDLE_GEMFILE: 'Gemfile-faraday1.gemfile'
+    - name: elasticsearch-transport faraday2
       run: cd elasticsearch-transport && bundle exec rake test:all
     - name: elasticsearch-api
       run: cd elasticsearch-api && bundle exec rake test:spec

--- a/elasticsearch-transport/Gemfile-faraday1.gemfile
+++ b/elasticsearch-transport/Gemfile-faraday1.gemfile
@@ -17,8 +17,13 @@
 
 source 'https://rubygems.org'
 
-# Specify your gem's dependencies in elasticsearch-transport.gemspec
-gemspec
+# Usage:
+#
+# $ BUNDLE_GEMFILE=./Gemfile-faraday1.gemfile bundle install
+# $ BUNDLE_GEMFILE=./Gemfile-faraday1.gemfile bundle exec rake test:faraday1:unit
+
+gem 'faraday', '~> 1'
+gemspec path: './'
 
 if File.exist? File.expand_path('../elasticsearch-api/elasticsearch-api.gemspec', __dir__)
   gem 'elasticsearch-api', path: File.expand_path('../elasticsearch-api', __dir__), require: false
@@ -29,14 +34,14 @@ if File.exist? File.expand_path('../elasticsearch/elasticsearch.gemspec', __dir_
 end
 
 group :development, :test do
-  gem 'faraday-httpclient'
-  gem 'faraday-net_http_persistent'
-  gem 'faraday-patron' unless defined? JRUBY_VERSION
-  gem 'faraday-typhoeus'
+  gem 'httpclient'
+  gem 'net-http-persistent'
+  gem 'patron' unless defined? JRUBY_VERSION
+  gem 'typhoeus'
   gem 'rspec'
   if defined?(JRUBY_VERSION)
     gem 'pry-nav'
   else
-    gem 'pry-byebug', '~> 3.9'
+    gem 'pry-byebug'
   end
 end

--- a/elasticsearch-transport/Rakefile
+++ b/elasticsearch-transport/Rakefile
@@ -25,6 +25,15 @@ task :test    => 'test:unit'
 
 require 'rake/testtask'
 require 'rspec/core/rake_task'
+FARADAY1_GEMFILE = 'Gemfile-faraday1.gemfile'.freeze
+GEMFILES = ['Gemfile', FARADAY1_GEMFILE].freeze
+
+task :install do
+  GEMFILES.each do |gemfile|
+    gemfile = File.expand_path("../#{gemfile}", __FILE__)
+    sh "bundle install --gemfile #{gemfile}"
+  end
+end
 
 namespace :test do
   desc 'Wait for Elasticsearch to be in a green state'
@@ -52,12 +61,41 @@ namespace :test do
   desc 'Run all tests'
   task :all do
     Rake::Task['test:unit'].invoke
+    Rake::Task['test:spec'].invoke
     Rake::Task['test:integration'].invoke
   end
 
   Rake::TestTask.new(:profile) do |test|
     test.libs << 'lib' << 'test'
     test.test_files = FileList['test/profile/**/*_test.rb']
+  end
+
+  namespace :faraday1 do
+    desc 'Faraday 1: Run RSpec with dependency on Faraday 1'
+    task :spec do
+      sh "BUNDLE_GEMFILE=#{FARADAY1_GEMFILE} bundle exec rspec"
+    end
+
+    desc 'Faraday 1: Run unit tests with dependency on Faraday 1'
+    task :unit do
+      Dir.glob('./test/unit/**/**.rb').each do |test|
+        sh "BUNDLE_GEMFILE=#{FARADAY1_GEMFILE} ruby -Ilib:test #{test}"
+      end
+    end
+
+    desc 'Faraday 1: Run integration tests with dependency on Faraday 1'
+    task :integration do
+      Dir.glob('./test/integration/**/**.rb').each do |test|
+        sh "BUNDLE_GEMFILE=#{FARADAY1_GEMFILE} ruby -Ilib:test #{test}"
+      end
+    end
+
+    desc 'Faraday 1: Run all tests'
+    task :all do
+      Rake::Task['test:faraday1:unit'].invoke
+      Rake::Task['test:faraday1:spec'].invoke
+      Rake::Task['test:faraday1:integration'].invoke
+    end
   end
 
   namespace :cluster do

--- a/elasticsearch-transport/elasticsearch-transport.gemspec
+++ b/elasticsearch-transport/elasticsearch-transport.gemspec
@@ -45,21 +45,20 @@ Gem::Specification.new do |s|
   s.required_ruby_version = '>= 2.4'
 
   s.add_dependency 'multi_json'
-  s.add_dependency 'faraday', '~> 1'
+  s.add_dependency 'faraday', '>= 1', '< 3'
 
+  # Faraday Adapters
+  s.add_development_dependency 'manticore' if defined? JRUBY_VERSION
+  s.add_development_dependency 'curb' unless defined? JRUBY_VERSION
   s.add_development_dependency 'ansi'
   s.add_development_dependency 'bundler'
   s.add_development_dependency 'cane'
-  s.add_development_dependency 'curb' unless defined? JRUBY_VERSION
   s.add_development_dependency 'elasticsearch', ['>= 7', '< 8.0.0']
   s.add_development_dependency 'elasticsearch-extensions'
   s.add_development_dependency 'hashie'
-  s.add_development_dependency 'httpclient'
-  s.add_development_dependency 'manticore' if defined? JRUBY_VERSION
   s.add_development_dependency 'minitest'
   s.add_development_dependency 'minitest-reporters'
   s.add_development_dependency 'mocha'
-  s.add_development_dependency 'net-http-persistent'
   s.add_development_dependency 'patron' unless defined? JRUBY_VERSION
   s.add_development_dependency 'pry'
   s.add_development_dependency 'rake', '~> 13'
@@ -68,7 +67,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'shoulda-context'
   s.add_development_dependency 'simplecov'
   s.add_development_dependency 'test-unit', '~> 2'
-  s.add_development_dependency 'typhoeus', '~> 1.4'
   s.add_development_dependency 'yard'
 
   s.description = <<-DESC.gsub(/^    /, '')

--- a/elasticsearch-transport/spec/elasticsearch/transport/base_spec.rb
+++ b/elasticsearch-transport/spec/elasticsearch/transport/base_spec.rb
@@ -145,7 +145,8 @@ describe Elasticsearch::Transport::Transport::Base do
     let(:arguments) do
       {
         hosts: ['http://unavailable:9200', 'http://unavailable:9201'],
-        retry_on_failure: 2
+        retry_on_failure: 2,
+        adapter: :net_http
       }
     end
 
@@ -169,7 +170,8 @@ describe Elasticsearch::Transport::Transport::Base do
       let(:arguments) do
         {
           hosts: ELASTICSEARCH_HOSTS,
-          retry_on_status: ['404']
+          retry_on_status: ['404'],
+          adapter: :net_http
         }
       end
 

--- a/elasticsearch-transport/spec/elasticsearch/transport/client_spec.rb
+++ b/elasticsearch-transport/spec/elasticsearch/transport/client_spec.rb
@@ -234,8 +234,8 @@ describe Elasticsearch::Transport::Client do
         it 'uses Faraday NetHttp' do
           expect(adapter).to eq Faraday::Adapter::NetHttp
         end
-      end unless jruby?
-    end
+      end
+    end unless jruby?
 
     context 'when the adapter is patron' do
       let(:adapter) do
@@ -247,9 +247,10 @@ describe Elasticsearch::Transport::Client do
       end
 
       it 'uses Faraday with the adapter' do
+        require 'faraday/patron'
         expect(adapter).to eq Faraday::Adapter::Patron
       end
-    end
+    end unless jruby?
 
     context 'when the adapter is typhoeus' do
       let(:adapter) do
@@ -257,6 +258,8 @@ describe Elasticsearch::Transport::Client do
       end
 
       let(:client) do
+        require 'faraday/typhoeus' if is_faraday_v2?
+
         described_class.new(adapter: :typhoeus, enable_meta_header: false)
       end
 
@@ -277,7 +280,7 @@ describe Elasticsearch::Transport::Client do
       it 'uses Faraday with the adapter' do
         expect(adapter).to eq Faraday::Adapter::Patron
       end
-    end
+    end unless jruby?
 
     context 'when the adapter can be detected', unless: jruby? do
 
@@ -319,7 +322,7 @@ describe Elasticsearch::Transport::Client do
       it 'sets the logger' do
         expect(handlers).to include(Faraday::Response::Logger)
       end
-    end
+    end unless jruby?
   end
 
   context 'when cloud credentials are provided' do
@@ -1587,6 +1590,8 @@ describe Elasticsearch::Transport::Client do
         end
 
         context 'when the Faraday adapter is set in the block' do
+          require 'faraday/net_http_persistent' if is_faraday_v2?
+
           let(:client) do
             described_class.new(host: ELASTICSEARCH_HOSTS.first, logger: logger) do |client|
               client.adapter(:net_http_persistent)
@@ -1747,6 +1752,7 @@ describe Elasticsearch::Transport::Client do
           end
 
           context 'when using the HTTPClient adapter' do
+            require 'faraday/httpclient'
 
             let(:client) do
               described_class.new(hosts: ELASTICSEARCH_HOSTS, compression: true, adapter: :httpclient, enable_meta_header: false)

--- a/elasticsearch-transport/spec/elasticsearch/transport/meta_header_spec.rb
+++ b/elasticsearch-transport/spec/elasticsearch/transport/meta_header_spec.rb
@@ -172,7 +172,7 @@ describe Elasticsearch::Transport::Client do
           expect(headers).to include('x-elastic-client-meta' => meta)
 
           Typhoeus = @klass if was_required
-        end unless jruby?
+        end
 
         it 'sets adapter in the meta header' do
           require 'typhoeus'
@@ -180,7 +180,7 @@ describe Elasticsearch::Transport::Client do
           meta = "#{meta_header},ty=#{Typhoeus::VERSION}"
           expect(headers).to include('x-elastic-client-meta' => meta)
         end
-      end
+      end unless jruby?
 
       unless jruby?
         let(:adapter) { :patron }

--- a/elasticsearch-transport/spec/spec_helper.rb
+++ b/elasticsearch-transport/spec/spec_helper.rb
@@ -75,6 +75,10 @@ def default_client
   $client ||= Elasticsearch::Client.new(hosts: ELASTICSEARCH_HOSTS)
 end
 
+def is_faraday_v2?
+  Gem::Version.new(Faraday::VERSION) >= Gem::Version.new(2)
+end
+
 module Config
   def self.included(context)
     # Get the hosts to use to connect an elasticsearch client.

--- a/elasticsearch-transport/test/integration/transport_test.rb
+++ b/elasticsearch-transport/test/integration/transport_test.rb
@@ -17,7 +17,7 @@
 
 require 'test_helper'
 
-class Elasticsearch::Transport::ClientIntegrationTest < Elasticsearch::Test::IntegrationTestCase
+class Elasticsearch::Transport::Transport::ClientIntegrationTest < Elasticsearch::Test::IntegrationTestCase
   startup do
     Elasticsearch::Extensions::Test::Cluster.start(number_of_nodes: 2) if ENV['SERVER'] and not Elasticsearch::Extensions::Test::Cluster.running?(number_of_nodes: 2)
   end
@@ -30,69 +30,115 @@ class Elasticsearch::Transport::ClientIntegrationTest < Elasticsearch::Test::Int
     setup do
       @host, @port = ELASTICSEARCH_HOSTS.first.split(':')
       @hosts = { hosts: [ { host: @host, port: @port } ] }
-      begin; Object.send(:remove_const, :Patron);   rescue NameError; end
     end
 
-    should "allow to customize the Faraday adapter to Typhoeus" do
-      require 'typhoeus'
-      require 'typhoeus/adapters/faraday'
-
+    should "use the default Faraday adapter" do
       transport = Elasticsearch::Transport::Transport::HTTP::Faraday.new(@hosts) do |f|
         f.response :logger
-        f.adapter  :typhoeus
       end
 
       client = Elasticsearch::Transport::Client.new transport: transport
-      client.perform_request 'GET', ''
-    end unless jruby?
-
-    should "allow to customize the Faraday adapter to NetHttpPersistent" do
-      require 'net/http/persistent'
-
-      transport = Elasticsearch::Transport::Transport::HTTP::Faraday.new(@hosts) do |f|
-        f.response :logger
-        f.adapter  :net_http_persistent
-      end
-
-      client = Elasticsearch::Transport::Client.new transport: transport
+      assert_equal(client.transport.connections.first.connection.adapter, Faraday::Adapter::NetHttp)
       client.perform_request 'GET', ''
     end
 
-    should "allow to define connection parameters and pass them" do
-      transport = Elasticsearch::Transport::Transport::HTTP::Faraday.new(
-        hosts: [ { host: @host, port: @port } ],
-        options: { transport_options: { params: { :format => 'yaml' } } }
-      )
-      client = Elasticsearch::Transport::Client.new transport: transport
-      response = client.perform_request 'GET', ''
+    unless jruby?
+      should "allow to customize the Faraday adapter to Typhoeus" do
+        if is_faraday_v2?
+          require 'faraday/typhoeus'
+        else
+          require 'typhoeus'
+        end
 
-      assert response.body.start_with?("---\n"), "Response body should be YAML: #{response.body.inspect}"
+        transport = Elasticsearch::Transport::Transport::HTTP::Faraday.new(@hosts) do |f|
+          f.response :logger
+          f.adapter  :typhoeus
+        end
+
+        client = Elasticsearch::Transport::Client.new transport: transport
+        assert_equal(client.transport.connections.first.connection.adapter, Faraday::Adapter::Typhoeus)
+        client.perform_request 'GET', ''
+      end
+
+      should "use the Curb client" do
+        require 'curb'
+        require 'elasticsearch/transport/transport/http/curb'
+        transport = Elasticsearch::Transport::Transport::HTTP::Curb.new(@hosts) do |curl|
+          curl.verbose = true
+        end
+
+        client = Elasticsearch::Transport::Client.new transport: transport
+        assert_equal(client.transport.class, Elasticsearch::Transport::Transport::HTTP::Curb)
+        client.perform_request 'GET', ''
+      end
+
+      should "deserialize JSON responses in the Curb client" do
+        require 'curb'
+        require 'elasticsearch/transport/transport/http/curb'
+        transport = Elasticsearch::Transport::Transport::HTTP::Curb.new(@hosts) do |curl|
+          curl.verbose = true
+        end
+
+        client = Elasticsearch::Transport::Client.new transport: transport
+        response = client.perform_request 'GET', ''
+
+        assert_respond_to(response.body, :to_hash)
+        assert_not_nil response.body['name']
+        assert_equal 'application/json', response.headers['content-type']
+      end
+
+      should 'allow to customize the Faraday adapter to Patron' do
+        if is_faraday_v2?
+          require 'faraday/patron'
+        else
+          require 'patron'
+        end
+        transport = Elasticsearch::Transport::Transport::HTTP::Faraday.new(@hosts) do |f|
+          f.response :logger
+          f.adapter  :patron
+        end
+
+        client = Elasticsearch::Transport::Client.new(transport: transport)
+        assert_equal(client.transport.connections.first.connection.adapter, Faraday::Adapter::Patron)
+        client.perform_request 'GET', ''
+      end
+
+      should "allow to customize the Faraday adapter to NetHttpPersistent" do
+        require 'faraday/net_http_persistent'
+
+        transport = Elasticsearch::Transport::Transport::HTTP::Faraday.new(@hosts) do |f|
+          f.response :logger
+          f.adapter  :net_http_persistent
+        end
+
+        client = Elasticsearch::Transport::Client.new transport: transport
+        assert_equal(client.transport.connections.first.connection.adapter, Faraday::Adapter::NetHttpPersistent)
+        client.perform_request 'GET', ''
+      end
+
+      should 'allow to customize the Faraday adapter to HTTPClient' do
+        require 'faraday/httpclient'
+
+        transport = Elasticsearch::Transport::Transport::HTTP::Faraday.new(@hosts) do |f|
+          f.response :logger
+          f.adapter  :httpclient
+        end
+
+        client = Elasticsearch::Transport::Client.new(transport: transport)
+        assert_equal(client.transport.connections.first.connection.adapter, Faraday::Adapter::HTTPClient)
+        client.perform_request 'GET', ''
+      end
+
+      should "allow to define connection parameters and pass them" do
+        transport = Elasticsearch::Transport::Transport::HTTP::Faraday.new(
+          hosts: [ { host: @host, port: @port } ],
+          options: { transport_options: { params: { :format => 'yaml' } } }
+        )
+        client = Elasticsearch::Transport::Client.new transport: transport
+        response = client.perform_request 'GET', ''
+
+        assert response.body.start_with?("---\n"), "Response body should be YAML: #{response.body.inspect}"
+      end
     end
-
-    should "use the Curb client" do
-      require 'curb'
-      require 'elasticsearch/transport/transport/http/curb'
-      transport = Elasticsearch::Transport::Transport::HTTP::Curb.new(@hosts) do |curl|
-        curl.verbose = true
-      end
-
-      client = Elasticsearch::Transport::Client.new transport: transport
-      client.perform_request 'GET', ''
-    end unless jruby?
-
-    should "deserialize JSON responses in the Curb client" do
-      require 'curb'
-      require 'elasticsearch/transport/transport/http/curb'
-      transport = Elasticsearch::Transport::Transport::HTTP::Curb.new(@hosts) do |curl|
-        curl.verbose = true
-      end
-
-      client = Elasticsearch::Transport::Client.new transport: transport
-      response = client.perform_request 'GET', ''
-
-      assert_respond_to(response.body, :to_hash)
-      assert_not_nil response.body['name']
-      assert_equal 'application/json', response.headers['content-type']
-    end unless jruby?
   end
 end

--- a/elasticsearch-transport/test/test_helper.rb
+++ b/elasticsearch-transport/test/test_helper.rb
@@ -97,6 +97,10 @@ module Minitest
   end
 end
 
+def is_faraday_v2?
+  Gem::Version.new(Faraday::VERSION) >= Gem::Version.new(2)
+end
+
 Minitest::Reporters.use! FixedMinitestSpecReporter.new
 
 module Elasticsearch

--- a/elasticsearch-transport/test/unit/adapters_test.rb
+++ b/elasticsearch-transport/test/unit/adapters_test.rb
@@ -1,0 +1,88 @@
+# Licensed to Elasticsearch B.V. under one or more contributor
+# license agreements. See the NOTICE file distributed with
+# this work for additional information regarding copyright
+# ownership. Elasticsearch B.V. licenses this file to you under
+# the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+require 'test_helper'
+
+class Elasticsearch::Transport::Transport::ClientAdaptersUnitTest < Minitest::Test
+  context 'Adapters' do
+    setup do
+      begin
+        Object.send(:remove_const, :Patron)
+      rescue NameError
+      end
+    end
+
+    should 'use the default Faraday adapter' do
+      fork do
+        client = Elasticsearch::Transport::Client.new
+        assert_equal(client.transport.connections.first.connection.adapter, Faraday::Adapter::NetHttp)
+      end
+    end
+
+    should 'use Patron Faraday adapter' do
+      fork do
+        if is_faraday_v2?
+          require 'faraday/patron'
+        else
+          require 'patron'
+        end
+
+        client = Elasticsearch::Transport::Client.new
+        assert_equal(client.transport.connections.first.connection.adapter, Faraday::Adapter::Patron)
+      end
+    end
+
+    should 'use Typhoeus Faraday adapter' do
+      fork do
+        if is_faraday_v2?
+          require 'faraday/typhoeus'
+        else
+          require 'typhoeus'
+        end
+
+        client = Elasticsearch::Transport::Client.new
+        assert_equal(client.transport.connections.first.connection.adapter, Faraday::Adapter::Typhoeus)
+      end
+    end
+
+    should 'use NetHttpPersistent Faraday adapter' do
+      fork do
+        if is_faraday_v2?
+          require 'faraday/net_http_persistent'
+        else
+          require 'net/http/persistent'
+        end
+
+        client = Elasticsearch::Transport::Client.new
+        assert_equal(client.transport.connections.first.connection.adapter, Faraday::Adapter::NetHttpPersistent)
+      end
+    end
+
+    should 'use HTTPClient Faraday adapter' do
+      fork do
+        if is_faraday_v2?
+          require 'faraday/httpclient'
+        else
+          require 'httpclient'
+        end
+
+        client = Elasticsearch::Transport::Client.new
+        assert_equal(Faraday::Adapter::HTTPClient, client.transport.connections.first.connection.adapter)
+      end
+    end
+  end unless jruby?
+end


### PR DESCRIPTION
Attempts to close #2228.

All credit for this goes to @picandocodigo, as these are the same changes made in https://github.com/elastic/elastic-transport-ruby/pull/30 but for version 7.17 of `elastic-transport` – I just copy-pasted those changes over.