### PR TITLE
[8.11][Backport] Drop runtime dependency on base64

### DIFF
--- a/elasticsearch-api/api-spec-testing/test_file/task_group.rb
+++ b/elasticsearch-api/api-spec-testing/test_file/task_group.rb
@@ -15,6 +15,8 @@
 # specific language governing permissions and limitations
 # under the License.
 
+require 'base64'
+
 module Elasticsearch
   module RestAPIYAMLTests
     class TestFile

--- a/elasticsearch-api/spec/platinum/integration/api_key/api_key_invalidation_spec.rb
+++ b/elasticsearch-api/spec/platinum/integration/api_key/api_key_invalidation_spec.rb
@@ -15,6 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
+require 'base64'
 require_relative '../platinum_helper'
 
 describe 'API keys API invalidation' do

--- a/elasticsearch/elasticsearch.gemspec
+++ b/elasticsearch/elasticsearch.gemspec
@@ -46,10 +46,9 @@ Gem::Specification.new do |s|
   s.required_ruby_version = '>= 2.5'
 
   s.add_dependency 'elastic-transport', '~> 8.3'
-
   s.add_dependency 'elasticsearch-api', '8.11.1'
-  s.add_dependency 'base64'
 
+  s.add_development_dependency 'base64'
   s.add_development_dependency 'bundler'
   s.add_development_dependency 'byebug' unless defined?(JRUBY_VERSION) || defined?(Rubinius)
   s.add_development_dependency 'pry'

--- a/elasticsearch/lib/elasticsearch.rb
+++ b/elasticsearch/lib/elasticsearch.rb
@@ -18,7 +18,6 @@
 require 'elasticsearch/version'
 require 'elastic/transport'
 require 'elasticsearch/api'
-require 'base64'
 
 module Elasticsearch
   NOT_ELASTICSEARCH_WARNING = 'The client noticed that the server is not Elasticsearch and we do not support this unknown product.'.freeze
@@ -112,7 +111,8 @@ module Elasticsearch
 
     def setup_cloud_host(cloud_id, user, password, port)
       name = cloud_id.split(':')[0]
-      cloud_url, elasticsearch_instance = Base64.decode64(cloud_id.gsub("#{name}:", '')).split('$')
+      base64_decoded = cloud_id.gsub("#{name}:", '').unpack1('m')
+      cloud_url, elasticsearch_instance = base64_decoded.split('$')
 
       if cloud_url.include?(':')
         url, port = cloud_url.split(':')
@@ -154,7 +154,8 @@ module Elasticsearch
     # Credentials is the base64 encoding of id and api_key joined by a colon
     # @see https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-create-api-key.html
     def encode(api_key)
-      Base64.strict_encode64([api_key[:id], api_key[:api_key]].join(':'))
+      credentials = [api_key[:id], api_key[:api_key]].join(':')
+      [credentials].pack('m0')
     end
 
     def elasticsearch_validation_request

--- a/elasticsearch/spec/unit/api_key_spec.rb
+++ b/elasticsearch/spec/unit/api_key_spec.rb
@@ -16,6 +16,7 @@
 # under the License.
 
 require 'spec_helper'
+require 'base64'
 
 describe Elasticsearch::Client do
   context 'when using API Key' do


### PR DESCRIPTION
Backports https://github.com/elastic/elasticsearch-ruby/pull/2295