### PR TITLE
[API] Renames technical preview Serverless only APIs project routing

### DIFF
--- a/elasticsearch-api/lib/elasticsearch/api.rb
+++ b/elasticsearch-api/lib/elasticsearch/api.rb
@@ -73,7 +73,6 @@ module Elasticsearch
                       :machine_learning,
                       :nodes,
                       :project,
-                      :project_routing,
                       :query_rules,
                       :search_application,
                       :searchable_snapshots,

--- a/elasticsearch-api/lib/elasticsearch/api/actions/project/create_many_routing.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/project/create_many_routing.rb
@@ -20,16 +20,14 @@
 # See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
-    module ProjectRouting
+    module Project
       module Actions
-        # Get named project routing expressions.
-        # Get named project routing expressions.
+        # Create of update named project routing expressions.
         # This API is only available in Serverless.
         # This functionality is in technical preview and may be changed or removed in a future
         # release. Elastic will apply best effort to fix any issues, but features in technical
         # preview are not subject to the support SLA of official GA features.
         #
-        # @option arguments [String] :name The name of project routing expression (*Required*)
         # @option arguments [Boolean] :error_trace When set to `true` Elasticsearch will include the full stack trace of errors
         #  when they occur.
         # @option arguments [String, Array<String>] :filter_path Comma-separated list of filters in dot notation which reduce the response
@@ -42,28 +40,22 @@ module Elasticsearch
         # @option arguments [Boolean] :pretty If set to `true` the returned JSON will be "pretty-formatted". Only use
         #  this option for debugging only.
         # @option arguments [Hash] :headers Custom HTTP headers
+        # @option arguments [Hash] :body expressions
         #
-        # @see
+        # @see https://www.elastic.co/docs/api/doc/elasticsearch#TODO
         #
-        def get(arguments = {})
-          request_opts = { endpoint: arguments[:endpoint] || 'project_routing.get' }
+        def create_many_routing(arguments = {})
+          request_opts = { endpoint: arguments[:endpoint] || 'project.create_many_routing' }
 
-          defined_params = [:name].each_with_object({}) do |variable, set_variables|
-            set_variables[variable] = arguments[variable] if arguments.key?(variable)
-          end
-          request_opts[:defined_params] = defined_params unless defined_params.empty?
-
-          raise ArgumentError, "Required argument 'name' missing" unless arguments[:name]
+          raise ArgumentError, "Required argument 'body' missing" unless arguments[:body]
 
           arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
-          body = nil
+          body = arguments.delete(:body)
 
-          _name = arguments.delete(:name)
-
-          method = Elasticsearch::API::HTTP_GET
-          path   = "_project_routing/#{Utils.listify(_name)}"
+          method = Elasticsearch::API::HTTP_PUT
+          path   = '_project_routing'
           params = Utils.process_params(arguments)
 
           Elasticsearch::API::Response.new(

--- a/elasticsearch-api/lib/elasticsearch/api/actions/project/create_routing.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/project/create_routing.rb
@@ -20,15 +20,15 @@
 # See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
-    module ProjectRouting
+    module Project
       module Actions
-        # Get named project routing expressions.
-        # Get named project routing expressions.
+        # Create of update a single named project routing expression.
         # This API is only available in Serverless.
         # This functionality is in technical preview and may be changed or removed in a future
         # release. Elastic will apply best effort to fix any issues, but features in technical
         # preview are not subject to the support SLA of official GA features.
         #
+        # @option arguments [String] :name The name of project routing expression (*Required*)
         # @option arguments [Boolean] :error_trace When set to `true` Elasticsearch will include the full stack trace of errors
         #  when they occur.
         # @option arguments [String, Array<String>] :filter_path Comma-separated list of filters in dot notation which reduce the response
@@ -41,19 +41,30 @@ module Elasticsearch
         # @option arguments [Boolean] :pretty If set to `true` the returned JSON will be "pretty-formatted". Only use
         #  this option for debugging only.
         # @option arguments [Hash] :headers Custom HTTP headers
+        # @option arguments [Hash] :body expressions
         #
-        # @see
+        # @see https://www.elastic.co/docs/api/doc/elasticsearch#TODO
         #
-        def get_many(arguments = {})
-          request_opts = { endpoint: arguments[:endpoint] || 'project_routing.get_many' }
+        def create_routing(arguments = {})
+          request_opts = { endpoint: arguments[:endpoint] || 'project.create_routing' }
+
+          defined_params = [:name].each_with_object({}) do |variable, set_variables|
+            set_variables[variable] = arguments[variable] if arguments.key?(variable)
+          end
+          request_opts[:defined_params] = defined_params unless defined_params.empty?
+
+          raise ArgumentError, "Required argument 'body' missing" unless arguments[:body]
+          raise ArgumentError, "Required argument 'name' missing" unless arguments[:name]
 
           arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
-          body = nil
+          body = arguments.delete(:body)
 
-          method = Elasticsearch::API::HTTP_GET
-          path   = '_project_routing'
+          _name = arguments.delete(:name)
+
+          method = Elasticsearch::API::HTTP_PUT
+          path   = "_project_routing/#{Utils.listify(_name)}"
           params = Utils.process_params(arguments)
 
           Elasticsearch::API::Response.new(

--- a/elasticsearch-api/lib/elasticsearch/api/actions/project/delete_routing.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/project/delete_routing.rb
@@ -20,9 +20,8 @@
 # See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
-    module ProjectRouting
+    module Project
       module Actions
-        # Delete named project routing expressions.
         # Delete named project routing expressions.
         # This API is only available in Serverless.
         # This functionality is in technical preview and may be changed or removed in a future
@@ -43,10 +42,10 @@ module Elasticsearch
         #  this option for debugging only.
         # @option arguments [Hash] :headers Custom HTTP headers
         #
-        # @see
+        # @see https://www.elastic.co/docs/api/doc/elasticsearch#TODO
         #
-        def delete(arguments = {})
-          request_opts = { endpoint: arguments[:endpoint] || 'project_routing.delete' }
+        def delete_routing(arguments = {})
+          request_opts = { endpoint: arguments[:endpoint] || 'project.delete_routing' }
 
           defined_params = [:name].each_with_object({}) do |variable, set_variables|
             set_variables[variable] = arguments[variable] if arguments.key?(variable)

--- a/elasticsearch-api/lib/elasticsearch/api/actions/project/get_many_routing.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/project/get_many_routing.rb
@@ -20,10 +20,9 @@
 # See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
-    module ProjectRouting
+    module Project
       module Actions
-        # Create of update named project routing expressions.
-        # Create or update named project routing expressions.
+        # Get named project routing expressions.
         # This API is only available in Serverless.
         # This functionality is in technical preview and may be changed or removed in a future
         # release. Elastic will apply best effort to fix any issues, but features in technical
@@ -41,21 +40,18 @@ module Elasticsearch
         # @option arguments [Boolean] :pretty If set to `true` the returned JSON will be "pretty-formatted". Only use
         #  this option for debugging only.
         # @option arguments [Hash] :headers Custom HTTP headers
-        # @option arguments [Hash] :body expressions
         #
-        # @see
+        # @see https://www.elastic.co/docs/api/doc/elasticsearch#TODO
         #
-        def create_many(arguments = {})
-          request_opts = { endpoint: arguments[:endpoint] || 'project_routing.create_many' }
-
-          raise ArgumentError, "Required argument 'body' missing" unless arguments[:body]
+        def get_many_routing(arguments = {})
+          request_opts = { endpoint: arguments[:endpoint] || 'project.get_many_routing' }
 
           arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
-          body = arguments.delete(:body)
+          body = nil
 
-          method = Elasticsearch::API::HTTP_PUT
+          method = Elasticsearch::API::HTTP_GET
           path   = '_project_routing'
           params = Utils.process_params(arguments)
 

--- a/elasticsearch-api/lib/elasticsearch/api/actions/project/get_routing.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/project/get_routing.rb
@@ -20,10 +20,9 @@
 # See Elasticsearch::ES_SPECIFICATION_COMMIT for commit hash.
 module Elasticsearch
   module API
-    module ProjectRouting
+    module Project
       module Actions
-        # Create of update a single named project routing expression.
-        # Create of update a single named project routing expression.
+        # Get named project routing expressions.
         # This API is only available in Serverless.
         # This functionality is in technical preview and may be changed or removed in a future
         # release. Elastic will apply best effort to fix any issues, but features in technical
@@ -42,29 +41,27 @@ module Elasticsearch
         # @option arguments [Boolean] :pretty If set to `true` the returned JSON will be "pretty-formatted". Only use
         #  this option for debugging only.
         # @option arguments [Hash] :headers Custom HTTP headers
-        # @option arguments [Hash] :body expressions
         #
-        # @see
+        # @see https://www.elastic.co/docs/api/doc/elasticsearch#TODO
         #
-        def create(arguments = {})
-          request_opts = { endpoint: arguments[:endpoint] || 'project_routing.create' }
+        def get_routing(arguments = {})
+          request_opts = { endpoint: arguments[:endpoint] || 'project.get_routing' }
 
           defined_params = [:name].each_with_object({}) do |variable, set_variables|
             set_variables[variable] = arguments[variable] if arguments.key?(variable)
           end
           request_opts[:defined_params] = defined_params unless defined_params.empty?
 
-          raise ArgumentError, "Required argument 'body' missing" unless arguments[:body]
           raise ArgumentError, "Required argument 'name' missing" unless arguments[:name]
 
           arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
-          body = arguments.delete(:body)
+          body = nil
 
           _name = arguments.delete(:name)
 
-          method = Elasticsearch::API::HTTP_PUT
+          method = Elasticsearch::API::HTTP_GET
           path   = "_project_routing/#{Utils.listify(_name)}"
           params = Utils.process_params(arguments)
 

--- a/elasticsearch-api/lib/elasticsearch/api/version.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/version.rb
@@ -18,6 +18,6 @@
 module Elasticsearch
   module API
     VERSION = '9.3.0'.freeze
-    ES_SPECIFICATION_COMMIT = '87915edbcc080a07001e81a5d9f4317103819329'.freeze
+    ES_SPECIFICATION_COMMIT = '6785a6caa1fa3ca5ab3308963d79dce923a3469f'.freeze
   end
 end

--- a/elasticsearch-api/spec/unit/actions/project/create_many_routing_spec.rb
+++ b/elasticsearch-api/spec/unit/actions/project/create_many_routing_spec.rb
@@ -17,19 +17,19 @@
 
 require 'spec_helper'
 
-describe 'client.project_routing#delete' do
+describe 'client.project#create_many_routing' do
   let(:expected_args) do
     [
-      'DELETE',
-      '_project_routing/foo',
+      'PUT',
+      '_project_routing',
       {},
-      nil,
       {},
-      { endpoint: 'project_routing.delete', defined_params: { name: 'foo' } }
+      {},
+      { endpoint: 'project.create_many_routing' }
     ]
   end
 
   it 'performs the request' do
-    expect(client_double.project_routing.delete(name: 'foo')).to be_a Elasticsearch::API::Response
+    expect(client_double.project.create_many_routing(body: {})).to be_a Elasticsearch::API::Response
   end
 end

--- a/elasticsearch-api/spec/unit/actions/project/create_routing_spec.rb
+++ b/elasticsearch-api/spec/unit/actions/project/create_routing_spec.rb
@@ -17,19 +17,19 @@
 
 require 'spec_helper'
 
-describe 'client.project_routing#create_many' do
+describe 'client.project#create_routing' do
   let(:expected_args) do
     [
       'PUT',
-      '_project_routing',
+      '_project_routing/foo',
       {},
       {},
       {},
-      { endpoint: 'project_routing.create_many' }
+      { endpoint: 'project.create_routing', defined_params: { name: 'foo' } }
     ]
   end
 
   it 'performs the request' do
-    expect(client_double.project_routing.create_many(body: {})).to be_a Elasticsearch::API::Response
+    expect(client_double.project.create_routing(name: 'foo', body: {})).to be_a Elasticsearch::API::Response
   end
 end

--- a/elasticsearch-api/spec/unit/actions/project/delete_routing_spec.rb
+++ b/elasticsearch-api/spec/unit/actions/project/delete_routing_spec.rb
@@ -17,19 +17,19 @@
 
 require 'spec_helper'
 
-describe 'client.project_routing#get' do
+describe 'client.project#delete_routing' do
   let(:expected_args) do
     [
-      'GET',
+      'DELETE',
       '_project_routing/foo',
       {},
       nil,
       {},
-      { endpoint: 'project_routing.get', defined_params: { name: 'foo' } }
+      { endpoint: 'project.delete_routing', defined_params: { name: 'foo' } }
     ]
   end
 
   it 'performs the request' do
-    expect(client_double.project_routing.get(name: 'foo')).to be_a Elasticsearch::API::Response
+    expect(client_double.project.delete_routing(name: 'foo')).to be_a Elasticsearch::API::Response
   end
 end

--- a/elasticsearch-api/spec/unit/actions/project/get_many_routing_spec.rb
+++ b/elasticsearch-api/spec/unit/actions/project/get_many_routing_spec.rb
@@ -17,7 +17,7 @@
 
 require 'spec_helper'
 
-describe 'client.project_routing#get_many' do
+describe 'client.project#get_many_routing' do
   let(:expected_args) do
     [
       'GET',
@@ -25,11 +25,11 @@ describe 'client.project_routing#get_many' do
       {},
       nil,
       {},
-      { endpoint: 'project_routing.get_many' }
+      { endpoint: 'project.get_many_routing' }
     ]
   end
 
   it 'performs the request' do
-    expect(client_double.project_routing.get_many).to be_a Elasticsearch::API::Response
+    expect(client_double.project.get_many_routing).to be_a Elasticsearch::API::Response
   end
 end

--- a/elasticsearch-api/spec/unit/actions/project/get_routing_spec.rb
+++ b/elasticsearch-api/spec/unit/actions/project/get_routing_spec.rb
@@ -17,19 +17,19 @@
 
 require 'spec_helper'
 
-describe 'client.project_routing#create' do
+describe 'client.project#get_routing' do
   let(:expected_args) do
     [
-      'PUT',
+      'GET',
       '_project_routing/foo',
       {},
+      nil,
       {},
-      {},
-      { endpoint: 'project_routing.create', defined_params: { name: 'foo' } }
+      { endpoint: 'project.get_routing', defined_params: { name: 'foo' } }
     ]
   end
 
   it 'performs the request' do
-    expect(client_double.project_routing.create(name: 'foo', body: {})).to be_a Elasticsearch::API::Response
+    expect(client_double.project.get_routing(name: 'foo')).to be_a Elasticsearch::API::Response
   end
 end


### PR DESCRIPTION
Moved from the `project_routing` namespace to `project`.