### PR TITLE
[API] Test Runner: Updates wipe cluster templates convention

### DIFF
--- a/elasticsearch-api/api-spec-testing/wipe_cluster.rb
+++ b/elasticsearch-api/api-spec-testing/wipe_cluster.rb
@@ -41,8 +41,7 @@ module Elasticsearch
         'synthetics', 'synthetics-settings', 'synthetics-mappings',
         '.snapshot-blob-cache', '.deprecation-indexing-template',
         '.deprecation-indexing-mappings', '.deprecation-indexing-settings',
-        'security-index-template', 'data-streams-mappings', 'ecs@dynamic_templates',
-        'search-acl-filter'
+        'security-index-template', 'data-streams-mappings', 'search-acl-filter'
       ].freeze
 
       # Wipe Cluster, based on PHP's implementation of ESRestTestCase.java:wipeCluster()
@@ -254,6 +253,8 @@ module Elasticsearch
         end
 
         def platinum_template?(template)
+          return true if template.include?('@')
+
           platinum_prefixes = [
             '.monitoring', '.watch', '.triggered-watches', '.data-frame', '.ml-',
             '.transform', '.deprecation', 'data-streams-mappings', '.fleet',


### PR DESCRIPTION
Considers new naming convention that internal component templates contain `@`.

See https://github.com/elastic/elasticsearch/commit/75d9bd7790839f14e2921aeeb38cd4537fe43950#diff-41f49d06cc74aecb5cb12c115be8754894909ff74907100547f5a20a1430653c