### PR TITLE
Add the buildkite-pipeline to the catalog-info.yaml

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,0 +1,19 @@
+apiVersion: backstage.io/v1alpha1
+kind: Resource
+metadata:
+  name: buildkite-pipeline-elasticsearch-ruby
+spec:
+  implementation:
+    apiVersion: buildkite.elastic.dev/v1
+    kind: Pipeline
+    metadata:
+      description: Elasticsearch Ruby Client
+      name: elasticsearch-ruby
+    spec:
+      repository: elastic/elasticsearch-ruby
+      teams:
+        clients-team: {}
+        everyone:
+          access_level: READ_ONLY
+  owner: group:clients-team
+  type: buildkite-pipeline


### PR DESCRIPTION
This PR converts the data in
https://github.com/elastic/ci/blob/6843857da04cc0602307ed3773ecec4c9c87f4ca/terrazzo/manifests/prod/buildkite/
 into an RRE and stores it their associated repo.