### PR TITLE
Test Runner: Skips snapshot test

### DIFF
--- a/elasticsearch-api/spec/rest_api/skipped_tests_platinum.yml
+++ b/elasticsearch-api/spec/rest_api/skipped_tests_platinum.yml
@@ -212,6 +212,9 @@
 -
   :file: 'esql/180_match_operator.yml'
   :description: '*'
+-
+  :file: 'snapshot/10_basic.yml'
+  :description: 'Failed to snapshot indices with synthetic source'
 # Private APIs
 -
   :file: 'ml/validate.yml'


### PR DESCRIPTION
This in addition to [a PR](https://github.com/elastic/elasticsearch-clients-tests/pull/131) in the tests repository should fix the build.

Waiting on:
* https://github.com/elastic/elasticsearch-clients-tests/pull/131