### PR TITLE
[API] Updates source code docs to 76cd5c918a1c3aeb4d26f76a6683bba7a9e79289

### DIFF
--- a/elasticsearch-api/lib/elasticsearch/api/actions/create.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/create.rb
@@ -77,15 +77,7 @@ module Elasticsearch
       # @option arguments [String] :index The name of the data stream or index to target.
       #  If the target doesn't exist and matches the name or wildcard (`*`) pattern of an index template with a `data_stream` definition, this request creates the data stream.
       #  If the target doesn't exist and doesn’t match a data stream template, this request creates the index. (*Required*)
-      # @option arguments [Integer] :if_primary_term Only perform the operation if the document has this primary term.
-      # @option arguments [Integer] :if_seq_no Only perform the operation if the document has this sequence number.
       # @option arguments [Boolean] :include_source_on_error True or false if to include the document source in the error message in case of parsing errors. Server default: true.
-      # @option arguments [String] :op_type Set to `create` to only index the document if it does not already exist (put if absent).
-      #  If a document with the specified `_id` already exists, the indexing operation will fail.
-      #  The behavior is the same as using the `<index>/_create` endpoint.
-      #  If a document ID is specified, this paramater defaults to `index`.
-      #  Otherwise, it defaults to `create`.
-      #  If the request targets a data stream, an `op_type` of `create` is required.
       # @option arguments [String] :pipeline The ID of the pipeline to use to preprocess incoming documents.
       #  If the index has a default ingest pipeline specified, setting the value to `_none` turns off the default ingest pipeline for this request.
       #  If a final pipeline is configured, it will always run regardless of the value of this parameter.

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/recovery.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/recovery.rb
@@ -45,6 +45,12 @@ module Elasticsearch
         #  To target all data streams and indices, omit this parameter or use `*` or `_all`.
         # @option arguments [Boolean] :active_only If `true`, the response only includes ongoing shard recoveries.
         # @option arguments [Boolean] :detailed If `true`, the response includes detailed information about shard recoveries.
+        # @option arguments [Boolean] :allow_no_indices If `false`, the request returns an error if any wildcard expression, index alias, or `_all` value targets only missing or closed indices.
+        #  This behavior applies even if the request targets other open indices. Server default: true.
+        # @option arguments [String, Array<String>] :expand_wildcards Type of index that wildcard patterns can match.
+        #  If the request can target data streams, this argument determines whether wildcard expressions match hidden data streams.
+        #  Supports comma-separated values, such as `open,hidden`. Server default: open.
+        # @option arguments [Boolean] :ignore_unavailable If `false`, the request returns an error if it targets a missing or closed index.
         # @option arguments [Boolean] :error_trace When set to `true` Elasticsearch will include the full stack trace of errors
         #  when they occur.
         # @option arguments [String, Array<String>] :filter_path Comma-separated list of filters in dot notation which reduce the response

--- a/elasticsearch-api/lib/elasticsearch/api/actions/info.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/info.rb
@@ -23,6 +23,7 @@ module Elasticsearch
     module Actions
       # Get cluster info.
       # Get basic build, version, and cluster information.
+      # ::: In Serverless, this API is retained for backward compatibility only. Some response fields, such as the version number, should be ignored.
       #
       # @option arguments [Boolean] :error_trace When set to `true` Elasticsearch will include the full stack trace of errors
       #  when they occur.

--- a/elasticsearch-api/lib/elasticsearch/api/version.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/version.rb
@@ -18,6 +18,6 @@
 module Elasticsearch
   module API
     VERSION = '9.1.0'.freeze
-    ES_SPECIFICATION_COMMIT = '119eb27ee25a0be53121ed59edadbc5acb55462e'.freeze
+    ES_SPECIFICATION_COMMIT = '4f3be59696b7f349bfd270a485fe538fc75e4cd6'.freeze
   end
 end


### PR DESCRIPTION
create
* Removes parameters `:if_primary_term`, `:if_seq_no`, `:op_type`.

indices.recovery - new parameters:
* [Boolean] `:allow_no_indices` If `false`, the request returns an error if any wildcard expression, index alias, or `_all` value targets only missing or closed indices.
* [String, Array<String>] `:expand_wildcards` Type of index that wildcard patterns can match.
* [Boolean] `:ignore_unavailable` If `false`, the request returns an error if it targets a missing or closed index.