### PR TITLE
[API] Updates synonyms.delete_synonym_rule, synonyms.put_synonym, synonyms.put_synonym_rule

### DIFF
--- a/elasticsearch-api/lib/elasticsearch/api/actions/machine_learning/get_data_frame_analytics_stats.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/machine_learning/get_data_frame_analytics_stats.rb
@@ -22,7 +22,7 @@ module Elasticsearch
   module API
     module MachineLearning
       module Actions
-        # Get data frame analytics jobs usage info.
+        # Get data frame analytics job stats.
         #
         # @option arguments [String] :id Identifier for the data frame analytics job. If you do not specify this
         #  option, the API returns information for the first hundred data frame

--- a/elasticsearch-api/lib/elasticsearch/api/actions/machine_learning/get_datafeed_stats.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/machine_learning/get_datafeed_stats.rb
@@ -22,7 +22,7 @@ module Elasticsearch
   module API
     module MachineLearning
       module Actions
-        # Get datafeeds usage info.
+        # Get datafeed stats.
         # You can get statistics for multiple datafeeds in a single API request by
         # using a comma-separated list of datafeeds or a wildcard expression. You can
         # get statistics for all datafeeds by using +_all+, by specifying +*+ as the

--- a/elasticsearch-api/lib/elasticsearch/api/actions/machine_learning/get_job_stats.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/machine_learning/get_job_stats.rb
@@ -22,7 +22,7 @@ module Elasticsearch
   module API
     module MachineLearning
       module Actions
-        # Get anomaly detection jobs usage info.
+        # Get anomaly detection job stats.
         #
         # @option arguments [String] :job_id Identifier for the anomaly detection job. It can be a job identifier, a
         #  group name, a comma-separated list of jobs, or a wildcard expression. If

--- a/elasticsearch-api/lib/elasticsearch/api/actions/synonyms/delete_synonym_rule.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/synonyms/delete_synonym_rule.rb
@@ -27,6 +27,8 @@ module Elasticsearch
         #
         # @option arguments [String] :set_id The ID of the synonym set to update. (*Required*)
         # @option arguments [String] :rule_id The ID of the synonym rule to delete. (*Required*)
+        # @option arguments [Boolean] :refresh If +true+, the request will refresh the analyzers with the deleted synonym rule and wait for the new synonyms to be available before returning.
+        #  If +false+, analyzers will not be reloaded with the deleted synonym rule Server default: true.
         # @option arguments [Hash] :headers Custom HTTP headers
         #
         # @see https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-synonyms-delete-synonym-rule
@@ -53,7 +55,7 @@ module Elasticsearch
 
           method = Elasticsearch::API::HTTP_DELETE
           path   = "_synonyms/#{Utils.listify(_set_id)}/#{Utils.listify(_rule_id)}"
-          params = {}
+          params = Utils.process_params(arguments)
 
           Elasticsearch::API::Response.new(
             perform_request(method, path, params, body, headers, request_opts)

--- a/elasticsearch-api/lib/elasticsearch/api/actions/synonyms/put_synonym.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/synonyms/put_synonym.rb
@@ -29,6 +29,8 @@ module Elasticsearch
         # This is equivalent to invoking the reload search analyzers API for all indices that use the synonyms set.
         #
         # @option arguments [String] :id The ID of the synonyms set to be created or updated. (*Required*)
+        # @option arguments [Boolean] :refresh If +true+, the request will refresh the analyzers with the new synonyms set and wait for the new synonyms to be available before returning.
+        #  If +false+, analyzers will not be reloaded with the new synonym set Server default: true.
         # @option arguments [Hash] :headers Custom HTTP headers
         # @option arguments [Hash] :body request body
         #
@@ -54,7 +56,7 @@ module Elasticsearch
 
           method = Elasticsearch::API::HTTP_PUT
           path   = "_synonyms/#{Utils.listify(_id)}"
-          params = {}
+          params = Utils.process_params(arguments)
 
           Elasticsearch::API::Response.new(
             perform_request(method, path, params, body, headers, request_opts)

--- a/elasticsearch-api/lib/elasticsearch/api/actions/synonyms/put_synonym_rule.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/synonyms/put_synonym_rule.rb
@@ -29,6 +29,8 @@ module Elasticsearch
         #
         # @option arguments [String] :set_id The ID of the synonym set. (*Required*)
         # @option arguments [String] :rule_id The ID of the synonym rule to be updated or created. (*Required*)
+        # @option arguments [Boolean] :refresh If +true+, the request will refresh the analyzers with the new synonym rule and wait for the new synonyms to be available before returning.
+        #  If +false+, analyzers will not be reloaded with the new synonym rule Server default: true.
         # @option arguments [Hash] :headers Custom HTTP headers
         # @option arguments [Hash] :body request body
         #
@@ -57,7 +59,7 @@ module Elasticsearch
 
           method = Elasticsearch::API::HTTP_PUT
           path   = "_synonyms/#{Utils.listify(_set_id)}/#{Utils.listify(_rule_id)}"
-          params = {}
+          params = Utils.process_params(arguments)
 
           Elasticsearch::API::Response.new(
             perform_request(method, path, params, body, headers, request_opts)

--- a/elasticsearch-api/lib/elasticsearch/api/version.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/version.rb
@@ -18,6 +18,6 @@
 module Elasticsearch
   module API
     VERSION = '9.0.0'.freeze
-    ES_SPECIFICATION_COMMIT = 'cd9c33775947086a99e6cf299b87733ba0111c28'.freeze
+    ES_SPECIFICATION_COMMIT = '2843115df10df34cd34d22868131fdf7592e2655'.freeze
   end
 end


### PR DESCRIPTION
Adds Boolean `:refresh` parameter. If `true`, the request will refresh the analyzers with the deleted synonym rule and wait for the new synonyms to be available before returning. If `false`, analyzers will not be reloaded with the deleted synonym rule Server default: true.

Updates source code documentation.