### PR TITLE
Updates helpers

### DIFF
--- a/elasticsearch/lib/elasticsearch/helpers/bulk_helper.rb
+++ b/elasticsearch/lib/elasticsearch/helpers/bulk_helper.rb
@@ -48,7 +48,9 @@ module Elasticsearch
       def ingest(docs, params = {}, body = {}, &block)
         ingest_docs = docs.map { |doc| { index: { _index: @index, data: doc} } }
         if (slice = params.delete(:slice))
-          ingest_docs.each_slice(slice) { |items| ingest(items, params, &block) }
+          ingest_docs.each_slice(slice) do |items|
+            ingest(items.map { |item| item[:index][:data] }, params, &block)
+          end
         else
           bulk_request(ingest_docs, params, &block)
         end

--- a/elasticsearch/lib/elasticsearch/helpers/esql_helper.rb
+++ b/elasticsearch/lib/elasticsearch/helpers/esql_helper.rb
@@ -67,7 +67,7 @@ module Elasticsearch
         response['values'].map do |value|
           (value.length - 1).downto(0).map do |index|
             key = columns[index]['name']
-            value[index] = parser[key].call value[index] if parser[key]
+            value[index] = parser[key].call(value[index]) if value[index] && parser[key]
             { key => value[index] }
           end.reduce({}, :merge)
         end


### PR DESCRIPTION
Fixes **ES|QL Helper** - When passing in a parser, if the value was nil, the helper would error. Now it returns nil for nil values.

Fixes **Bulk Helper** - Addresses an issue where when using `slice`, the wrong hash was being passed again to `ingest` therefore adding unneccessary hash nesting.