### PR TITLE
Adds base64 dependency

### DIFF
--- a/elasticsearch/elasticsearch.gemspec
+++ b/elasticsearch/elasticsearch.gemspec
@@ -46,8 +46,8 @@ Gem::Specification.new do |s|
   s.required_ruby_version = '>= 2.5'
 
   s.add_dependency 'elastic-transport', '~> 8.3'
-
   s.add_dependency 'elasticsearch-api', '8.13.0'
+  s.add_dependency 'base64'
 
   s.add_development_dependency 'bundler'
   s.add_development_dependency 'byebug' unless defined?(JRUBY_VERSION) || defined?(Rubinius)

--- a/elasticsearch/lib/elasticsearch.rb
+++ b/elasticsearch/lib/elasticsearch.rb
@@ -18,6 +18,7 @@
 require 'elasticsearch/version'
 require 'elastic/transport'
 require 'elasticsearch/api'
+require 'base64'
 
 module Elasticsearch
   NOT_ELASTICSEARCH_WARNING = 'The client noticed that the server is not Elasticsearch and we do not support this unknown product.'.freeze


### PR DESCRIPTION
base64 was added to the gemspec, since starting in Ruby 3.4.0, base64 will no longer be part of the default gems and will no longer be in the standard library.

base64 is used forAPI key and Cloud ID. The dependency used to be declared in transport, but it's not needed there since the implementation using it is in this codebase.