### PR TITLE
[CI] Increase retries for 409 on Serverless tests

### DIFF
--- a/elasticsearch-api/spec/yaml-test-runner/run.rb
+++ b/elasticsearch-api/spec/yaml-test-runner/run.rb
@@ -63,7 +63,7 @@ if serverless?
   options.merge!(
     {
       retry_on_status: [409, 400, 503],
-      retry_on_failure: 10,
+      retry_on_failure: 20,
       delay_on_retry: 10_000,
       request_timeout: 120
     }


### PR DESCRIPTION
This test still takes longer on Serverless, 20 retries worked for `9.0`, so hopefully will work on main too. Error:
```
Test: machine_learning/20_trained_model_serverless.yml
Action: ["do", {"ml.infer_trained_model" => {"model_id" => "test_model", "body" => "{\n  \"docs\": [\n    { \"input\": \"words\" }\n  ]\n}\n"}}]
Hash - [409] {"error":{"root_cause":[{"type":"status_exception","reason":"Trained model deployment [test_model] is not allocated to any nodes"}],"type":"status_exception","reason":"Trained model deployment [test_model] is not allocated to any nodes"},"status":409}
```