### PR TITLE
[docs] Fix external links

### DIFF
--- a/docs/reference/connecting.md
+++ b/docs/reference/connecting.md
@@ -309,7 +309,7 @@ end
 Resources used to assess these recommendations:
 
 * [GCP Cloud Functions: Tips & Tricks](https://cloud.google.com/functions/docs/bestpractices/tips#use_global_variables_to_reuse_objects_in_future_invocations)
-* [Best practices for working with AWS Lambda functions](https://docs.aws.amazon.com/lambda/latest/dg/best-practices.md)
+* [Best practices for working with AWS Lambda functions](https://docs.aws.amazon.com/lambda/latest/dg/best-practices.html)
 
 
 ## Enabling the Compatibility Mode [client-comp]

--- a/docs/reference/dsl.md
+++ b/docs/reference/dsl.md
@@ -5,7 +5,7 @@ mapped_pages:
 
 # Elasticsearch DSL [dsl]
 
-The [elasticsearch-dsl](https://github.com/elastic/elasticsearch-dsl-ruby) gem provides a Ruby API for the [Elasticsearch Query DSL](https://www.elasticsearch.com/guide/en/elasticsearch/reference/current/query-dsl.md). The library allows to programmatically build complex search definitions for {{es}} in Ruby, which are translated to Hashes, and ultimately, JSON, the language of {{es}}.
+The [elasticsearch-dsl](https://github.com/elastic/elasticsearch-dsl-ruby) gem provides a Ruby API for the [Elasticsearch Query DSL](https://www.elasticsearch.com/guide/en/elasticsearch/reference/current/query-dsl.html). The library allows to programmatically build complex search definitions for {{es}} in Ruby, which are translated to Hashes, and ultimately, JSON, the language of {{es}}.
 
 See [the README](https://github.com/elastic/elasticsearch-dsl-ruby#elasticsearchdsl) for more information.
 

--- a/docs/reference/transport.md
+++ b/docs/reference/transport.md
@@ -259,7 +259,7 @@ You can write your own transport implementation by including the {Elastic::Trans
 
 * `Elastic::Transport::Client` is composed of `Elastic::Transport::Transport`.
 * `Elastic::Transport::Transport` is composed of `Elastic::Transport::Transport::Connections`, and an instance of logger, tracer, serializer and sniffer.
-* Logger and tracer can be any object conforming to Ruby logging interface, for example, an instance of [`Logger`](https://ruby-doc.org/stdlib-1.9.3/libdoc/logger/rdoc/Logger.md), [log4r](https://rubygems.org/gems/log4r), [logging](https://github.com/TwP/logging/), and so on.
+* Logger and tracer can be any object conforming to Ruby logging interface, for example, an instance of [`Logger`](https://ruby-doc.org/stdlib-1.9.3/libdoc/logger/rdoc/Logger.html), [log4r](https://rubygems.org/gems/log4r), [logging](https://github.com/TwP/logging/), and so on.
 * The `Elastic::Transport::Transport::Serializer::Base` implementations handle converting data for {{es}} (for example, to JSON). You can implement your own serializer.
 * `Elastic::Transport::Transport::Sniffer` allows to discover nodes in the cluster and use them as connections.
 * `Elastic::Transport::Transport::Connections::Collection` is composed of `Elastic::Transport::Transport::Connections::Connection` instances and a selector instance.


### PR DESCRIPTION
Fix external links that incorrectly use `.md` instead of `.html`.