### PR TITLE
[docs] Clean up cross-repo links

### DIFF
--- a/docs/reference/advanced-config.md
+++ b/docs/reference/advanced-config.md
@@ -71,7 +71,7 @@ To log requests and responses to standard output with the default logger (an ins
 Elasticsearch::Client.new(log: true)
 ```
 
-You can also use [`ecs-logging`](https://github.com/elastic/ecs-logging-ruby) which is a set of libraries that enables you to transform your application logs to structured logs that comply with the [Elastic Common Schema](ecs://docs/reference/index.md). See [Elastic Common Schema (ECS)](/reference/ecs.md).
+You can also use [`ecs-logging`](https://github.com/elastic/ecs-logging-ruby) which is a set of libraries that enables you to transform your application logs to structured logs that comply with the [Elastic Common Schema](ecs://reference/index.md). See [Elastic Common Schema (ECS)](/reference/ecs.md).
 
 To trace requests and responses in the Curl format, set the `trace` argument:
 

--- a/docs/reference/ecs.md
+++ b/docs/reference/ecs.md
@@ -5,7 +5,7 @@ mapped_pages:
 
 # Elastic Common Schema (ECS) [ecs]
 
-The [Elastic Common Schema (ECS)][Elastic Common Schema (ECS)](ecs://docs/reference/index.md)) is an open source format that defines a common set of fields to be used when storing event data like logs in Elasticsearch.
+The [Elastic Common Schema (ECS)][Elastic Common Schema (ECS)](ecs://reference/index.md)) is an open source format that defines a common set of fields to be used when storing event data like logs in Elasticsearch.
 
 You can use the library [ecs-logging](https://github.com/elastic/ecs-logging-ruby) which is a set of libraries that enables you to transform your application logs to structured logs that comply with the ECS format.
 
@@ -33,5 +33,5 @@ client = Elasticsearch::Client.new(logger: logger)
 {"@timestamp":"2022-07-12T05:31:18.590Z","log.level":"INFO","message":"GET http://localhost:9200/ [status:200, request:0.009s, query:n/a]","ecs.version":"1.4.0"}...
 ```
 
-See [ECS Logging Ruby Reference](ecs-logging-ruby://docs/reference/index.md) for more information on how to configure the logger.
+See [ECS Logging Ruby Reference](ecs-logging-ruby://reference/index.md) for more information on how to configure the logger.
 


### PR DESCRIPTION
Follow up to #2582 

When using cross-repo links, the path should be relative to the `docset.yml` not the full path within the repo ([updated docs-builder docs](https://elastic.github.io/docs-builder/syntax/links/#cross-repository-links)).