### PR TITLE
[API] Adds timeout, local parameters

### DIFF
--- a/elasticsearch-api/lib/elasticsearch/api/actions/cluster/exists_component_template.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/cluster/exists_component_template.rb
@@ -25,8 +25,8 @@ module Elasticsearch
         # Returns information about whether a particular component template exist
         #
         # @option arguments [String] :name The name of the template
-        # @option arguments [Time] :master_timeout Explicit operation timeout for connection to master node
-        # @option arguments [Boolean] :local Return local information, do not retrieve the state from master node (default: false)
+        # @option arguments [Time] :master_timeout Timeout for waiting for new cluster state in case it is blocked
+        # @option arguments [Boolean] :local Return local information, do not retrieve the state from master node (default: false) *Deprecated*
         # @option arguments [Hash] :headers Custom HTTP headers
         #
         # @see https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-component-template.html

--- a/elasticsearch-api/lib/elasticsearch/api/actions/cluster/get_component_template.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/cluster/get_component_template.rb
@@ -25,8 +25,8 @@ module Elasticsearch
         # Returns one or more component templates
         #
         # @option arguments [List] :name The comma separated names of the component templates
-        # @option arguments [Time] :master_timeout Explicit operation timeout for connection to master node
-        # @option arguments [Boolean] :local Return local information, do not retrieve the state from master node (default: false)
+        # @option arguments [Time] :master_timeout Timeout for waiting for new cluster state in case it is blocked
+        # @option arguments [Boolean] :local Return local information, do not retrieve the state from master node (default: false) *Deprecated*
         # @option arguments [Boolean] :include_defaults Return all default configurations for the component template (default: false)
         # @option arguments [Hash] :headers Custom HTTP headers
         #

--- a/elasticsearch-api/lib/elasticsearch/api/actions/snapshot_lifecycle_management/delete_lifecycle.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/snapshot_lifecycle_management/delete_lifecycle.rb
@@ -25,6 +25,8 @@ module Elasticsearch
         # Deletes an existing snapshot lifecycle policy.
         #
         # @option arguments [String] :policy_id The id of the snapshot lifecycle policy to remove
+        # @option arguments [Time] :master_timeout Explicit operation timeout for connection to master node
+        # @option arguments [Time] :timeout Explicit operation timeout
         # @option arguments [Hash] :headers Custom HTTP headers
         #
         # @see https://www.elastic.co/guide/en/elasticsearch/reference/current/slm-api-delete-policy.html
@@ -48,7 +50,7 @@ module Elasticsearch
 
           method = Elasticsearch::API::HTTP_DELETE
           path   = "_slm/policy/#{Utils.__listify(_policy_id)}"
-          params = {}
+          params = Utils.process_params(arguments)
 
           Elasticsearch::API::Response.new(
             perform_request(method, path, params, body, headers, request_opts)

--- a/elasticsearch-api/lib/elasticsearch/api/actions/snapshot_lifecycle_management/execute_lifecycle.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/snapshot_lifecycle_management/execute_lifecycle.rb
@@ -25,6 +25,8 @@ module Elasticsearch
         # Immediately creates a snapshot according to the lifecycle policy, without waiting for the scheduled time.
         #
         # @option arguments [String] :policy_id The id of the snapshot lifecycle policy to be executed
+        # @option arguments [Time] :master_timeout Explicit operation timeout for connection to master node
+        # @option arguments [Time] :timeout Explicit operation timeout
         # @option arguments [Hash] :headers Custom HTTP headers
         #
         # @see https://www.elastic.co/guide/en/elasticsearch/reference/current/slm-api-execute-lifecycle.html
@@ -48,7 +50,7 @@ module Elasticsearch
 
           method = Elasticsearch::API::HTTP_PUT
           path   = "_slm/policy/#{Utils.__listify(_policy_id)}/_execute"
-          params = {}
+          params = Utils.process_params(arguments)
 
           Elasticsearch::API::Response.new(
             perform_request(method, path, params, body, headers, request_opts)

--- a/elasticsearch-api/lib/elasticsearch/api/actions/snapshot_lifecycle_management/execute_retention.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/snapshot_lifecycle_management/execute_retention.rb
@@ -24,6 +24,8 @@ module Elasticsearch
       module Actions
         # Deletes any snapshots that are expired according to the policy's retention rules.
         #
+        # @option arguments [Time] :master_timeout Explicit operation timeout for connection to master node
+        # @option arguments [Time] :timeout Explicit operation timeout
         # @option arguments [Hash] :headers Custom HTTP headers
         #
         # @see https://www.elastic.co/guide/en/elasticsearch/reference/current/slm-api-execute-retention.html
@@ -38,7 +40,7 @@ module Elasticsearch
 
           method = Elasticsearch::API::HTTP_POST
           path   = '_slm/_execute_retention'
-          params = {}
+          params = Utils.process_params(arguments)
 
           Elasticsearch::API::Response.new(
             perform_request(method, path, params, body, headers, request_opts)

--- a/elasticsearch-api/lib/elasticsearch/api/actions/snapshot_lifecycle_management/get_lifecycle.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/snapshot_lifecycle_management/get_lifecycle.rb
@@ -25,6 +25,8 @@ module Elasticsearch
         # Retrieves one or more snapshot lifecycle policy definitions and information about the latest snapshot attempts.
         #
         # @option arguments [List] :policy_id Comma-separated list of snapshot lifecycle policies to retrieve
+        # @option arguments [Time] :master_timeout Explicit operation timeout for connection to master node
+        # @option arguments [Time] :timeout Explicit operation timeout
         # @option arguments [Hash] :headers Custom HTTP headers
         #
         # @see https://www.elastic.co/guide/en/elasticsearch/reference/current/slm-api-get-policy.html
@@ -50,7 +52,7 @@ module Elasticsearch
                    else
                      '_slm/policy'
                    end
-          params = {}
+          params = Utils.process_params(arguments)
 
           Elasticsearch::API::Response.new(
             perform_request(method, path, params, body, headers, request_opts)

--- a/elasticsearch-api/lib/elasticsearch/api/actions/snapshot_lifecycle_management/get_stats.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/snapshot_lifecycle_management/get_stats.rb
@@ -24,6 +24,8 @@ module Elasticsearch
       module Actions
         # Returns global and policy-level statistics about actions taken by snapshot lifecycle management.
         #
+        # @option arguments [Time] :master_timeout Explicit operation timeout for connection to master node
+        # @option arguments [Time] :timeout Explicit operation timeout
         # @option arguments [Hash] :headers Custom HTTP headers
         #
         # @see https://www.elastic.co/guide/en/elasticsearch/reference/current/slm-api-get-stats.html
@@ -38,7 +40,7 @@ module Elasticsearch
 
           method = Elasticsearch::API::HTTP_GET
           path   = '_slm/stats'
-          params = {}
+          params = Utils.process_params(arguments)
 
           Elasticsearch::API::Response.new(
             perform_request(method, path, params, body, headers, request_opts)

--- a/elasticsearch-api/lib/elasticsearch/api/actions/snapshot_lifecycle_management/get_status.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/snapshot_lifecycle_management/get_status.rb
@@ -24,6 +24,8 @@ module Elasticsearch
       module Actions
         # Retrieves the status of snapshot lifecycle management (SLM).
         #
+        # @option arguments [Time] :master_timeout Explicit operation timeout for connection to master node
+        # @option arguments [Time] :timeout Explicit operation timeout
         # @option arguments [Hash] :headers Custom HTTP headers
         #
         # @see https://www.elastic.co/guide/en/elasticsearch/reference/current/slm-api-get-status.html
@@ -38,7 +40,7 @@ module Elasticsearch
 
           method = Elasticsearch::API::HTTP_GET
           path   = '_slm/status'
-          params = {}
+          params = Utils.process_params(arguments)
 
           Elasticsearch::API::Response.new(
             perform_request(method, path, params, body, headers, request_opts)

--- a/elasticsearch-api/lib/elasticsearch/api/actions/snapshot_lifecycle_management/put_lifecycle.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/snapshot_lifecycle_management/put_lifecycle.rb
@@ -25,6 +25,8 @@ module Elasticsearch
         # Creates or updates a snapshot lifecycle policy.
         #
         # @option arguments [String] :policy_id The id of the snapshot lifecycle policy
+        # @option arguments [Time] :master_timeout Explicit operation timeout for connection to master node
+        # @option arguments [Time] :timeout Explicit operation timeout
         # @option arguments [Hash] :headers Custom HTTP headers
         # @option arguments [Hash] :body The snapshot lifecycle policy definition to register
         #
@@ -49,7 +51,7 @@ module Elasticsearch
 
           method = Elasticsearch::API::HTTP_PUT
           path   = "_slm/policy/#{Utils.__listify(_policy_id)}"
-          params = {}
+          params = Utils.process_params(arguments)
 
           Elasticsearch::API::Response.new(
             perform_request(method, path, params, body, headers, request_opts)


### PR DESCRIPTION
* cluster.exists_component_template - adds master_timeout, local parameters
* cluster.get_component_template - adds master_timeout, local parameters
* snapshot_lifecycle_management.delete_lifecycle - adds master_timeout, timeout parameters
* snapshot_lifecycle_management.execute_lifecycle - adds master_timeout, timeout parameters
* snapshot_lifecycle_management.execute_retention - adds master_timeout, timeout parameters
* snapshot_lifecycle_management.get_lifecycle - adds master_timeout, timeout parameters
* snapshot_lifecycle_management.get_stats - adds master_timeout, timeout parameters
* snapshot_lifecycle_management.get_status - adds master_timeout, timeout parameters
* snapshot_lifecycle_management.put_lifecycle - adds master_timeout, timeout parameters