### PR TITLE
Update build hash

### DIFF
--- a/elasticsearch-api/lib/elasticsearch/api/actions/async_search/delete.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/async_search/delete.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module AsyncSearch

--- a/elasticsearch-api/lib/elasticsearch/api/actions/async_search/get.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/async_search/get.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module AsyncSearch

--- a/elasticsearch-api/lib/elasticsearch/api/actions/async_search/status.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/async_search/status.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module AsyncSearch

--- a/elasticsearch-api/lib/elasticsearch/api/actions/async_search/submit.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/async_search/submit.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module AsyncSearch

--- a/elasticsearch-api/lib/elasticsearch/api/actions/bulk.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/bulk.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Actions

--- a/elasticsearch-api/lib/elasticsearch/api/actions/cat/aliases.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/cat/aliases.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Cat

--- a/elasticsearch-api/lib/elasticsearch/api/actions/cat/allocation.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/cat/allocation.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Cat

--- a/elasticsearch-api/lib/elasticsearch/api/actions/cat/component_templates.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/cat/component_templates.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Cat

--- a/elasticsearch-api/lib/elasticsearch/api/actions/cat/count.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/cat/count.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Cat

--- a/elasticsearch-api/lib/elasticsearch/api/actions/cat/fielddata.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/cat/fielddata.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Cat

--- a/elasticsearch-api/lib/elasticsearch/api/actions/cat/health.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/cat/health.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Cat

--- a/elasticsearch-api/lib/elasticsearch/api/actions/cat/help.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/cat/help.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Cat

--- a/elasticsearch-api/lib/elasticsearch/api/actions/cat/indices.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/cat/indices.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Cat

--- a/elasticsearch-api/lib/elasticsearch/api/actions/cat/master.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/cat/master.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Cat

--- a/elasticsearch-api/lib/elasticsearch/api/actions/cat/ml_data_frame_analytics.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/cat/ml_data_frame_analytics.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Cat

--- a/elasticsearch-api/lib/elasticsearch/api/actions/cat/ml_datafeeds.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/cat/ml_datafeeds.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Cat

--- a/elasticsearch-api/lib/elasticsearch/api/actions/cat/ml_jobs.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/cat/ml_jobs.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Cat

--- a/elasticsearch-api/lib/elasticsearch/api/actions/cat/ml_trained_models.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/cat/ml_trained_models.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Cat

--- a/elasticsearch-api/lib/elasticsearch/api/actions/cat/nodeattrs.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/cat/nodeattrs.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Cat

--- a/elasticsearch-api/lib/elasticsearch/api/actions/cat/nodes.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/cat/nodes.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Cat

--- a/elasticsearch-api/lib/elasticsearch/api/actions/cat/pending_tasks.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/cat/pending_tasks.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Cat

--- a/elasticsearch-api/lib/elasticsearch/api/actions/cat/plugins.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/cat/plugins.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Cat

--- a/elasticsearch-api/lib/elasticsearch/api/actions/cat/recovery.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/cat/recovery.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Cat

--- a/elasticsearch-api/lib/elasticsearch/api/actions/cat/repositories.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/cat/repositories.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Cat

--- a/elasticsearch-api/lib/elasticsearch/api/actions/cat/segments.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/cat/segments.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Cat

--- a/elasticsearch-api/lib/elasticsearch/api/actions/cat/shards.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/cat/shards.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Cat

--- a/elasticsearch-api/lib/elasticsearch/api/actions/cat/snapshots.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/cat/snapshots.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Cat

--- a/elasticsearch-api/lib/elasticsearch/api/actions/cat/tasks.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/cat/tasks.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Cat

--- a/elasticsearch-api/lib/elasticsearch/api/actions/cat/templates.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/cat/templates.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Cat

--- a/elasticsearch-api/lib/elasticsearch/api/actions/cat/thread_pool.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/cat/thread_pool.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Cat

--- a/elasticsearch-api/lib/elasticsearch/api/actions/cat/transforms.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/cat/transforms.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Cat

--- a/elasticsearch-api/lib/elasticsearch/api/actions/clear_scroll.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/clear_scroll.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Actions

--- a/elasticsearch-api/lib/elasticsearch/api/actions/close_point_in_time.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/close_point_in_time.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Actions

--- a/elasticsearch-api/lib/elasticsearch/api/actions/cluster/allocation_explain.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/cluster/allocation_explain.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Cluster

--- a/elasticsearch-api/lib/elasticsearch/api/actions/cluster/delete_component_template.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/cluster/delete_component_template.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Cluster

--- a/elasticsearch-api/lib/elasticsearch/api/actions/cluster/delete_voting_config_exclusions.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/cluster/delete_voting_config_exclusions.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Cluster

--- a/elasticsearch-api/lib/elasticsearch/api/actions/cluster/exists_component_template.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/cluster/exists_component_template.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Cluster

--- a/elasticsearch-api/lib/elasticsearch/api/actions/cluster/get_component_template.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/cluster/get_component_template.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Cluster

--- a/elasticsearch-api/lib/elasticsearch/api/actions/cluster/get_settings.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/cluster/get_settings.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Cluster

--- a/elasticsearch-api/lib/elasticsearch/api/actions/cluster/health.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/cluster/health.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Cluster

--- a/elasticsearch-api/lib/elasticsearch/api/actions/cluster/info.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/cluster/info.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Cluster

--- a/elasticsearch-api/lib/elasticsearch/api/actions/cluster/pending_tasks.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/cluster/pending_tasks.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Cluster

--- a/elasticsearch-api/lib/elasticsearch/api/actions/cluster/post_voting_config_exclusions.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/cluster/post_voting_config_exclusions.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Cluster

--- a/elasticsearch-api/lib/elasticsearch/api/actions/cluster/put_component_template.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/cluster/put_component_template.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Cluster

--- a/elasticsearch-api/lib/elasticsearch/api/actions/cluster/put_settings.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/cluster/put_settings.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Cluster

--- a/elasticsearch-api/lib/elasticsearch/api/actions/cluster/remote_info.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/cluster/remote_info.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Cluster

--- a/elasticsearch-api/lib/elasticsearch/api/actions/cluster/reroute.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/cluster/reroute.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Cluster

--- a/elasticsearch-api/lib/elasticsearch/api/actions/cluster/state.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/cluster/state.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Cluster

--- a/elasticsearch-api/lib/elasticsearch/api/actions/cluster/stats.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/cluster/stats.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Cluster

--- a/elasticsearch-api/lib/elasticsearch/api/actions/connector/check_in.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/connector/check_in.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Connector

--- a/elasticsearch-api/lib/elasticsearch/api/actions/connector/delete.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/connector/delete.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Connector

--- a/elasticsearch-api/lib/elasticsearch/api/actions/connector/get.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/connector/get.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Connector

--- a/elasticsearch-api/lib/elasticsearch/api/actions/connector/list.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/connector/list.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Connector

--- a/elasticsearch-api/lib/elasticsearch/api/actions/connector/post.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/connector/post.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Connector

--- a/elasticsearch-api/lib/elasticsearch/api/actions/connector/put.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/connector/put.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Connector

--- a/elasticsearch-api/lib/elasticsearch/api/actions/connector/sync_job_cancel.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/connector/sync_job_cancel.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Connector

--- a/elasticsearch-api/lib/elasticsearch/api/actions/connector/sync_job_check_in.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/connector/sync_job_check_in.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Connector

--- a/elasticsearch-api/lib/elasticsearch/api/actions/connector/sync_job_claim.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/connector/sync_job_claim.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Connector

--- a/elasticsearch-api/lib/elasticsearch/api/actions/connector/sync_job_delete.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/connector/sync_job_delete.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Connector

--- a/elasticsearch-api/lib/elasticsearch/api/actions/connector/sync_job_error.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/connector/sync_job_error.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Connector

--- a/elasticsearch-api/lib/elasticsearch/api/actions/connector/sync_job_get.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/connector/sync_job_get.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Connector

--- a/elasticsearch-api/lib/elasticsearch/api/actions/connector/sync_job_list.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/connector/sync_job_list.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Connector

--- a/elasticsearch-api/lib/elasticsearch/api/actions/connector/sync_job_post.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/connector/sync_job_post.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Connector

--- a/elasticsearch-api/lib/elasticsearch/api/actions/connector/sync_job_update_stats.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/connector/sync_job_update_stats.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Connector

--- a/elasticsearch-api/lib/elasticsearch/api/actions/connector/update_active_filtering.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/connector/update_active_filtering.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Connector

--- a/elasticsearch-api/lib/elasticsearch/api/actions/connector/update_api_key_id.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/connector/update_api_key_id.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Connector

--- a/elasticsearch-api/lib/elasticsearch/api/actions/connector/update_configuration.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/connector/update_configuration.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Connector

--- a/elasticsearch-api/lib/elasticsearch/api/actions/connector/update_error.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/connector/update_error.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Connector

--- a/elasticsearch-api/lib/elasticsearch/api/actions/connector/update_features.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/connector/update_features.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Connector

--- a/elasticsearch-api/lib/elasticsearch/api/actions/connector/update_filtering.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/connector/update_filtering.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Connector

--- a/elasticsearch-api/lib/elasticsearch/api/actions/connector/update_filtering_validation.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/connector/update_filtering_validation.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Connector

--- a/elasticsearch-api/lib/elasticsearch/api/actions/connector/update_index_name.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/connector/update_index_name.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Connector

--- a/elasticsearch-api/lib/elasticsearch/api/actions/connector/update_name.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/connector/update_name.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Connector

--- a/elasticsearch-api/lib/elasticsearch/api/actions/connector/update_native.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/connector/update_native.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Connector

--- a/elasticsearch-api/lib/elasticsearch/api/actions/connector/update_pipeline.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/connector/update_pipeline.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Connector

--- a/elasticsearch-api/lib/elasticsearch/api/actions/connector/update_scheduling.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/connector/update_scheduling.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Connector

--- a/elasticsearch-api/lib/elasticsearch/api/actions/connector/update_service_type.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/connector/update_service_type.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Connector

--- a/elasticsearch-api/lib/elasticsearch/api/actions/connector/update_status.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/connector/update_status.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Connector

--- a/elasticsearch-api/lib/elasticsearch/api/actions/count.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/count.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Actions

--- a/elasticsearch-api/lib/elasticsearch/api/actions/create.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/create.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Actions

--- a/elasticsearch-api/lib/elasticsearch/api/actions/cross_cluster_replication/delete_auto_follow_pattern.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/cross_cluster_replication/delete_auto_follow_pattern.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module CrossClusterReplication

--- a/elasticsearch-api/lib/elasticsearch/api/actions/cross_cluster_replication/follow.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/cross_cluster_replication/follow.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module CrossClusterReplication

--- a/elasticsearch-api/lib/elasticsearch/api/actions/cross_cluster_replication/follow_info.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/cross_cluster_replication/follow_info.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module CrossClusterReplication

--- a/elasticsearch-api/lib/elasticsearch/api/actions/cross_cluster_replication/follow_stats.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/cross_cluster_replication/follow_stats.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module CrossClusterReplication

--- a/elasticsearch-api/lib/elasticsearch/api/actions/cross_cluster_replication/forget_follower.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/cross_cluster_replication/forget_follower.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module CrossClusterReplication

--- a/elasticsearch-api/lib/elasticsearch/api/actions/cross_cluster_replication/get_auto_follow_pattern.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/cross_cluster_replication/get_auto_follow_pattern.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module CrossClusterReplication

--- a/elasticsearch-api/lib/elasticsearch/api/actions/cross_cluster_replication/pause_auto_follow_pattern.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/cross_cluster_replication/pause_auto_follow_pattern.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module CrossClusterReplication

--- a/elasticsearch-api/lib/elasticsearch/api/actions/cross_cluster_replication/pause_follow.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/cross_cluster_replication/pause_follow.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module CrossClusterReplication

--- a/elasticsearch-api/lib/elasticsearch/api/actions/cross_cluster_replication/put_auto_follow_pattern.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/cross_cluster_replication/put_auto_follow_pattern.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module CrossClusterReplication

--- a/elasticsearch-api/lib/elasticsearch/api/actions/cross_cluster_replication/resume_auto_follow_pattern.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/cross_cluster_replication/resume_auto_follow_pattern.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module CrossClusterReplication

--- a/elasticsearch-api/lib/elasticsearch/api/actions/cross_cluster_replication/resume_follow.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/cross_cluster_replication/resume_follow.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module CrossClusterReplication

--- a/elasticsearch-api/lib/elasticsearch/api/actions/cross_cluster_replication/stats.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/cross_cluster_replication/stats.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module CrossClusterReplication

--- a/elasticsearch-api/lib/elasticsearch/api/actions/cross_cluster_replication/unfollow.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/cross_cluster_replication/unfollow.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module CrossClusterReplication

--- a/elasticsearch-api/lib/elasticsearch/api/actions/dangling_indices/delete_dangling_index.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/dangling_indices/delete_dangling_index.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module DanglingIndices

--- a/elasticsearch-api/lib/elasticsearch/api/actions/dangling_indices/import_dangling_index.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/dangling_indices/import_dangling_index.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module DanglingIndices

--- a/elasticsearch-api/lib/elasticsearch/api/actions/dangling_indices/list_dangling_indices.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/dangling_indices/list_dangling_indices.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module DanglingIndices

--- a/elasticsearch-api/lib/elasticsearch/api/actions/delete.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/delete.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Actions

--- a/elasticsearch-api/lib/elasticsearch/api/actions/delete_by_query.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/delete_by_query.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Actions

--- a/elasticsearch-api/lib/elasticsearch/api/actions/delete_by_query_rethrottle.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/delete_by_query_rethrottle.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Actions

--- a/elasticsearch-api/lib/elasticsearch/api/actions/delete_script.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/delete_script.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Actions

--- a/elasticsearch-api/lib/elasticsearch/api/actions/enrich/delete_policy.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/enrich/delete_policy.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Enrich

--- a/elasticsearch-api/lib/elasticsearch/api/actions/enrich/execute_policy.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/enrich/execute_policy.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Enrich

--- a/elasticsearch-api/lib/elasticsearch/api/actions/enrich/get_policy.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/enrich/get_policy.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Enrich

--- a/elasticsearch-api/lib/elasticsearch/api/actions/enrich/put_policy.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/enrich/put_policy.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Enrich

--- a/elasticsearch-api/lib/elasticsearch/api/actions/enrich/stats.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/enrich/stats.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Enrich

--- a/elasticsearch-api/lib/elasticsearch/api/actions/eql/delete.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/eql/delete.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Eql

--- a/elasticsearch-api/lib/elasticsearch/api/actions/eql/get.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/eql/get.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Eql

--- a/elasticsearch-api/lib/elasticsearch/api/actions/eql/get_status.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/eql/get_status.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Eql

--- a/elasticsearch-api/lib/elasticsearch/api/actions/eql/search.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/eql/search.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Eql

--- a/elasticsearch-api/lib/elasticsearch/api/actions/esql/async_query.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/esql/async_query.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Esql

--- a/elasticsearch-api/lib/elasticsearch/api/actions/esql/async_query_delete.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/esql/async_query_delete.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Esql

--- a/elasticsearch-api/lib/elasticsearch/api/actions/esql/async_query_get.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/esql/async_query_get.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Esql

--- a/elasticsearch-api/lib/elasticsearch/api/actions/esql/async_query_stop.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/esql/async_query_stop.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Esql

--- a/elasticsearch-api/lib/elasticsearch/api/actions/esql/query.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/esql/query.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Esql

--- a/elasticsearch-api/lib/elasticsearch/api/actions/exists.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/exists.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Actions

--- a/elasticsearch-api/lib/elasticsearch/api/actions/exists_source.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/exists_source.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Actions

--- a/elasticsearch-api/lib/elasticsearch/api/actions/explain.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/explain.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Actions

--- a/elasticsearch-api/lib/elasticsearch/api/actions/features/get_features.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/features/get_features.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Features

--- a/elasticsearch-api/lib/elasticsearch/api/actions/features/reset_features.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/features/reset_features.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Features

--- a/elasticsearch-api/lib/elasticsearch/api/actions/field_caps.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/field_caps.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Actions

--- a/elasticsearch-api/lib/elasticsearch/api/actions/fleet/global_checkpoints.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/fleet/global_checkpoints.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Fleet

--- a/elasticsearch-api/lib/elasticsearch/api/actions/fleet/msearch.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/fleet/msearch.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Fleet

--- a/elasticsearch-api/lib/elasticsearch/api/actions/fleet/search.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/fleet/search.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Fleet

--- a/elasticsearch-api/lib/elasticsearch/api/actions/get.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/get.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Actions

--- a/elasticsearch-api/lib/elasticsearch/api/actions/get_script.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/get_script.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Actions

--- a/elasticsearch-api/lib/elasticsearch/api/actions/get_script_context.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/get_script_context.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Actions

--- a/elasticsearch-api/lib/elasticsearch/api/actions/get_script_languages.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/get_script_languages.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Actions

--- a/elasticsearch-api/lib/elasticsearch/api/actions/get_source.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/get_source.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Actions

--- a/elasticsearch-api/lib/elasticsearch/api/actions/graph/explore.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/graph/explore.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Graph

--- a/elasticsearch-api/lib/elasticsearch/api/actions/health_report.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/health_report.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Actions

--- a/elasticsearch-api/lib/elasticsearch/api/actions/index.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/index.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Actions

--- a/elasticsearch-api/lib/elasticsearch/api/actions/index_lifecycle_management/delete_lifecycle.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/index_lifecycle_management/delete_lifecycle.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module IndexLifecycleManagement

--- a/elasticsearch-api/lib/elasticsearch/api/actions/index_lifecycle_management/explain_lifecycle.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/index_lifecycle_management/explain_lifecycle.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module IndexLifecycleManagement

--- a/elasticsearch-api/lib/elasticsearch/api/actions/index_lifecycle_management/get_lifecycle.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/index_lifecycle_management/get_lifecycle.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module IndexLifecycleManagement

--- a/elasticsearch-api/lib/elasticsearch/api/actions/index_lifecycle_management/get_status.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/index_lifecycle_management/get_status.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module IndexLifecycleManagement

--- a/elasticsearch-api/lib/elasticsearch/api/actions/index_lifecycle_management/migrate_to_data_tiers.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/index_lifecycle_management/migrate_to_data_tiers.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module IndexLifecycleManagement

--- a/elasticsearch-api/lib/elasticsearch/api/actions/index_lifecycle_management/move_to_step.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/index_lifecycle_management/move_to_step.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module IndexLifecycleManagement

--- a/elasticsearch-api/lib/elasticsearch/api/actions/index_lifecycle_management/put_lifecycle.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/index_lifecycle_management/put_lifecycle.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module IndexLifecycleManagement

--- a/elasticsearch-api/lib/elasticsearch/api/actions/index_lifecycle_management/remove_policy.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/index_lifecycle_management/remove_policy.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module IndexLifecycleManagement

--- a/elasticsearch-api/lib/elasticsearch/api/actions/index_lifecycle_management/retry.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/index_lifecycle_management/retry.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module IndexLifecycleManagement

--- a/elasticsearch-api/lib/elasticsearch/api/actions/index_lifecycle_management/start.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/index_lifecycle_management/start.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module IndexLifecycleManagement

--- a/elasticsearch-api/lib/elasticsearch/api/actions/index_lifecycle_management/stop.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/index_lifecycle_management/stop.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module IndexLifecycleManagement

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/add_block.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/add_block.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Indices

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/analyze.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/analyze.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Indices

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/cancel_migrate_reindex.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/cancel_migrate_reindex.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Indices

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/clear_cache.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/clear_cache.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Indices

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/clone.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/clone.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Indices

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/close.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/close.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Indices

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/create.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/create.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Indices

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/create_data_stream.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/create_data_stream.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Indices

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/create_from.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/create_from.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Indices

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/data_streams_stats.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/data_streams_stats.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Indices

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/delete.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/delete.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Indices

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/delete_alias.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/delete_alias.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Indices

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/delete_data_lifecycle.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/delete_data_lifecycle.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Indices

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/delete_data_stream.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/delete_data_stream.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Indices

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/delete_index_template.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/delete_index_template.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Indices

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/delete_template.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/delete_template.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Indices

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/disk_usage.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/disk_usage.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Indices

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/downsample.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/downsample.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Indices

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/exists.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/exists.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Indices

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/exists_alias.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/exists_alias.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Indices

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/exists_index_template.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/exists_index_template.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Indices

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/exists_template.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/exists_template.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Indices

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/explain_data_lifecycle.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/explain_data_lifecycle.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Indices

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/field_usage_stats.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/field_usage_stats.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Indices

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/flush.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/flush.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Indices

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/forcemerge.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/forcemerge.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Indices

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/get.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/get.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Indices

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/get_alias.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/get_alias.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Indices

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/get_data_lifecycle.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/get_data_lifecycle.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Indices

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/get_data_lifecycle_stats.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/get_data_lifecycle_stats.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Indices

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/get_data_stream.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/get_data_stream.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Indices

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/get_field_mapping.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/get_field_mapping.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Indices

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/get_index_template.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/get_index_template.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Indices

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/get_mapping.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/get_mapping.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Indices

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/get_migrate_reindex_status.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/get_migrate_reindex_status.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Indices

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/get_settings.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/get_settings.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Indices

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/get_template.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/get_template.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Indices

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/migrate_reindex.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/migrate_reindex.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Indices

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/migrate_to_data_stream.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/migrate_to_data_stream.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Indices

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/modify_data_stream.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/modify_data_stream.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Indices

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/open.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/open.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Indices

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/promote_data_stream.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/promote_data_stream.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Indices

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/put_alias.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/put_alias.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Indices

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/put_data_lifecycle.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/put_data_lifecycle.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Indices

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/put_index_template.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/put_index_template.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Indices

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/put_mapping.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/put_mapping.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Indices

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/put_settings.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/put_settings.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Indices

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/put_template.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/put_template.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Indices

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/recovery.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/recovery.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Indices

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/refresh.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/refresh.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Indices

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/reload_search_analyzers.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/reload_search_analyzers.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Indices

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/resolve_cluster.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/resolve_cluster.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Indices

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/resolve_index.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/resolve_index.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Indices

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/rollover.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/rollover.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Indices

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/segments.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/segments.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Indices

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/shard_stores.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/shard_stores.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Indices

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/shrink.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/shrink.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Indices

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/simulate_index_template.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/simulate_index_template.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Indices

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/simulate_template.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/simulate_template.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Indices

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/split.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/split.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Indices

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/stats.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/stats.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Indices

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/update_aliases.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/update_aliases.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Indices

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/validate_query.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/validate_query.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Indices

--- a/elasticsearch-api/lib/elasticsearch/api/actions/inference/chat_completion_unified.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/inference/chat_completion_unified.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Inference

--- a/elasticsearch-api/lib/elasticsearch/api/actions/inference/completion.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/inference/completion.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Inference

--- a/elasticsearch-api/lib/elasticsearch/api/actions/inference/delete.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/inference/delete.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Inference

--- a/elasticsearch-api/lib/elasticsearch/api/actions/inference/get.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/inference/get.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Inference

--- a/elasticsearch-api/lib/elasticsearch/api/actions/inference/post_eis_chat_completion.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/inference/post_eis_chat_completion.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Inference

--- a/elasticsearch-api/lib/elasticsearch/api/actions/inference/put.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/inference/put.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Inference

--- a/elasticsearch-api/lib/elasticsearch/api/actions/inference/put_alibabacloud.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/inference/put_alibabacloud.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Inference

--- a/elasticsearch-api/lib/elasticsearch/api/actions/inference/put_amazonbedrock.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/inference/put_amazonbedrock.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Inference

--- a/elasticsearch-api/lib/elasticsearch/api/actions/inference/put_anthropic.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/inference/put_anthropic.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Inference

--- a/elasticsearch-api/lib/elasticsearch/api/actions/inference/put_azureaistudio.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/inference/put_azureaistudio.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Inference

--- a/elasticsearch-api/lib/elasticsearch/api/actions/inference/put_azureopenai.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/inference/put_azureopenai.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Inference

--- a/elasticsearch-api/lib/elasticsearch/api/actions/inference/put_cohere.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/inference/put_cohere.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Inference

--- a/elasticsearch-api/lib/elasticsearch/api/actions/inference/put_eis.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/inference/put_eis.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Inference

--- a/elasticsearch-api/lib/elasticsearch/api/actions/inference/put_elasticsearch.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/inference/put_elasticsearch.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Inference

--- a/elasticsearch-api/lib/elasticsearch/api/actions/inference/put_elser.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/inference/put_elser.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Inference

--- a/elasticsearch-api/lib/elasticsearch/api/actions/inference/put_googleaistudio.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/inference/put_googleaistudio.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Inference

--- a/elasticsearch-api/lib/elasticsearch/api/actions/inference/put_googlevertexai.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/inference/put_googlevertexai.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Inference

--- a/elasticsearch-api/lib/elasticsearch/api/actions/inference/put_hugging_face.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/inference/put_hugging_face.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Inference

--- a/elasticsearch-api/lib/elasticsearch/api/actions/inference/put_jinaai.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/inference/put_jinaai.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Inference

--- a/elasticsearch-api/lib/elasticsearch/api/actions/inference/put_mistral.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/inference/put_mistral.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Inference

--- a/elasticsearch-api/lib/elasticsearch/api/actions/inference/put_openai.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/inference/put_openai.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Inference

--- a/elasticsearch-api/lib/elasticsearch/api/actions/inference/put_voyageai.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/inference/put_voyageai.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Inference

--- a/elasticsearch-api/lib/elasticsearch/api/actions/inference/put_watsonx.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/inference/put_watsonx.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Inference

--- a/elasticsearch-api/lib/elasticsearch/api/actions/inference/rerank.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/inference/rerank.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Inference

--- a/elasticsearch-api/lib/elasticsearch/api/actions/inference/sparse_embedding.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/inference/sparse_embedding.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Inference

--- a/elasticsearch-api/lib/elasticsearch/api/actions/inference/stream_completion.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/inference/stream_completion.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Inference

--- a/elasticsearch-api/lib/elasticsearch/api/actions/inference/text_embedding.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/inference/text_embedding.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Inference

--- a/elasticsearch-api/lib/elasticsearch/api/actions/inference/update.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/inference/update.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Inference

--- a/elasticsearch-api/lib/elasticsearch/api/actions/info.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/info.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Actions

--- a/elasticsearch-api/lib/elasticsearch/api/actions/ingest/delete_geoip_database.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/ingest/delete_geoip_database.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Ingest

--- a/elasticsearch-api/lib/elasticsearch/api/actions/ingest/delete_ip_location_database.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/ingest/delete_ip_location_database.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Ingest

--- a/elasticsearch-api/lib/elasticsearch/api/actions/ingest/delete_pipeline.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/ingest/delete_pipeline.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Ingest

--- a/elasticsearch-api/lib/elasticsearch/api/actions/ingest/geo_ip_stats.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/ingest/geo_ip_stats.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Ingest

--- a/elasticsearch-api/lib/elasticsearch/api/actions/ingest/get_geoip_database.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/ingest/get_geoip_database.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Ingest

--- a/elasticsearch-api/lib/elasticsearch/api/actions/ingest/get_ip_location_database.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/ingest/get_ip_location_database.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Ingest

--- a/elasticsearch-api/lib/elasticsearch/api/actions/ingest/get_pipeline.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/ingest/get_pipeline.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Ingest

--- a/elasticsearch-api/lib/elasticsearch/api/actions/ingest/processor_grok.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/ingest/processor_grok.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Ingest

--- a/elasticsearch-api/lib/elasticsearch/api/actions/ingest/put_geoip_database.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/ingest/put_geoip_database.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Ingest

--- a/elasticsearch-api/lib/elasticsearch/api/actions/ingest/put_ip_location_database.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/ingest/put_ip_location_database.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Ingest

--- a/elasticsearch-api/lib/elasticsearch/api/actions/ingest/put_pipeline.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/ingest/put_pipeline.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Ingest

--- a/elasticsearch-api/lib/elasticsearch/api/actions/ingest/simulate.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/ingest/simulate.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Ingest

--- a/elasticsearch-api/lib/elasticsearch/api/actions/knn_search.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/knn_search.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Actions

--- a/elasticsearch-api/lib/elasticsearch/api/actions/license/delete.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/license/delete.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module License

--- a/elasticsearch-api/lib/elasticsearch/api/actions/license/get.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/license/get.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module License

--- a/elasticsearch-api/lib/elasticsearch/api/actions/license/get_basic_status.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/license/get_basic_status.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module License

--- a/elasticsearch-api/lib/elasticsearch/api/actions/license/get_trial_status.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/license/get_trial_status.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module License

--- a/elasticsearch-api/lib/elasticsearch/api/actions/license/post.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/license/post.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module License

--- a/elasticsearch-api/lib/elasticsearch/api/actions/license/post_start_basic.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/license/post_start_basic.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module License

--- a/elasticsearch-api/lib/elasticsearch/api/actions/license/post_start_trial.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/license/post_start_trial.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module License

--- a/elasticsearch-api/lib/elasticsearch/api/actions/logstash/delete_pipeline.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/logstash/delete_pipeline.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Logstash

--- a/elasticsearch-api/lib/elasticsearch/api/actions/logstash/get_pipeline.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/logstash/get_pipeline.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Logstash

--- a/elasticsearch-api/lib/elasticsearch/api/actions/logstash/put_pipeline.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/logstash/put_pipeline.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Logstash

--- a/elasticsearch-api/lib/elasticsearch/api/actions/machine_learning/clear_trained_model_deployment_cache.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/machine_learning/clear_trained_model_deployment_cache.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module MachineLearning

--- a/elasticsearch-api/lib/elasticsearch/api/actions/machine_learning/close_job.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/machine_learning/close_job.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module MachineLearning

--- a/elasticsearch-api/lib/elasticsearch/api/actions/machine_learning/delete_calendar.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/machine_learning/delete_calendar.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module MachineLearning

--- a/elasticsearch-api/lib/elasticsearch/api/actions/machine_learning/delete_calendar_event.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/machine_learning/delete_calendar_event.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module MachineLearning

--- a/elasticsearch-api/lib/elasticsearch/api/actions/machine_learning/delete_calendar_job.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/machine_learning/delete_calendar_job.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module MachineLearning

--- a/elasticsearch-api/lib/elasticsearch/api/actions/machine_learning/delete_data_frame_analytics.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/machine_learning/delete_data_frame_analytics.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module MachineLearning

--- a/elasticsearch-api/lib/elasticsearch/api/actions/machine_learning/delete_datafeed.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/machine_learning/delete_datafeed.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module MachineLearning

--- a/elasticsearch-api/lib/elasticsearch/api/actions/machine_learning/delete_expired_data.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/machine_learning/delete_expired_data.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module MachineLearning

--- a/elasticsearch-api/lib/elasticsearch/api/actions/machine_learning/delete_filter.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/machine_learning/delete_filter.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module MachineLearning

--- a/elasticsearch-api/lib/elasticsearch/api/actions/machine_learning/delete_forecast.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/machine_learning/delete_forecast.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module MachineLearning

--- a/elasticsearch-api/lib/elasticsearch/api/actions/machine_learning/delete_job.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/machine_learning/delete_job.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module MachineLearning

--- a/elasticsearch-api/lib/elasticsearch/api/actions/machine_learning/delete_model_snapshot.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/machine_learning/delete_model_snapshot.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module MachineLearning

--- a/elasticsearch-api/lib/elasticsearch/api/actions/machine_learning/delete_trained_model.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/machine_learning/delete_trained_model.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module MachineLearning

--- a/elasticsearch-api/lib/elasticsearch/api/actions/machine_learning/delete_trained_model_alias.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/machine_learning/delete_trained_model_alias.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module MachineLearning

--- a/elasticsearch-api/lib/elasticsearch/api/actions/machine_learning/estimate_model_memory.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/machine_learning/estimate_model_memory.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module MachineLearning

--- a/elasticsearch-api/lib/elasticsearch/api/actions/machine_learning/evaluate_data_frame.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/machine_learning/evaluate_data_frame.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module MachineLearning

--- a/elasticsearch-api/lib/elasticsearch/api/actions/machine_learning/explain_data_frame_analytics.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/machine_learning/explain_data_frame_analytics.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module MachineLearning

--- a/elasticsearch-api/lib/elasticsearch/api/actions/machine_learning/flush_job.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/machine_learning/flush_job.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module MachineLearning

--- a/elasticsearch-api/lib/elasticsearch/api/actions/machine_learning/forecast.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/machine_learning/forecast.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module MachineLearning

--- a/elasticsearch-api/lib/elasticsearch/api/actions/machine_learning/get_buckets.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/machine_learning/get_buckets.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module MachineLearning

--- a/elasticsearch-api/lib/elasticsearch/api/actions/machine_learning/get_calendar_events.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/machine_learning/get_calendar_events.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module MachineLearning

--- a/elasticsearch-api/lib/elasticsearch/api/actions/machine_learning/get_calendars.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/machine_learning/get_calendars.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module MachineLearning

--- a/elasticsearch-api/lib/elasticsearch/api/actions/machine_learning/get_categories.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/machine_learning/get_categories.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module MachineLearning

--- a/elasticsearch-api/lib/elasticsearch/api/actions/machine_learning/get_data_frame_analytics.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/machine_learning/get_data_frame_analytics.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module MachineLearning

--- a/elasticsearch-api/lib/elasticsearch/api/actions/machine_learning/get_data_frame_analytics_stats.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/machine_learning/get_data_frame_analytics_stats.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module MachineLearning

--- a/elasticsearch-api/lib/elasticsearch/api/actions/machine_learning/get_datafeed_stats.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/machine_learning/get_datafeed_stats.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module MachineLearning

--- a/elasticsearch-api/lib/elasticsearch/api/actions/machine_learning/get_datafeeds.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/machine_learning/get_datafeeds.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module MachineLearning

--- a/elasticsearch-api/lib/elasticsearch/api/actions/machine_learning/get_filters.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/machine_learning/get_filters.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module MachineLearning

--- a/elasticsearch-api/lib/elasticsearch/api/actions/machine_learning/get_influencers.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/machine_learning/get_influencers.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module MachineLearning

--- a/elasticsearch-api/lib/elasticsearch/api/actions/machine_learning/get_job_stats.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/machine_learning/get_job_stats.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module MachineLearning

--- a/elasticsearch-api/lib/elasticsearch/api/actions/machine_learning/get_jobs.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/machine_learning/get_jobs.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module MachineLearning

--- a/elasticsearch-api/lib/elasticsearch/api/actions/machine_learning/get_memory_stats.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/machine_learning/get_memory_stats.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module MachineLearning

--- a/elasticsearch-api/lib/elasticsearch/api/actions/machine_learning/get_model_snapshot_upgrade_stats.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/machine_learning/get_model_snapshot_upgrade_stats.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module MachineLearning

--- a/elasticsearch-api/lib/elasticsearch/api/actions/machine_learning/get_model_snapshots.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/machine_learning/get_model_snapshots.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module MachineLearning

--- a/elasticsearch-api/lib/elasticsearch/api/actions/machine_learning/get_overall_buckets.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/machine_learning/get_overall_buckets.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module MachineLearning

--- a/elasticsearch-api/lib/elasticsearch/api/actions/machine_learning/get_records.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/machine_learning/get_records.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module MachineLearning

--- a/elasticsearch-api/lib/elasticsearch/api/actions/machine_learning/get_trained_models.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/machine_learning/get_trained_models.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module MachineLearning

--- a/elasticsearch-api/lib/elasticsearch/api/actions/machine_learning/get_trained_models_stats.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/machine_learning/get_trained_models_stats.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module MachineLearning

--- a/elasticsearch-api/lib/elasticsearch/api/actions/machine_learning/infer_trained_model.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/machine_learning/infer_trained_model.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module MachineLearning

--- a/elasticsearch-api/lib/elasticsearch/api/actions/machine_learning/info.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/machine_learning/info.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module MachineLearning

--- a/elasticsearch-api/lib/elasticsearch/api/actions/machine_learning/open_job.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/machine_learning/open_job.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module MachineLearning

--- a/elasticsearch-api/lib/elasticsearch/api/actions/machine_learning/post_calendar_events.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/machine_learning/post_calendar_events.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module MachineLearning

--- a/elasticsearch-api/lib/elasticsearch/api/actions/machine_learning/post_data.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/machine_learning/post_data.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module MachineLearning

--- a/elasticsearch-api/lib/elasticsearch/api/actions/machine_learning/preview_data_frame_analytics.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/machine_learning/preview_data_frame_analytics.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module MachineLearning

--- a/elasticsearch-api/lib/elasticsearch/api/actions/machine_learning/preview_datafeed.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/machine_learning/preview_datafeed.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module MachineLearning

--- a/elasticsearch-api/lib/elasticsearch/api/actions/machine_learning/put_calendar.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/machine_learning/put_calendar.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module MachineLearning

--- a/elasticsearch-api/lib/elasticsearch/api/actions/machine_learning/put_calendar_job.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/machine_learning/put_calendar_job.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module MachineLearning

--- a/elasticsearch-api/lib/elasticsearch/api/actions/machine_learning/put_data_frame_analytics.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/machine_learning/put_data_frame_analytics.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module MachineLearning

--- a/elasticsearch-api/lib/elasticsearch/api/actions/machine_learning/put_datafeed.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/machine_learning/put_datafeed.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module MachineLearning

--- a/elasticsearch-api/lib/elasticsearch/api/actions/machine_learning/put_filter.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/machine_learning/put_filter.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module MachineLearning

--- a/elasticsearch-api/lib/elasticsearch/api/actions/machine_learning/put_job.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/machine_learning/put_job.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module MachineLearning

--- a/elasticsearch-api/lib/elasticsearch/api/actions/machine_learning/put_trained_model.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/machine_learning/put_trained_model.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module MachineLearning

--- a/elasticsearch-api/lib/elasticsearch/api/actions/machine_learning/put_trained_model_alias.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/machine_learning/put_trained_model_alias.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module MachineLearning

--- a/elasticsearch-api/lib/elasticsearch/api/actions/machine_learning/put_trained_model_definition_part.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/machine_learning/put_trained_model_definition_part.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module MachineLearning

--- a/elasticsearch-api/lib/elasticsearch/api/actions/machine_learning/put_trained_model_vocabulary.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/machine_learning/put_trained_model_vocabulary.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module MachineLearning

--- a/elasticsearch-api/lib/elasticsearch/api/actions/machine_learning/reset_job.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/machine_learning/reset_job.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module MachineLearning

--- a/elasticsearch-api/lib/elasticsearch/api/actions/machine_learning/revert_model_snapshot.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/machine_learning/revert_model_snapshot.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module MachineLearning

--- a/elasticsearch-api/lib/elasticsearch/api/actions/machine_learning/set_upgrade_mode.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/machine_learning/set_upgrade_mode.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module MachineLearning

--- a/elasticsearch-api/lib/elasticsearch/api/actions/machine_learning/start_data_frame_analytics.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/machine_learning/start_data_frame_analytics.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module MachineLearning

--- a/elasticsearch-api/lib/elasticsearch/api/actions/machine_learning/start_datafeed.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/machine_learning/start_datafeed.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module MachineLearning

--- a/elasticsearch-api/lib/elasticsearch/api/actions/machine_learning/start_trained_model_deployment.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/machine_learning/start_trained_model_deployment.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module MachineLearning

--- a/elasticsearch-api/lib/elasticsearch/api/actions/machine_learning/stop_data_frame_analytics.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/machine_learning/stop_data_frame_analytics.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module MachineLearning

--- a/elasticsearch-api/lib/elasticsearch/api/actions/machine_learning/stop_datafeed.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/machine_learning/stop_datafeed.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module MachineLearning

--- a/elasticsearch-api/lib/elasticsearch/api/actions/machine_learning/stop_trained_model_deployment.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/machine_learning/stop_trained_model_deployment.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module MachineLearning

--- a/elasticsearch-api/lib/elasticsearch/api/actions/machine_learning/update_data_frame_analytics.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/machine_learning/update_data_frame_analytics.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module MachineLearning

--- a/elasticsearch-api/lib/elasticsearch/api/actions/machine_learning/update_datafeed.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/machine_learning/update_datafeed.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module MachineLearning

--- a/elasticsearch-api/lib/elasticsearch/api/actions/machine_learning/update_filter.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/machine_learning/update_filter.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module MachineLearning

--- a/elasticsearch-api/lib/elasticsearch/api/actions/machine_learning/update_job.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/machine_learning/update_job.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module MachineLearning

--- a/elasticsearch-api/lib/elasticsearch/api/actions/machine_learning/update_model_snapshot.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/machine_learning/update_model_snapshot.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module MachineLearning

--- a/elasticsearch-api/lib/elasticsearch/api/actions/machine_learning/update_trained_model_deployment.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/machine_learning/update_trained_model_deployment.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module MachineLearning

--- a/elasticsearch-api/lib/elasticsearch/api/actions/machine_learning/upgrade_job_snapshot.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/machine_learning/upgrade_job_snapshot.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module MachineLearning

--- a/elasticsearch-api/lib/elasticsearch/api/actions/mget.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/mget.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Actions

--- a/elasticsearch-api/lib/elasticsearch/api/actions/migration/deprecations.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/migration/deprecations.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Migration

--- a/elasticsearch-api/lib/elasticsearch/api/actions/migration/get_feature_upgrade_status.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/migration/get_feature_upgrade_status.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Migration

--- a/elasticsearch-api/lib/elasticsearch/api/actions/migration/post_feature_upgrade.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/migration/post_feature_upgrade.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Migration

--- a/elasticsearch-api/lib/elasticsearch/api/actions/msearch.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/msearch.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Actions

--- a/elasticsearch-api/lib/elasticsearch/api/actions/msearch_template.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/msearch_template.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Actions

--- a/elasticsearch-api/lib/elasticsearch/api/actions/mtermvectors.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/mtermvectors.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Actions

--- a/elasticsearch-api/lib/elasticsearch/api/actions/nodes/clear_repositories_metering_archive.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/nodes/clear_repositories_metering_archive.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Nodes

--- a/elasticsearch-api/lib/elasticsearch/api/actions/nodes/get_repositories_metering_info.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/nodes/get_repositories_metering_info.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Nodes

--- a/elasticsearch-api/lib/elasticsearch/api/actions/nodes/hot_threads.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/nodes/hot_threads.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Nodes

--- a/elasticsearch-api/lib/elasticsearch/api/actions/nodes/info.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/nodes/info.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Nodes

--- a/elasticsearch-api/lib/elasticsearch/api/actions/nodes/reload_secure_settings.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/nodes/reload_secure_settings.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Nodes

--- a/elasticsearch-api/lib/elasticsearch/api/actions/nodes/stats.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/nodes/stats.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Nodes

--- a/elasticsearch-api/lib/elasticsearch/api/actions/nodes/usage.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/nodes/usage.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Nodes

--- a/elasticsearch-api/lib/elasticsearch/api/actions/open_point_in_time.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/open_point_in_time.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Actions

--- a/elasticsearch-api/lib/elasticsearch/api/actions/ping.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/ping.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Actions

--- a/elasticsearch-api/lib/elasticsearch/api/actions/put_script.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/put_script.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Actions

--- a/elasticsearch-api/lib/elasticsearch/api/actions/query_rules/delete_rule.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/query_rules/delete_rule.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module QueryRules

--- a/elasticsearch-api/lib/elasticsearch/api/actions/query_rules/delete_ruleset.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/query_rules/delete_ruleset.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module QueryRules

--- a/elasticsearch-api/lib/elasticsearch/api/actions/query_rules/get_rule.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/query_rules/get_rule.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module QueryRules

--- a/elasticsearch-api/lib/elasticsearch/api/actions/query_rules/get_ruleset.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/query_rules/get_ruleset.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module QueryRules

--- a/elasticsearch-api/lib/elasticsearch/api/actions/query_rules/list_rulesets.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/query_rules/list_rulesets.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module QueryRules

--- a/elasticsearch-api/lib/elasticsearch/api/actions/query_rules/put_rule.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/query_rules/put_rule.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module QueryRules

--- a/elasticsearch-api/lib/elasticsearch/api/actions/query_rules/put_ruleset.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/query_rules/put_ruleset.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module QueryRules

--- a/elasticsearch-api/lib/elasticsearch/api/actions/query_rules/test.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/query_rules/test.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module QueryRules

--- a/elasticsearch-api/lib/elasticsearch/api/actions/rank_eval.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/rank_eval.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Actions

--- a/elasticsearch-api/lib/elasticsearch/api/actions/reindex.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/reindex.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Actions

--- a/elasticsearch-api/lib/elasticsearch/api/actions/reindex_rethrottle.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/reindex_rethrottle.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Actions

--- a/elasticsearch-api/lib/elasticsearch/api/actions/render_search_template.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/render_search_template.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Actions

--- a/elasticsearch-api/lib/elasticsearch/api/actions/scripts_painless_execute.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/scripts_painless_execute.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Actions

--- a/elasticsearch-api/lib/elasticsearch/api/actions/scroll.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/scroll.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Actions

--- a/elasticsearch-api/lib/elasticsearch/api/actions/search.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/search.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Actions

--- a/elasticsearch-api/lib/elasticsearch/api/actions/search_application/delete.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/search_application/delete.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module SearchApplication

--- a/elasticsearch-api/lib/elasticsearch/api/actions/search_application/delete_behavioral_analytics.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/search_application/delete_behavioral_analytics.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module SearchApplication

--- a/elasticsearch-api/lib/elasticsearch/api/actions/search_application/get.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/search_application/get.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module SearchApplication

--- a/elasticsearch-api/lib/elasticsearch/api/actions/search_application/get_behavioral_analytics.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/search_application/get_behavioral_analytics.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module SearchApplication

--- a/elasticsearch-api/lib/elasticsearch/api/actions/search_application/list.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/search_application/list.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module SearchApplication

--- a/elasticsearch-api/lib/elasticsearch/api/actions/search_application/post_behavioral_analytics_event.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/search_application/post_behavioral_analytics_event.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module SearchApplication

--- a/elasticsearch-api/lib/elasticsearch/api/actions/search_application/put.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/search_application/put.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module SearchApplication

--- a/elasticsearch-api/lib/elasticsearch/api/actions/search_application/put_behavioral_analytics.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/search_application/put_behavioral_analytics.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module SearchApplication

--- a/elasticsearch-api/lib/elasticsearch/api/actions/search_application/render_query.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/search_application/render_query.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module SearchApplication

--- a/elasticsearch-api/lib/elasticsearch/api/actions/search_application/search.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/search_application/search.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module SearchApplication

--- a/elasticsearch-api/lib/elasticsearch/api/actions/search_mvt.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/search_mvt.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Actions

--- a/elasticsearch-api/lib/elasticsearch/api/actions/search_shards.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/search_shards.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Actions

--- a/elasticsearch-api/lib/elasticsearch/api/actions/search_template.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/search_template.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Actions

--- a/elasticsearch-api/lib/elasticsearch/api/actions/searchable_snapshots/cache_stats.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/searchable_snapshots/cache_stats.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module SearchableSnapshots

--- a/elasticsearch-api/lib/elasticsearch/api/actions/searchable_snapshots/clear_cache.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/searchable_snapshots/clear_cache.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module SearchableSnapshots

--- a/elasticsearch-api/lib/elasticsearch/api/actions/searchable_snapshots/mount.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/searchable_snapshots/mount.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module SearchableSnapshots

--- a/elasticsearch-api/lib/elasticsearch/api/actions/searchable_snapshots/stats.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/searchable_snapshots/stats.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module SearchableSnapshots

--- a/elasticsearch-api/lib/elasticsearch/api/actions/security/activate_user_profile.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/security/activate_user_profile.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Security

--- a/elasticsearch-api/lib/elasticsearch/api/actions/security/authenticate.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/security/authenticate.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Security

--- a/elasticsearch-api/lib/elasticsearch/api/actions/security/bulk_delete_role.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/security/bulk_delete_role.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Security

--- a/elasticsearch-api/lib/elasticsearch/api/actions/security/bulk_put_role.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/security/bulk_put_role.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Security

--- a/elasticsearch-api/lib/elasticsearch/api/actions/security/bulk_update_api_keys.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/security/bulk_update_api_keys.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Security

--- a/elasticsearch-api/lib/elasticsearch/api/actions/security/change_password.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/security/change_password.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Security

--- a/elasticsearch-api/lib/elasticsearch/api/actions/security/clear_api_key_cache.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/security/clear_api_key_cache.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Security

--- a/elasticsearch-api/lib/elasticsearch/api/actions/security/clear_cached_privileges.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/security/clear_cached_privileges.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Security

--- a/elasticsearch-api/lib/elasticsearch/api/actions/security/clear_cached_realms.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/security/clear_cached_realms.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Security

--- a/elasticsearch-api/lib/elasticsearch/api/actions/security/clear_cached_roles.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/security/clear_cached_roles.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Security

--- a/elasticsearch-api/lib/elasticsearch/api/actions/security/clear_cached_service_tokens.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/security/clear_cached_service_tokens.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Security

--- a/elasticsearch-api/lib/elasticsearch/api/actions/security/create_api_key.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/security/create_api_key.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Security

--- a/elasticsearch-api/lib/elasticsearch/api/actions/security/create_cross_cluster_api_key.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/security/create_cross_cluster_api_key.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Security

--- a/elasticsearch-api/lib/elasticsearch/api/actions/security/create_service_token.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/security/create_service_token.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Security

--- a/elasticsearch-api/lib/elasticsearch/api/actions/security/delegate_pki.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/security/delegate_pki.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Security

--- a/elasticsearch-api/lib/elasticsearch/api/actions/security/delete_privileges.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/security/delete_privileges.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Security

--- a/elasticsearch-api/lib/elasticsearch/api/actions/security/delete_role.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/security/delete_role.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Security

--- a/elasticsearch-api/lib/elasticsearch/api/actions/security/delete_role_mapping.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/security/delete_role_mapping.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Security

--- a/elasticsearch-api/lib/elasticsearch/api/actions/security/delete_service_token.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/security/delete_service_token.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Security

--- a/elasticsearch-api/lib/elasticsearch/api/actions/security/delete_user.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/security/delete_user.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Security

--- a/elasticsearch-api/lib/elasticsearch/api/actions/security/disable_user.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/security/disable_user.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Security

--- a/elasticsearch-api/lib/elasticsearch/api/actions/security/disable_user_profile.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/security/disable_user_profile.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Security

--- a/elasticsearch-api/lib/elasticsearch/api/actions/security/enable_user.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/security/enable_user.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Security

--- a/elasticsearch-api/lib/elasticsearch/api/actions/security/enable_user_profile.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/security/enable_user_profile.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Security

--- a/elasticsearch-api/lib/elasticsearch/api/actions/security/enroll_kibana.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/security/enroll_kibana.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Security

--- a/elasticsearch-api/lib/elasticsearch/api/actions/security/enroll_node.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/security/enroll_node.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Security

--- a/elasticsearch-api/lib/elasticsearch/api/actions/security/get_api_key.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/security/get_api_key.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Security

--- a/elasticsearch-api/lib/elasticsearch/api/actions/security/get_builtin_privileges.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/security/get_builtin_privileges.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Security

--- a/elasticsearch-api/lib/elasticsearch/api/actions/security/get_privileges.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/security/get_privileges.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Security

--- a/elasticsearch-api/lib/elasticsearch/api/actions/security/get_role.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/security/get_role.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Security

--- a/elasticsearch-api/lib/elasticsearch/api/actions/security/get_role_mapping.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/security/get_role_mapping.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Security

--- a/elasticsearch-api/lib/elasticsearch/api/actions/security/get_service_accounts.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/security/get_service_accounts.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Security

--- a/elasticsearch-api/lib/elasticsearch/api/actions/security/get_service_credentials.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/security/get_service_credentials.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Security

--- a/elasticsearch-api/lib/elasticsearch/api/actions/security/get_settings.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/security/get_settings.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Security

--- a/elasticsearch-api/lib/elasticsearch/api/actions/security/get_token.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/security/get_token.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Security

--- a/elasticsearch-api/lib/elasticsearch/api/actions/security/get_user.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/security/get_user.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Security

--- a/elasticsearch-api/lib/elasticsearch/api/actions/security/get_user_privileges.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/security/get_user_privileges.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Security

--- a/elasticsearch-api/lib/elasticsearch/api/actions/security/get_user_profile.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/security/get_user_profile.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Security

--- a/elasticsearch-api/lib/elasticsearch/api/actions/security/grant_api_key.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/security/grant_api_key.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Security

--- a/elasticsearch-api/lib/elasticsearch/api/actions/security/has_privileges.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/security/has_privileges.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Security

--- a/elasticsearch-api/lib/elasticsearch/api/actions/security/has_privileges_user_profile.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/security/has_privileges_user_profile.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Security

--- a/elasticsearch-api/lib/elasticsearch/api/actions/security/invalidate_api_key.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/security/invalidate_api_key.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Security

--- a/elasticsearch-api/lib/elasticsearch/api/actions/security/invalidate_token.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/security/invalidate_token.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Security

--- a/elasticsearch-api/lib/elasticsearch/api/actions/security/oidc_authenticate.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/security/oidc_authenticate.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Security

--- a/elasticsearch-api/lib/elasticsearch/api/actions/security/oidc_logout.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/security/oidc_logout.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Security

--- a/elasticsearch-api/lib/elasticsearch/api/actions/security/oidc_prepare_authentication.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/security/oidc_prepare_authentication.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Security

--- a/elasticsearch-api/lib/elasticsearch/api/actions/security/put_privileges.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/security/put_privileges.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Security

--- a/elasticsearch-api/lib/elasticsearch/api/actions/security/put_role.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/security/put_role.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Security

--- a/elasticsearch-api/lib/elasticsearch/api/actions/security/put_role_mapping.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/security/put_role_mapping.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Security

--- a/elasticsearch-api/lib/elasticsearch/api/actions/security/put_user.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/security/put_user.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Security

--- a/elasticsearch-api/lib/elasticsearch/api/actions/security/query_api_keys.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/security/query_api_keys.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Security

--- a/elasticsearch-api/lib/elasticsearch/api/actions/security/query_role.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/security/query_role.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Security

--- a/elasticsearch-api/lib/elasticsearch/api/actions/security/query_user.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/security/query_user.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Security

--- a/elasticsearch-api/lib/elasticsearch/api/actions/security/saml_authenticate.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/security/saml_authenticate.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Security

--- a/elasticsearch-api/lib/elasticsearch/api/actions/security/saml_complete_logout.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/security/saml_complete_logout.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Security

--- a/elasticsearch-api/lib/elasticsearch/api/actions/security/saml_invalidate.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/security/saml_invalidate.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Security

--- a/elasticsearch-api/lib/elasticsearch/api/actions/security/saml_logout.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/security/saml_logout.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Security

--- a/elasticsearch-api/lib/elasticsearch/api/actions/security/saml_prepare_authentication.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/security/saml_prepare_authentication.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Security

--- a/elasticsearch-api/lib/elasticsearch/api/actions/security/saml_service_provider_metadata.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/security/saml_service_provider_metadata.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Security

--- a/elasticsearch-api/lib/elasticsearch/api/actions/security/suggest_user_profiles.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/security/suggest_user_profiles.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Security

--- a/elasticsearch-api/lib/elasticsearch/api/actions/security/update_api_key.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/security/update_api_key.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Security

--- a/elasticsearch-api/lib/elasticsearch/api/actions/security/update_cross_cluster_api_key.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/security/update_cross_cluster_api_key.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Security

--- a/elasticsearch-api/lib/elasticsearch/api/actions/security/update_settings.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/security/update_settings.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Security

--- a/elasticsearch-api/lib/elasticsearch/api/actions/security/update_user_profile_data.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/security/update_user_profile_data.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Security

--- a/elasticsearch-api/lib/elasticsearch/api/actions/simulate/ingest.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/simulate/ingest.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Simulate

--- a/elasticsearch-api/lib/elasticsearch/api/actions/snapshot/cleanup_repository.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/snapshot/cleanup_repository.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Snapshot

--- a/elasticsearch-api/lib/elasticsearch/api/actions/snapshot/clone.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/snapshot/clone.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Snapshot

--- a/elasticsearch-api/lib/elasticsearch/api/actions/snapshot/create.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/snapshot/create.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Snapshot

--- a/elasticsearch-api/lib/elasticsearch/api/actions/snapshot/create_repository.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/snapshot/create_repository.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Snapshot

--- a/elasticsearch-api/lib/elasticsearch/api/actions/snapshot/delete.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/snapshot/delete.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Snapshot

--- a/elasticsearch-api/lib/elasticsearch/api/actions/snapshot/delete_repository.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/snapshot/delete_repository.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Snapshot

--- a/elasticsearch-api/lib/elasticsearch/api/actions/snapshot/get.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/snapshot/get.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Snapshot

--- a/elasticsearch-api/lib/elasticsearch/api/actions/snapshot/get_repository.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/snapshot/get_repository.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Snapshot

--- a/elasticsearch-api/lib/elasticsearch/api/actions/snapshot/repository_analyze.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/snapshot/repository_analyze.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Snapshot

--- a/elasticsearch-api/lib/elasticsearch/api/actions/snapshot/restore.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/snapshot/restore.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Snapshot

--- a/elasticsearch-api/lib/elasticsearch/api/actions/snapshot/status.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/snapshot/status.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Snapshot

--- a/elasticsearch-api/lib/elasticsearch/api/actions/snapshot/verify_repository.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/snapshot/verify_repository.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Snapshot

--- a/elasticsearch-api/lib/elasticsearch/api/actions/snapshot_lifecycle_management/delete_lifecycle.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/snapshot_lifecycle_management/delete_lifecycle.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module SnapshotLifecycleManagement

--- a/elasticsearch-api/lib/elasticsearch/api/actions/snapshot_lifecycle_management/execute_lifecycle.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/snapshot_lifecycle_management/execute_lifecycle.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module SnapshotLifecycleManagement

--- a/elasticsearch-api/lib/elasticsearch/api/actions/snapshot_lifecycle_management/execute_retention.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/snapshot_lifecycle_management/execute_retention.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module SnapshotLifecycleManagement

--- a/elasticsearch-api/lib/elasticsearch/api/actions/snapshot_lifecycle_management/get_lifecycle.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/snapshot_lifecycle_management/get_lifecycle.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module SnapshotLifecycleManagement

--- a/elasticsearch-api/lib/elasticsearch/api/actions/snapshot_lifecycle_management/get_stats.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/snapshot_lifecycle_management/get_stats.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module SnapshotLifecycleManagement

--- a/elasticsearch-api/lib/elasticsearch/api/actions/snapshot_lifecycle_management/get_status.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/snapshot_lifecycle_management/get_status.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module SnapshotLifecycleManagement

--- a/elasticsearch-api/lib/elasticsearch/api/actions/snapshot_lifecycle_management/put_lifecycle.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/snapshot_lifecycle_management/put_lifecycle.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module SnapshotLifecycleManagement

--- a/elasticsearch-api/lib/elasticsearch/api/actions/snapshot_lifecycle_management/start.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/snapshot_lifecycle_management/start.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module SnapshotLifecycleManagement

--- a/elasticsearch-api/lib/elasticsearch/api/actions/snapshot_lifecycle_management/stop.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/snapshot_lifecycle_management/stop.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module SnapshotLifecycleManagement

--- a/elasticsearch-api/lib/elasticsearch/api/actions/sql/clear_cursor.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/sql/clear_cursor.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module SQL

--- a/elasticsearch-api/lib/elasticsearch/api/actions/sql/delete_async.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/sql/delete_async.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module SQL

--- a/elasticsearch-api/lib/elasticsearch/api/actions/sql/get_async.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/sql/get_async.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module SQL

--- a/elasticsearch-api/lib/elasticsearch/api/actions/sql/get_async_status.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/sql/get_async_status.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module SQL

--- a/elasticsearch-api/lib/elasticsearch/api/actions/sql/query.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/sql/query.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module SQL

--- a/elasticsearch-api/lib/elasticsearch/api/actions/sql/translate.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/sql/translate.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module SQL

--- a/elasticsearch-api/lib/elasticsearch/api/actions/ssl/certificates.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/ssl/certificates.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module SSL

--- a/elasticsearch-api/lib/elasticsearch/api/actions/synonyms/delete_synonym.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/synonyms/delete_synonym.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Synonyms

--- a/elasticsearch-api/lib/elasticsearch/api/actions/synonyms/delete_synonym_rule.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/synonyms/delete_synonym_rule.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Synonyms

--- a/elasticsearch-api/lib/elasticsearch/api/actions/synonyms/get_synonym.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/synonyms/get_synonym.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Synonyms

--- a/elasticsearch-api/lib/elasticsearch/api/actions/synonyms/get_synonym_rule.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/synonyms/get_synonym_rule.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Synonyms

--- a/elasticsearch-api/lib/elasticsearch/api/actions/synonyms/get_synonyms_sets.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/synonyms/get_synonyms_sets.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Synonyms

--- a/elasticsearch-api/lib/elasticsearch/api/actions/synonyms/put_synonym.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/synonyms/put_synonym.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Synonyms

--- a/elasticsearch-api/lib/elasticsearch/api/actions/synonyms/put_synonym_rule.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/synonyms/put_synonym_rule.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Synonyms

--- a/elasticsearch-api/lib/elasticsearch/api/actions/tasks/cancel.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/tasks/cancel.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Tasks

--- a/elasticsearch-api/lib/elasticsearch/api/actions/tasks/get.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/tasks/get.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Tasks

--- a/elasticsearch-api/lib/elasticsearch/api/actions/tasks/list.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/tasks/list.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Tasks

--- a/elasticsearch-api/lib/elasticsearch/api/actions/terms_enum.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/terms_enum.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Actions

--- a/elasticsearch-api/lib/elasticsearch/api/actions/termvectors.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/termvectors.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Actions

--- a/elasticsearch-api/lib/elasticsearch/api/actions/text_structure/find_field_structure.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/text_structure/find_field_structure.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module TextStructure

--- a/elasticsearch-api/lib/elasticsearch/api/actions/text_structure/find_message_structure.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/text_structure/find_message_structure.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module TextStructure

--- a/elasticsearch-api/lib/elasticsearch/api/actions/text_structure/find_structure.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/text_structure/find_structure.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module TextStructure

--- a/elasticsearch-api/lib/elasticsearch/api/actions/text_structure/test_grok_pattern.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/text_structure/test_grok_pattern.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module TextStructure

--- a/elasticsearch-api/lib/elasticsearch/api/actions/transform/delete_transform.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/transform/delete_transform.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Transform

--- a/elasticsearch-api/lib/elasticsearch/api/actions/transform/get_node_stats.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/transform/get_node_stats.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Transform

--- a/elasticsearch-api/lib/elasticsearch/api/actions/transform/get_transform.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/transform/get_transform.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Transform

--- a/elasticsearch-api/lib/elasticsearch/api/actions/transform/get_transform_stats.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/transform/get_transform_stats.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Transform

--- a/elasticsearch-api/lib/elasticsearch/api/actions/transform/preview_transform.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/transform/preview_transform.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Transform

--- a/elasticsearch-api/lib/elasticsearch/api/actions/transform/put_transform.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/transform/put_transform.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Transform

--- a/elasticsearch-api/lib/elasticsearch/api/actions/transform/reset_transform.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/transform/reset_transform.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Transform

--- a/elasticsearch-api/lib/elasticsearch/api/actions/transform/schedule_now_transform.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/transform/schedule_now_transform.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Transform

--- a/elasticsearch-api/lib/elasticsearch/api/actions/transform/start_transform.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/transform/start_transform.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Transform

--- a/elasticsearch-api/lib/elasticsearch/api/actions/transform/stop_transform.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/transform/stop_transform.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Transform

--- a/elasticsearch-api/lib/elasticsearch/api/actions/transform/update_transform.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/transform/update_transform.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Transform

--- a/elasticsearch-api/lib/elasticsearch/api/actions/transform/upgrade_transforms.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/transform/upgrade_transforms.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Transform

--- a/elasticsearch-api/lib/elasticsearch/api/actions/update.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/update.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Actions

--- a/elasticsearch-api/lib/elasticsearch/api/actions/update_by_query.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/update_by_query.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Actions

--- a/elasticsearch-api/lib/elasticsearch/api/actions/update_by_query_rethrottle.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/update_by_query_rethrottle.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Actions

--- a/elasticsearch-api/lib/elasticsearch/api/actions/watcher/ack_watch.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/watcher/ack_watch.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Watcher

--- a/elasticsearch-api/lib/elasticsearch/api/actions/watcher/activate_watch.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/watcher/activate_watch.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Watcher

--- a/elasticsearch-api/lib/elasticsearch/api/actions/watcher/deactivate_watch.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/watcher/deactivate_watch.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Watcher

--- a/elasticsearch-api/lib/elasticsearch/api/actions/watcher/delete_watch.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/watcher/delete_watch.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Watcher

--- a/elasticsearch-api/lib/elasticsearch/api/actions/watcher/execute_watch.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/watcher/execute_watch.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Watcher

--- a/elasticsearch-api/lib/elasticsearch/api/actions/watcher/get_settings.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/watcher/get_settings.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Watcher

--- a/elasticsearch-api/lib/elasticsearch/api/actions/watcher/get_watch.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/watcher/get_watch.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Watcher

--- a/elasticsearch-api/lib/elasticsearch/api/actions/watcher/put_watch.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/watcher/put_watch.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Watcher

--- a/elasticsearch-api/lib/elasticsearch/api/actions/watcher/query_watches.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/watcher/query_watches.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Watcher

--- a/elasticsearch-api/lib/elasticsearch/api/actions/watcher/start.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/watcher/start.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Watcher

--- a/elasticsearch-api/lib/elasticsearch/api/actions/watcher/stats.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/watcher/stats.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Watcher

--- a/elasticsearch-api/lib/elasticsearch/api/actions/watcher/stop.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/watcher/stop.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Watcher

--- a/elasticsearch-api/lib/elasticsearch/api/actions/watcher/update_settings.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/watcher/update_settings.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module Watcher

--- a/elasticsearch-api/lib/elasticsearch/api/actions/xpack/info.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/xpack/info.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module XPack

--- a/elasticsearch-api/lib/elasticsearch/api/actions/xpack/usage.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/xpack/usage.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Auto generated from commit 3e97c19ea994ba17fbdaa94e813b27c345f9bbbd
-# @see https://github.com/elastic/elasticsearch-specification
-#
+# This code was automatically generated from the Elasticsearch Specification
+# See https://github.com/elastic/elasticsearch-specification
+# See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
     module XPack

--- a/elasticsearch-api/lib/elasticsearch/api/version.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/version.rb
@@ -18,5 +18,6 @@
 module Elasticsearch
   module API
     VERSION = '9.0.0'.freeze
+    ES_SPECIFICATION_COMMIT = 'dbb89db180052524cab77d324be4f0c00972807a'.freeze
   end
 end


### PR DESCRIPTION
[API] Adds ES_SPECIFICATION_COMMIT

The code is automatically generated from [elasticsearch-specification](https://github.com/elastic/elasticsearch-specification).
The value `Elasticsearch::ES_SPECIFICATION_COMMIT` will be updated with the commit hash of
elasticsearch-specification in which the code is based.

Instead of writing the commit hash in each generated file, it will be saved in this constant.