### PR TITLE
Fix mapped_pages front matter on docs/reference/index

### DIFF
--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -1,6 +1,6 @@
 ---
 mapped_pages:
-  https://www.elastic.co/guide/en/elasticsearch/client/ruby-api/current/index.html
+  - https://www.elastic.co/guide/en/elasticsearch/client/ruby-api/current/index.html
   - https://www.elastic.co/guide/en/elasticsearch/client/ruby-api/current/ruby_client.html
 ---
 


### PR DESCRIPTION
Hello!

While I was working on making use of the front matter to show the user there's a previous version available, I've found this missing dash.