### PR TITLE
YAML test runner

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -61,6 +61,16 @@ steps:
     # I'm publishing test results to HTML and JUnit in this directory and this directive makes them
     # available in the Artifacts tab of a build in Buildkite.
     artifact_paths: "elasticsearch-api/tmp/*"
+  - label: ":ruby: :yaml: Test suite"
+    agents:
+      provider: "gcp"
+    env:
+      RUBY_VERSION: "3.3"
+      STACK_VERSION: 8.15.0-SNAPSHOT
+      TRANSPORT_VERSION: "8.3"
+      RUBY_SOURCE: "ruby"
+      TEST_SUITE: "platinum"
+    command: ./.buildkite/run-yaml-tests.sh
   - wait: ~
     continue_on_failure: true
   - label: "Log Results"

--- a/.buildkite/run-yaml-tests.sh
+++ b/.buildkite/run-yaml-tests.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+#
+# Script to run YAML runner integration tests on Buildkite
+#
+# Version 0.1
+#
+script_path=$(dirname $(realpath -s $0))
+source $script_path/functions/imports.sh
+set -euo pipefail
+repo=`pwd`
+
+echo "--- :elasticsearch: Starting Elasticsearch"
+DETACH=true bash $script_path/run-elasticsearch.sh
+
+export RUBY_VERSION=${RUBY_VERSION:-3.1}
+export TRANSPORT_VERSION=${TRANSPORT_VERSION:-8}
+
+echo "--- :ruby: Building Docker image"
+docker build \
+       --file $script_path/Dockerfile \
+       --tag elastic/elasticsearch-ruby \
+       --build-arg RUBY_VERSION=$RUBY_VERSION \
+       --build-arg TRANSPORT_VERSION=$TRANSPORT_VERSION \
+       --build-arg RUBY_SOURCE=$RUBY_SOURCE \
+       .
+
+mkdir -p elasticsearch-api/tmp
+
+echo "--- :ruby: Running :yaml: tests"
+docker run \
+       -u "$(id -u)" \
+       --network="${network_name}" \
+       --env "TEST_ES_SERVER=${elasticsearch_url}" \
+       --env "ELASTIC_PASSWORD=${elastic_password}" \
+       --env "ELASTIC_USER=elastic" \
+       --env "BUILDKITE=true" \
+       --env "TRANSPORT_VERSION=${TRANSPORT_VERSION}" \
+       --env "STACK_VERSION=${STACK_VERSION}" \
+       --volume $repo:/usr/src/app \
+       --name elasticsearch-ruby \
+       --rm \
+       elastic/elasticsearch-ruby \
+       bundle exec rake test:yaml

--- a/elasticsearch-api/Gemfile
+++ b/elasticsearch-api/Gemfile
@@ -20,8 +20,8 @@ source 'https://rubygems.org'
 # Specify your gem's dependencies in elasticsearch-api.gemspec
 gemspec
 
-if File.exist? File.expand_path("../../elasticsearch/elasticsearch.gemspec", __FILE__)
-  gem 'elasticsearch', path: File.expand_path('../../elasticsearch', __FILE__), require: false
+if File.exist? File.expand_path("../../elasticsearch/elasticsearch.gemspec", __dir__)
+  gem 'elasticsearch', path: File.expand_path('../../elasticsearch', __dir__), require: false
 end
 
 group :development do

--- a/elasticsearch-api/Rakefile
+++ b/elasticsearch-api/Rakefile
@@ -50,6 +50,11 @@ namespace :test do
     Rake::Task['test:integration'].invoke
   end
 
+  desc 'Run tests with yaml runner'
+  task :yaml do
+    ruby './spec/yaml-test-runner/run.rb'
+  end
+
   namespace :platinum do
     desc 'Run Platinum Rest API Spec tests'
     RSpec::Core::RakeTask.new(:api) do

--- a/elasticsearch-api/elasticsearch-api.gemspec
+++ b/elasticsearch-api/elasticsearch-api.gemspec
@@ -49,6 +49,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'ansi'
   s.add_development_dependency 'bundler'
   s.add_development_dependency 'elasticsearch'
+  s.add_development_dependency 'elasticsearch-test-runner'
   s.add_development_dependency 'minitest'
   s.add_development_dependency 'minitest-reporters', '>= 1.6'
   s.add_development_dependency 'mocha'

--- a/elasticsearch-api/elasticsearch-api.gemspec
+++ b/elasticsearch-api/elasticsearch-api.gemspec
@@ -49,7 +49,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'ansi'
   s.add_development_dependency 'bundler'
   s.add_development_dependency 'elasticsearch'
-  s.add_development_dependency 'elasticsearch-test-runner'
+  s.add_development_dependency 'elasticsearch-test-runner' unless defined?(JRUBY_VERSION) && JRUBY_VERSION <= "9.4"
   s.add_development_dependency 'minitest'
   s.add_development_dependency 'minitest-reporters', '>= 1.6'
   s.add_development_dependency 'mocha'

--- a/elasticsearch-api/spec/yaml-test-runner/run.rb
+++ b/elasticsearch-api/spec/yaml-test-runner/run.rb
@@ -1,0 +1,65 @@
+# Licensed to Elasticsearch B.V. under one or more contributor
+# license agreements. See the NOTICE file distributed with
+# this work for additional information regarding copyright
+# ownership. Elasticsearch B.V. licenses this file to you under
+# the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+require 'logger'
+require 'openssl'
+require 'elasticsearch'
+require 'elasticsearch/tests/test_runner'
+require 'elasticsearch/tests/downloader'
+
+PROJECT_PATH = File.join(File.dirname(__FILE__), '../..')
+CERTS_PATH = "#{PROJECT_PATH}/../.buildkite/certs/".freeze
+host = ENV['TEST_ES_SERVER'] || 'https://localhost:9200'
+raise URI::InvalidURIError unless host =~ /\A#{URI::DEFAULT_PARSER.make_regexp}\z/
+
+password = ENV['ELASTIC_PASSWORD'] || 'changeme'
+uri = URI.parse(host)
+
+if uri.is_a?(URI::HTTPS)
+  raw_certificate = File.read("#{CERTS_PATH}/testnode.crt")
+  certificate = OpenSSL::X509::Certificate.new(raw_certificate)
+  raw_key = File.read("#{CERTS_PATH}/testnode.key")
+  key = OpenSSL::PKey::RSA.new(raw_key)
+  ca_file = File.expand_path("#{CERTS_PATH}/ca.crt")
+  host = "https://elastic:#{password}@#{uri.host}:#{uri.port}".freeze
+  transport_options = {
+    ssl: {
+      client_cert: certificate,
+      client_key: key,
+      ca_file: ca_file,
+      verify: false
+    }
+  }
+elsif uri.is_a?(URI::HTTP)
+  host = "http://elastic:#{password}@#{uri.host}:#{uri.port}".freeze
+  transport_options = {}
+end
+
+if ENV['ES_API_KEY']
+  CLIENT = Elasticsearch::Client.new(host: host, api_key: ENV['ES_API_KEY'], transport_options: transport_options)
+else
+  CLIENT = Elasticsearch::Client.new(host: host, transport_options: transport_options)
+end
+
+
+tests_path = File.expand_path('./tmp', __dir__)
+
+logger = Logger.new($stdout)
+logger.level = Logger::WARN unless ENV['DEBUG']
+
+Elasticsearch::Tests::Downloader::run(tests_path)
+Elasticsearch::Tests::TestRunner.new(CLIENT, tests_path, logger).run

--- a/rake_tasks/test_tasks.rake
+++ b/rake_tasks/test_tasks.rake
@@ -61,6 +61,11 @@ namespace :test do
     puts "\n"
   end
 
+  desc 'Run YAML test runner tests'
+  task :yaml do
+    sh "cd #{CURRENT_PATH.join('elasticsearch-api')} && unset BUNDLE_GEMFILE && bundle exec rake test:yaml"
+  end
+
   namespace :platinum do
     desc 'Run platinum integration tests'
     task :integration do


### PR DESCRIPTION
Adds a task to run the YAML test runner to [es-test-runner-ruby](https://github.com/elastic/es-test-runner-ruby) which will eventually replace running the whole Elasticsearch test suite for elasticsearch-api.

Depends on:
* https://github.com/elastic/elasticsearch-clients-tests/pull/65