### PR TITLE
Drop runtime dependency on base64

### DIFF
--- a/elasticsearch-api/api-spec-testing/test_file/task_group.rb
+++ b/elasticsearch-api/api-spec-testing/test_file/task_group.rb
@@ -15,6 +15,8 @@
 # specific language governing permissions and limitations
 # under the License.
 
+require 'base64'
+
 module Elasticsearch
   module RestAPIYAMLTests
     class TestFile

--- a/elasticsearch-api/spec/platinum/integration/api_key/api_key_invalidation_spec.rb
+++ b/elasticsearch-api/spec/platinum/integration/api_key/api_key_invalidation_spec.rb
@@ -15,6 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
+require 'base64'
 require_relative '../platinum_helper'
 
 describe 'API keys API invalidation' do

--- a/elasticsearch/elasticsearch.gemspec
+++ b/elasticsearch/elasticsearch.gemspec
@@ -47,8 +47,8 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'elastic-transport', '~> 8.3'
   s.add_dependency 'elasticsearch-api', '8.13.0'
-  s.add_dependency 'base64'
-
+  
+  s.add_development_dependency 'base64'
   s.add_development_dependency 'bundler'
   s.add_development_dependency 'debug' unless defined?(JRUBY_VERSION)
   s.add_development_dependency 'pry'

--- a/elasticsearch/lib/elasticsearch.rb
+++ b/elasticsearch/lib/elasticsearch.rb
@@ -18,7 +18,6 @@
 require 'elasticsearch/version'
 require 'elastic/transport'
 require 'elasticsearch/api'
-require 'base64'
 
 module Elasticsearch
   NOT_ELASTICSEARCH_WARNING = 'The client noticed that the server is not Elasticsearch and we do not support this unknown product.'.freeze
@@ -108,7 +107,8 @@ module Elasticsearch
 
     def setup_cloud_host(cloud_id, user, password, port)
       name = cloud_id.split(':')[0]
-      cloud_url, elasticsearch_instance = Base64.decode64(cloud_id.gsub("#{name}:", '')).split('$')
+      base64_decoded = cloud_id.gsub("#{name}:", '').unpack1('m')
+      cloud_url, elasticsearch_instance = base64_decoded.split('$')
 
       if cloud_url.include?(':')
         url, port = cloud_url.split(':')
@@ -150,7 +150,8 @@ module Elasticsearch
     # Credentials is the base64 encoding of id and api_key joined by a colon
     # @see https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-create-api-key.html
     def encode(api_key)
-      Base64.strict_encode64([api_key[:id], api_key[:api_key]].join(':'))
+      credentials = [api_key[:id], api_key[:api_key]].join(':')
+      [credentials].pack('m0')
     end
 
     def elasticsearch_validation_request

--- a/elasticsearch/spec/unit/api_key_spec.rb
+++ b/elasticsearch/spec/unit/api_key_spec.rb
@@ -16,6 +16,7 @@
 # under the License.
 
 require 'spec_helper'
+require 'base64'
 
 describe Elasticsearch::Client do
   context 'when using API Key' do


### PR DESCRIPTION
#2282 added `base64` as a runtime dependency. It's easy enough to replace, the `base64` is for the most part a wrapper around the `pack`/`unpack` methods.

Also see:
* https://github.com/lostisland/faraday/pull/1541
* https://github.com/bblimke/webmock/pull/1046
* https://github.com/rubocop/rubocop/pull/12313
* https://github.com/rack/rack/pull/2110
* etc.

I have made it a dev dependency since test files use it in a bunch of places and replacing all that doesn't make the code much better.