### PR TITLE
[Test Runner] Allows failures in Serverless

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -56,6 +56,8 @@ steps:
         key: run-serverless-tests
         depends_on:
           - step: create-serverless
+        soft_fail:
+          - exit_status: "*"
         agents:
           provider: gcp
         env:

--- a/elasticsearch-api/spec/yaml-test-runner/run.rb
+++ b/elasticsearch-api/spec/yaml-test-runner/run.rb
@@ -64,8 +64,8 @@ if serverless?
     {
       retry_on_status: [409, 400, 503],
       retry_on_failure: 30,
-      delay_on_retry: 10_000,
-      request_timeout: 120
+      delay_on_retry: 5_000,
+      request_timeout: 60
     }
   )
 end


### PR DESCRIPTION
Reducing the timeouts to bring down the build times and allowing Serverless tests to fail, since these tests fail in our testing server, but not on production Serverless.