### PR TITLE
Don't remove opts from args, add OTel integration test

### DIFF
--- a/.github/workflows/otel.yml
+++ b/.github/workflows/otel.yml
@@ -1,0 +1,45 @@
+name: opentelemetry
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+jobs:
+  test-otel:
+    name: 'Test Open Telemetry'
+    env:
+      TEST_ES_SERVER: http://localhost:9250
+      PORT: 9250
+      TEST_WITH_OTEL: true
+    strategy:
+      fail-fast: false
+      matrix:
+        ruby: [ '3.2', 'jruby-9.4' ]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Increase system limits
+        run: |
+          sudo swapoff -a
+          sudo sysctl -w vm.swappiness=1
+          sudo sysctl -w fs.file-max=262144
+          sudo sysctl -w vm.max_map_count=262144
+      - uses: elastic/elastic-github-actions/elasticsearch@master
+        with:
+          stack-version: 8.12.0-SNAPSHOT
+          security-enabled: false
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby }}
+      - name: Build
+        run: |
+          sudo apt-get update
+          sudo apt-get install libcurl4-openssl-dev
+          rake bundle:clean
+          rake bundle:install
+      - name: elasticsearch
+        run: cd elasticsearch && bundle exec rake test:all
+      - name: elasticsearch-api
+        run: rake elasticsearch:download_artifacts[8.12.0-SNAPSHOT] && cd elasticsearch-api && bundle exec rake test:spec test:platinum:unit

--- a/elasticsearch/Gemfile
+++ b/elasticsearch/Gemfile
@@ -29,3 +29,7 @@ end
 if ENV['TRANSPORT_VERSION'] == 'main'
   gem 'elastic-transport', git: 'https://github.com/elastic/elastic-transport-ruby.git', branch: 'main'
 end
+
+if RUBY_VERSION >= '3.0'
+  gem 'opentelemetry-sdk', require: false
+end

--- a/elasticsearch/lib/elasticsearch.rb
+++ b/elasticsearch/lib/elasticsearch.rb
@@ -60,10 +60,6 @@ module Elasticsearch
       elsif name == :perform_request
         # The signature for perform_request is:
         # method, path, params, body, headers, opts
-        # The last arg is opts, which shouldn't be sent when `perform_request` is called
-        # directly. Check if :endpoint is a key, which means it's the extra identifier
-        # used for OpenTelemetry.
-        args.pop if args[-1].is_a?(Hash) && args[-1][:endpoint]
         if (opaque_id = args[2]&.delete(:opaque_id))
           headers = args[4] || {}
           opaque_id = @opaque_id_prefix ? "#{@opaque_id_prefix}#{opaque_id}" : opaque_id

--- a/elasticsearch/spec/integration/opentelemetry_spec.rb
+++ b/elasticsearch/spec/integration/opentelemetry_spec.rb
@@ -1,0 +1,55 @@
+# Licensed to Elasticsearch B.V. under one or more contributor
+# license agreements. See the NOTICE file distributed with
+# this work for additional information regarding copyright
+# ownership. Elasticsearch B.V. licenses this file to you under
+# the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+if ENV['TEST_WITH_OTEL'] == 'true'
+  ELASTICSEARCH_URL = ENV['TEST_ES_SERVER'] || "http://localhost:#{(ENV['PORT'] || 9200)}"
+  raise URI::InvalidURIError unless ELASTICSEARCH_URL =~ /\A#{URI::DEFAULT_PARSER.make_regexp}\z/
+
+  require 'spec_helper'
+
+  context 'OpenTelemetry' do
+    let(:exporter) { EXPORTER }
+    before { exporter.reset }
+    after { exporter.reset }
+    let(:span) { exporter.finished_spans[0] }
+
+    let(:client) do
+      Elasticsearch::Client.new(
+        host: ELASTICSEARCH_URL,
+        user: 'elastic',
+        password: 'changeme'
+      )
+    end
+
+    after do
+     client.delete(index: 'myindex', id: 1); rescue
+    end
+
+    context 'when a request is instrumented' do
+      it 'sets the span name to the endpoint id' do
+        client.search(body: { query: { match: {a: 1} } })
+        expect(span.name).to eq 'search'
+      end
+
+      it 'sets the path parts' do
+        client.index(index: 'myindex', id: 1, body: { title: 'Test' })
+        expect(span.attributes['db.elasticsearch.path_parts.index']).to eq 'myindex'
+        expect(span.attributes['db.elasticsearch.path_parts.id']).to eq 1
+      end
+    end
+  end
+end

--- a/elasticsearch/spec/spec_helper.rb
+++ b/elasticsearch/spec/spec_helper.rb
@@ -29,3 +29,15 @@ end
 def jruby?
   defined?(JRUBY_VERSION)
 end
+
+if ENV['TEST_WITH_OTEL'] == 'true'
+  require 'opentelemetry-sdk'
+  EXPORTER = OpenTelemetry::SDK::Trace::Export::InMemorySpanExporter.new
+  span_processor = OpenTelemetry::SDK::Trace::Export::SimpleSpanProcessor.new(EXPORTER)
+
+  OpenTelemetry::SDK.configure do |c|
+    c.error_handler = ->(exception:, message:) { raise(exception || message) }
+    c.logger = Logger.new($stderr, level: ENV.fetch('OTEL_LOG_LEVEL', 'fatal').to_sym)
+    c.add_span_processor span_processor
+  end
+end

--- a/elasticsearch/spec/unit/opaque_id_spec.rb
+++ b/elasticsearch/spec/unit/opaque_id_spec.rb
@@ -29,7 +29,7 @@ describe Elasticsearch::Client do
     it 'uses x-opaque-id on a request' do
       client.search(opaque_id: '12345')
       expect(transport).to have_received(:perform_request)
-        .with('GET', '_search', {}, nil, { 'X-Opaque-Id' => '12345' })
+        .with('GET', '_search', {}, nil, { 'X-Opaque-Id' => '12345' }, {:endpoint=>"search"})
     end
   end
 
@@ -42,7 +42,7 @@ describe Elasticsearch::Client do
     it 'uses x-opaque-id on a request' do
       expect { client.search(opaque_id: '12345') }.not_to raise_error
       expect(transport).to have_received(:perform_request)
-        .with('GET', '_search', {}, nil, { 'X-Opaque-Id' => 'elastic_cloud12345' })
+        .with('GET', '_search', {}, nil, { 'X-Opaque-Id' => 'elastic_cloud12345' }, {:endpoint=>"search"})
     end
   end
 end


### PR DESCRIPTION
I was testing the OTel instrumentation and realized the span name wasn't being set because the opts with the endpoint id were being removed from the args.
~~I think the check on the args [here](https://github.com/elastic/elasticsearch-ruby/blob/v8.11.0/elasticsearch/lib/elasticsearch.rb#L66) should happen at the transport layer instead. So I will open a PR to make the change in the transport repo.~~ I don't think this is necessary. I am not 100% familiar with the usage of the `method_missing` code but I think it should be ok to pass the opts through to `@transport.perform_request` without removing them from args, as I think the code is only used for product verification.

I also added an integration test for OTel so this doesn't get missed again.

I also set up a GitHub workflow with the ENV var `TEST_WITH_OTEL=true`, like we did for the transport gem.