### PR TITLE
[Backport][8.12][DOCS] Adds doc examples for Elasticsearch Quick start guide

### DIFF
--- a/docs/examples/guide/36b86b97feedcf5632824eefc251d6ed.asciidoc
+++ b/docs/examples/guide/36b86b97feedcf5632824eefc251d6ed.asciidoc
@@ -1,0 +1,8 @@
+[source, ruby]
+----
+response = client.search(
+  index: 'books',
+  body: { query: { match: { name: 'brave' } } }
+)
+puts response
+----

--- a/docs/examples/guide/3d1ff6097e2359f927c88c2ccdb36252.asciidoc
+++ b/docs/examples/guide/3d1ff6097e2359f927c88c2ccdb36252.asciidoc
@@ -1,0 +1,5 @@
+[source, ruby]
+----
+response = client.info
+puts response
+----

--- a/docs/examples/guide/8575c966b004fb124c7afd6bb5827b50.asciidoc
+++ b/docs/examples/guide/8575c966b004fb124c7afd6bb5827b50.asciidoc
@@ -1,0 +1,13 @@
+[source, ruby]
+----
+response = client.index(
+  index: 'books',
+  body: {
+    name: 'Snow Crash',
+    author: 'Neal Stephenson',
+    release_date: '1992-06-01',
+    page_count: 470
+  }
+)
+puts response
+----

--- a/docs/examples/guide/bcc75fc01b45e482638c65b8fbdf09fa.asciidoc
+++ b/docs/examples/guide/bcc75fc01b45e482638c65b8fbdf09fa.asciidoc
@@ -1,0 +1,7 @@
+[source, ruby]
+----
+response = client.search(
+  index: 'books'
+)
+puts response
+----

--- a/docs/examples/guide/d04f0c8c44e8b4fb55f2e7d9d05977e7.asciidoc
+++ b/docs/examples/guide/d04f0c8c44e8b4fb55f2e7d9d05977e7.asciidoc
@@ -1,0 +1,18 @@
+[source, ruby]
+----
+response = client.bulk(
+  body: [
+    { index: { _index: 'books' } },
+    { name: 'Revelation Space', author: 'Alastair Reynolds', release_date: '2000-03-15', page_count: 585},
+    { index: { _index: 'books' } },
+    { name: '1984', author: 'George Orwell', release_date: '1985-06-01', page_count: 328},
+    { index: { _index: 'books' } },
+    { name: 'Fahrenheit 451', author: 'Ray Bradbury', release_date: '1953-10-15', page_count: 227},
+    { index: { _index: 'books' } },
+    { name: 'Brave New World', author: 'Aldous Huxley', release_date: '1932-06-01', page_count: 268},
+    { index: { _index: 'books' } },
+    { name: 'The Handmaids Tale', author: 'Margaret Atwood', release_date: '1985-06-01', page_count: 311}
+  ]
+)
+puts response
+----


### PR DESCRIPTION
https://www.elastic.co/guide/en/elasticsearch/reference/master/getting-started.html