### PR TITLE
[Gem] Don't use Rubocop with JRuby

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -38,5 +38,5 @@ end
 group :development, :test do
   gem 'debug' unless defined?(JRUBY_VERSION)
   gem 'rspec'
-  gem 'rubocop', '>= 1.51' unless defined?(JRUBY_VERSION) && Gem::Version.new(JRUBY_VERSION) <= Gem::Version.new('9.4')
+  gem 'rubocop', '>= 1.51' unless defined?(JRUBY_VERSION)
 end

--- a/elasticsearch-api/utils/Gemfile
+++ b/elasticsearch-api/utils/Gemfile
@@ -24,5 +24,5 @@ gem 'multi_json'
 gem 'pry'
 gem 'thor'
 
-gem 'rubocop', '>= 1.51' unless defined?(JRUBY_VERSION) && Gem::Version.new(JRUBY_VERSION) <= Gem::Version.new('9.4')
+gem 'rubocop', '>= 1.51' unless defined?(JRUBY_VERSION)
 gem 'debug' unless defined?(JRUBY_VERSION)


### PR DESCRIPTION
We use Rubocop just for development and not currently using JRuby for Rubocop development. This could fix the current dependency problem for now.