### PR TITLE
Updates

### DIFF
--- a/CHANGELOG-9.x.md
+++ b/CHANGELOG-9.x.md
@@ -1,14 +1,19 @@
 # CHANGELOG 9.x
 
+## Gem
+
+The size of both `elasticsearch` and `elasticsearch-api` gems will be smaller, since some unnecessary files that were being included in the gem have been removed.
+
+The required Ruby version is set to `2.6` to keep compatiblity wit JRuby 9.3. However, we only test the code against currently supported Ruby versions.
+
 ## Elasticsearch API
 
 ### Development
 
-**Integration Tests**
+#### Testing
 
-Migrated away from the Elasticsearch REST API tests and test runner in CI. We now run the [Elasticsearch Client tests](https://github.com/elastic/elasticsearch-clients-tests/) with the [Elasticsearch Tests Runner](https://github.com/elastic/es-test-runner-ruby/**. This gives us more control on what we're testing and makes the Buildkite build way faster in Pull Requests and scheduled builds.
+Migrated away from the Elasticsearch REST API tests and test runner in CI. We now run the [Elasticsearch Client tests](https://github.com/elastic/elasticsearch-clients-tests/) with the [Elasticsearch Tests Runner](https://github.com/elastic/es-test-runner-ruby). This gives us more control on what we're testing and makes the Buildkite build way faster in Pull Requests and scheduled builds.
 
-
-**Rake tasks**
+#### Rake tasks
 
 Some old rake tasks that were not being used have been removed. The rest were streamlined, the `es` namespace has been streamlined to make it easier to run Elasticsearch with Docker during development. The `docker` namespace was merged into `es`.

--- a/elasticsearch-api/elasticsearch-api.gemspec
+++ b/elasticsearch-api/elasticsearch-api.gemspec
@@ -37,8 +37,6 @@ Gem::Specification.new do |s|
   s.files = `git ls-files`.split($/).reject do |file|
     file.match(/^utils\/|^spec\/|^api-spec-testing\/|^Gemfile|^Rakefile/)
   end
-  s.executables   = s.files.grep(%r{^bin/}) { |f| File.basename(f) }
-  s.test_files    = s.files.grep(%r{^(test|spec|features)/})
   s.require_paths = ['lib']
 
   s.extra_rdoc_files  = ['README.md', 'LICENSE.txt']

--- a/elasticsearch-api/elasticsearch-api.gemspec
+++ b/elasticsearch-api/elasticsearch-api.gemspec
@@ -34,7 +34,9 @@ Gem::Specification.new do |s|
     'source_code_uri' => 'https://github.com/elastic/elasticsearch-ruby/tree/main/elasticsearch-api',
     'bug_tracker_uri' => 'https://github.com/elastic/elasticsearch-ruby/issues'
   }
-  s.files         = `git ls-files`.split($/)
+  s.files = `git ls-files`.split($/).reject do |file|
+    file.match(/^utils\/|^spec\/|^api-spec-testing\/|^Gemfile|^Rakefile/)
+  end
   s.executables   = s.files.grep(%r{^bin/}) { |f| File.basename(f) }
   s.test_files    = s.files.grep(%r{^(test|spec|features)/})
   s.require_paths = ['lib']

--- a/elasticsearch-api/elasticsearch-api.gemspec
+++ b/elasticsearch-api/elasticsearch-api.gemspec
@@ -38,12 +38,10 @@ Gem::Specification.new do |s|
     file.match(/^utils\/|^spec\/|^api-spec-testing\/|^Gemfile|^Rakefile/)
   end
   s.require_paths = ['lib']
-
   s.extra_rdoc_files  = ['README.md', 'LICENSE.txt']
   s.rdoc_options      = ['--charset=UTF-8']
 
-  s.required_ruby_version = '>= 2.5'
-
+  s.required_ruby_version = '>= 2.6' # For compatibility with JRuby 9.3
   s.add_dependency 'multi_json'
 
   s.add_development_dependency 'ansi'
@@ -66,13 +64,10 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency 'cane'
   s.add_development_dependency 'escape_utils' unless defined? JRUBY_VERSION
-
   s.add_development_dependency 'require-prof' unless defined?(JRUBY_VERSION) || defined?(Rubinius)
   s.add_development_dependency 'ruby-prof' unless defined?(JRUBY_VERSION) || defined?(Rubinius)
   s.add_development_dependency 'simplecov'
-
   s.add_development_dependency 'test-unit', '~> 2'
-
   s.description = <<-DESC.gsub(/^    /, '')
     Ruby API for Elasticsearch. See the `elasticsearch` gem for full integration.
   DESC

--- a/elasticsearch/Gemfile
+++ b/elasticsearch/Gemfile
@@ -30,6 +30,4 @@ if ENV['TRANSPORT_VERSION'] == 'main'
   gem 'elastic-transport', git: 'https://github.com/elastic/elastic-transport-ruby.git', branch: 'main'
 end
 
-if RUBY_VERSION >= '3.0'
-  gem 'opentelemetry-sdk', require: false
-end
+gem 'opentelemetry-sdk', require: false if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('3.0')

--- a/elasticsearch/elasticsearch.gemspec
+++ b/elasticsearch/elasticsearch.gemspec
@@ -39,7 +39,6 @@ Gem::Specification.new do |s|
 
   s.executables = s.files.grep(%r{^bin/}) { |f| File.basename(f) }
   s.executables << 'elastic_ruby_console'
-  s.test_files = s.files.grep(%r{^(test|spec|features)/})
   s.require_paths = ['lib']
   s.bindir = 'bin'
 

--- a/elasticsearch/elasticsearch.gemspec
+++ b/elasticsearch/elasticsearch.gemspec
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-lib = File.expand_path('../lib', __FILE__)
+lib = File.expand_path('lib', __dir__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'elasticsearch/version'
 
@@ -45,10 +45,9 @@ Gem::Specification.new do |s|
   s.extra_rdoc_files  = ['README.md', 'LICENSE.txt']
   s.rdoc_options      = ['--charset=UTF-8']
 
-  s.required_ruby_version = '>= 2.5'
-
-  s.add_dependency 'elastic-transport', '~> 8.3'
+  s.required_ruby_version = '>= 2.6' # For compatibility with JRuby 9.3
   s.add_dependency 'elasticsearch-api', '9.0.0'
+  s.add_dependency 'elastic-transport', '~> 8.3'
 
   s.add_development_dependency 'base64'
   s.add_development_dependency 'bundler'

--- a/elasticsearch/elasticsearch.gemspec
+++ b/elasticsearch/elasticsearch.gemspec
@@ -33,7 +33,10 @@ Gem::Specification.new do |s|
     'source_code_uri' => 'https://github.com/elastic/elasticsearch-ruby/tree/main',
     'bug_tracker_uri' => 'https://github.com/elastic/elasticsearch-ruby/issues'
   }
-  s.files = `git ls-files`.split($/)
+  s.files = `git ls-files`.split($/).reject do |file|
+    file.match(/^spec\/|^Gemfile|^Rakefile/)
+  end
+
   s.executables = s.files.grep(%r{^bin/}) { |f| File.basename(f) }
   s.executables << 'elastic_ruby_console'
   s.test_files = s.files.grep(%r{^(test|spec|features)/})

--- a/elasticsearch/lib/elasticsearch.rb
+++ b/elasticsearch/lib/elasticsearch.rb
@@ -37,8 +37,9 @@ module Elasticsearch
     #
     # @param [Hash] arguments - initializer arguments
     # @option arguments [String] :cloud_id - The Cloud ID to connect to Elastic Cloud
-    # @option arguments [String, Hash] :api_key Use API Key Authentication, either the base64 encoding of `id` and `api_key`
-    #                                           joined by a colon as a String, or a hash with the `id` and `api_key` values.
+    # @option arguments [String, Hash] :api_key Use API Key Authentication, either the base64 encoding of `id` and
+    #                                           `api_key` joined by a colon as a String, or a hash with the `id` and
+    #                                           `api_key` values.
     # @option arguments [String] :opaque_id_prefix set a prefix for X-Opaque-Id when initializing the client.
     #                                              This will be prepended to the id you set before each request
     #                                              if you're using X-Opaque-Id
@@ -65,10 +66,10 @@ module Elasticsearch
           opaque_id = @opaque_id_prefix ? "#{@opaque_id_prefix}#{opaque_id}" : opaque_id
           args[4] = headers.merge('X-Opaque-Id' => opaque_id)
         end
-        unless @verified
-          verify_elasticsearch(*args, &block)
-        else
+        if @verified
           @transport.perform_request(*args, &block)
+        else
+          verify_elasticsearch(*args, &block)
         end
       else
         @transport.send(name, *args, &block)
@@ -101,6 +102,7 @@ module Elasticsearch
         raise e
       end
       raise Elasticsearch::UnsupportedProductError unless response.headers['x-elastic-product'] == 'Elasticsearch'
+
       @verified = true
       response
     end
@@ -175,7 +177,7 @@ module Elasticsearch
       end
       arguments[:transport_options] ||= {}
       arguments[:transport_options][:headers] ||= {}
-      arguments[:transport_options][:headers].merge!({ user_agent: user_agent.join('; ')})
+      arguments[:transport_options][:headers].merge!({ user_agent: user_agent.join('; ') })
     end
   end
 


### PR DESCRIPTION
Cleanup and refactor for next major.

The size of both `elasticsearch` and `elasticsearch-api` gems will be smaller, since some unnecessary files that were being included in the gem have been removed.

The required Ruby version is set to `2.6` to keep compatiblity wit JRuby 9.3. However, we only test the code against currently supported Ruby versions.