### PR TITLE
[API] Updates to latest spec:

### DIFF
--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/create_from.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/create_from.rb
@@ -55,7 +55,6 @@ module Elasticsearch
           end
           request_opts[:defined_params] = defined_params unless defined_params.empty?
 
-          raise ArgumentError, "Required argument 'body' missing" unless arguments[:body]
           raise ArgumentError, "Required argument 'source' missing" unless arguments[:source]
           raise ArgumentError, "Required argument 'dest' missing" unless arguments[:dest]
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/disk_usage.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/disk_usage.rb
@@ -29,6 +29,7 @@ module Elasticsearch
         # NOTE: The total size of fields of the analyzed shards of the index in the response is usually smaller than the index `store_size` value because some small metadata files are ignored and some parts of data files might not be scanned by the API.
         # Since stored fields are stored together in a compressed format, the sizes of stored fields are also estimates and can be inaccurate.
         # The stored size of the `_id` field is likely underestimated while the `_source` field is overestimated.
+        # For usage examples see the External documentation or refer to {https://www.elastic.co/docs/reference/elasticsearch/rest-apis/index-disk-usage Analyze the index disk usage example} for an example.
         # This functionality is Experimental and may be changed or removed
         # completely in a future release. Elastic will take a best effort approach
         # to fix any issues, but experimental features are not subject to the

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/simulate_index_template.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/simulate_index_template.rb
@@ -42,6 +42,7 @@ module Elasticsearch
         # @option arguments [Boolean] :pretty If set to `true` the returned JSON will be "pretty-formatted". Only use
         #  this option for debugging only.
         # @option arguments [Hash] :headers Custom HTTP headers
+        # @option arguments [Hash] :body index_template
         #
         # @see https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-indices-simulate-index-template
         #
@@ -58,7 +59,7 @@ module Elasticsearch
           arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
-          body = nil
+          body = arguments.delete(:body)
 
           _name = arguments.delete(:name)
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/license/get.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/license/get.rb
@@ -27,7 +27,9 @@ module Elasticsearch
         #
         # @option arguments [Boolean] :accept_enterprise If `true`, this parameter returns enterprise for Enterprise license types. If `false`, this parameter returns platinum for both platinum and enterprise license types. This behavior is maintained for backwards compatibility.
         #  This parameter is deprecated and will always be set to true in 8.x. Server default: true.
-        # @option arguments [Boolean] :local Specifies whether to retrieve local information. The default value is `false`, which means the information is retrieved from the master node.
+        # @option arguments [Boolean] :local Specifies whether to retrieve local information.
+        #  From 9.2 onwards the default value is `true`, which means the information is retrieved from the responding node.
+        #  In earlier versions the default is `false`, which means the information is retrieved from the elected master node. Server default: true.
         # @option arguments [Boolean] :error_trace When set to `true` Elasticsearch will include the full stack trace of errors
         #  when they occur.
         # @option arguments [String, Array<String>] :filter_path Comma-separated list of filters in dot notation which reduce the response

--- a/elasticsearch-api/lib/elasticsearch/api/version.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/version.rb
@@ -18,6 +18,6 @@
 module Elasticsearch
   module API
     VERSION = '9.2.0'.freeze
-    ES_SPECIFICATION_COMMIT = '98ec7ac24c4fbb1acb2abccf8325251ad4a1e4c6'.freeze
+    ES_SPECIFICATION_COMMIT = 'a4676aabf1b13839ec5bef82f775aad25dbdec22'.freeze
   end
 end


### PR DESCRIPTION
- indices.create_from body is no longer required.
- indices.simulate_index_template adds body parameter.