### PR TITLE
[API] Generates 9f8c66bedb2d4b509c3f3a7dabbd274fd152c25a

### DIFF
--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/shrink.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/shrink.rb
@@ -34,6 +34,7 @@ module Elasticsearch
         # For example an index with 8 primary shards can be shrunk into 4, 2 or 1 primary shards or an index with 15 primary shards can be shrunk into 5, 3 or 1.
         # If the number of shards in the index is a prime number it can only be shrunk into a single primary shard
         #  Before shrinking, a (primary or replica) copy of every shard in the index must be present on the same node.
+        # IMPORTANT: If the source index already has one primary shard, configuring the shrink operation with 'index.number_of_shards: 1' will cause the request to fail. An index with one primary shard cannot be shrunk further.
         # The current write index on a data stream cannot be shrunk. In order to shrink the current write index, the data stream must first be rolled over so that a new write index is created and then the previous write index can be shrunk.
         # A shrink operation:
         # * Creates a new target index with the same definition as the source index, but with a smaller number of primary shards.

--- a/elasticsearch-api/lib/elasticsearch/api/actions/inference/get.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/inference/get.rb
@@ -25,8 +25,9 @@ module Elasticsearch
         # Get an inference endpoint.
         # This API requires the `monitor_inference` cluster privilege (the built-in `inference_admin` and `inference_user` roles grant this privilege).
         #
-        # @option arguments [String] :task_type The task type
-        # @option arguments [String] :inference_id The inference Id
+        # @option arguments [String] :task_type The task type of the endpoint to return
+        # @option arguments [String] :inference_id The inference Id of the endpoint to return. Using `_all` or `*` will return all endpoints with the specified
+        #  `task_type` if one is specified, or all endpoints for all task types if no `task_type` is specified
         # @option arguments [Boolean] :error_trace When set to `true` Elasticsearch will include the full stack trace of errors
         #  when they occur.
         # @option arguments [String, Array<String>] :filter_path Comma-separated list of filters in dot notation which reduce the response
@@ -62,6 +63,8 @@ module Elasticsearch
           method = Elasticsearch::API::HTTP_GET
           path   = if _task_type && _inference_id
                      "_inference/#{Utils.listify(_task_type)}/#{Utils.listify(_inference_id)}"
+                   elsif _task_type
+                     "_inference/#{Utils.listify(_task_type)}/_all"
                    elsif _inference_id
                      "_inference/#{Utils.listify(_inference_id)}"
                    else

--- a/elasticsearch-api/lib/elasticsearch/api/actions/snapshot/get.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/snapshot/get.rb
@@ -49,7 +49,7 @@ module Elasticsearch
         #  The default behavior is ascending order. Server default: asc.
         # @option arguments [Integer] :offset Numeric offset to start pagination from based on the snapshots matching this request. Using a non-zero value for this parameter is mutually exclusive with using the after parameter. Defaults to 0. Server default: 0.
         # @option arguments [Integer] :size The maximum number of snapshots to return.
-        #  The default is 0, which means to return all that match the request without limit. Server default: 0.
+        #  The default is -1, which means to return all that match the request without limit. Server default: -1.
         # @option arguments [String] :slm_policy_filter Filter snapshots by a comma-separated list of snapshot lifecycle management (SLM) policy names that snapshots belong to.You can use wildcards (`*`) and combinations of wildcards followed by exclude patterns starting with `-`.
         #  For example, the pattern `*,-policy-a-\*` will return all snapshots except for those that were created by an SLM policy with a name starting with `policy-a-`.
         #  Note that the wildcard pattern `*` matches all snapshots created by an SLM policy but not those snapshots that were not created by an SLM policy.

--- a/elasticsearch-api/lib/elasticsearch/api/actions/streams/logs_disable.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/streams/logs_disable.rb
@@ -22,15 +22,13 @@ module Elasticsearch
   module API
     module Streams
       module Actions
-        # Disable logs stream.
-        # Turn off the logs stream feature for this cluster.
-        #
-        # This API is only available behind a feature flag: `logs_stream`.
-        #
+        # Disable a named stream.
+        # Turn off the named stream feature for this cluster.
         # This functionality is in technical preview and may be changed or removed in a future
         # release. Elastic will apply best effort to fix any issues, but features in technical
         # preview are not subject to the support SLA of official GA features.
         #
+        # @option arguments [String] :name The stream type to disable. (*Required*)
         # @option arguments [Time] :master_timeout The period to wait for a connection to the master node.
         #  If no response is received before the timeout expires, the request fails and returns an error. Server default: 30s.
         # @option arguments [Time] :timeout The period to wait for a response.
@@ -53,13 +51,22 @@ module Elasticsearch
         def logs_disable(arguments = {})
           request_opts = { endpoint: arguments[:endpoint] || 'streams.logs_disable' }
 
+          defined_params = [:name].each_with_object({}) do |variable, set_variables|
+            set_variables[variable] = arguments[variable] if arguments.key?(variable)
+          end
+          request_opts[:defined_params] = defined_params unless defined_params.empty?
+
+          raise ArgumentError, "Required argument 'name' missing" unless arguments[:name]
+
           arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
           body = nil
 
+          _name = arguments.delete(:name)
+
           method = Elasticsearch::API::HTTP_POST
-          path   = '_streams/logs/_disable'
+          path   = "_streams/#{Utils.listify(_name)}/_disable"
           params = Utils.process_params(arguments)
 
           Elasticsearch::API::Response.new(

--- a/elasticsearch-api/lib/elasticsearch/api/actions/streams/logs_enable.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/streams/logs_enable.rb
@@ -22,18 +22,17 @@ module Elasticsearch
   module API
     module Streams
       module Actions
-        # Enable logs stream.
-        # Turn on the logs stream feature for this cluster.
-        # NOTE: To protect existing data, this feature can be turned on only if the
-        # cluster does not have existing indices or data streams that match the pattern `logs|logs.*`.
-        # If those indices or data streams exist, a `409 - Conflict` response and error is returned.
-        #
-        # This API is only available behind a feature flag: `logs_stream`.
-        #
+        # Enable a named stream.
+        # Turn on the named stream feature for this cluster.
+        # NOTE: To protect existing data, this feature can be turned on only if the cluster does not have
+        # existing indices or data streams that match the pattern `<name>|<name>.*` for the enabled stream
+        # type name. If those indices or data streams exist, a `409 - Conflict` response and error is
+        # returned.
         # This functionality is in technical preview and may be changed or removed in a future
         # release. Elastic will apply best effort to fix any issues, but features in technical
         # preview are not subject to the support SLA of official GA features.
         #
+        # @option arguments [String] :name The stream type to enable. (*Required*)
         # @option arguments [Time] :master_timeout The period to wait for a connection to the master node.
         #  If no response is received before the timeout expires, the request fails and returns an error. Server default: 30s.
         # @option arguments [Time] :timeout The period to wait for a response.
@@ -56,13 +55,22 @@ module Elasticsearch
         def logs_enable(arguments = {})
           request_opts = { endpoint: arguments[:endpoint] || 'streams.logs_enable' }
 
+          defined_params = [:name].each_with_object({}) do |variable, set_variables|
+            set_variables[variable] = arguments[variable] if arguments.key?(variable)
+          end
+          request_opts[:defined_params] = defined_params unless defined_params.empty?
+
+          raise ArgumentError, "Required argument 'name' missing" unless arguments[:name]
+
           arguments = arguments.clone
           headers = arguments.delete(:headers) || {}
 
           body = nil
 
+          _name = arguments.delete(:name)
+
           method = Elasticsearch::API::HTTP_POST
-          path   = '_streams/logs/_enable'
+          path   = "_streams/#{Utils.listify(_name)}/_enable"
           params = Utils.process_params(arguments)
 
           Elasticsearch::API::Response.new(

--- a/elasticsearch-api/lib/elasticsearch/api/actions/streams/status.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/streams/status.rb
@@ -24,9 +24,6 @@ module Elasticsearch
       module Actions
         # Get the status of streams.
         # Get the current status for all types of streams.
-        #
-        # This API is only available behind a feature flag: `logs_stream`.
-        #
         # This functionality is in technical preview and may be changed or removed in a future
         # release. Elastic will apply best effort to fix any issues, but features in technical
         # preview are not subject to the support SLA of official GA features.

--- a/elasticsearch-api/lib/elasticsearch/api/actions/update_by_query.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/update_by_query.rb
@@ -116,7 +116,7 @@ module Elasticsearch
       #  This parameter can be used only when the `q` query string parameter is specified.
       # @option arguments [Integer] :max_docs The maximum number of documents to process.
       #  It defaults to all documents.
-      #  When set to a value less then or equal to `scroll_size` then a scroll will not be used to retrieve the results for the operation.
+      #  When set to a value less than or equal to `scroll_size` and `conflicts` is set to `abort`, a scroll will not be used to retrieve the results for the operation.
       # @option arguments [String] :pipeline The ID of the pipeline to use to preprocess incoming documents.
       #  If the index has a default ingest pipeline specified, then setting the value to `_none` disables the default ingest pipeline for this request.
       #  If a final pipeline is configured it will always run, regardless of the value of this parameter.

--- a/elasticsearch-api/lib/elasticsearch/api/version.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/version.rb
@@ -18,6 +18,6 @@
 module Elasticsearch
   module API
     VERSION = '9.3.0'.freeze
-    ES_SPECIFICATION_COMMIT = 'f2e86a6bbc03b1e2732d163cf6ca3e07ba578ac1'.freeze
+    ES_SPECIFICATION_COMMIT = '9f8c66bedb2d4b509c3f3a7dabbd274fd152c25a'.freeze
   end
 end

--- a/elasticsearch-api/spec/unit/actions/streams/logs_disable_spec.rb
+++ b/elasticsearch-api/spec/unit/actions/streams/logs_disable_spec.rb
@@ -21,15 +21,15 @@ describe 'client.streams#logs_disable' do
   let(:expected_args) do
     [
       'POST',
-      '_streams/logs/_disable',
+      '_streams/foo/_disable',
       {},
       nil,
       {},
-      { endpoint: 'streams.logs_disable' }
+      { endpoint: 'streams.logs_disable', defined_params: { name: 'foo' } }
     ]
   end
 
   it 'performs the request' do
-    expect(client_double.streams.logs_disable).to be_a Elasticsearch::API::Response
+    expect(client_double.streams.logs_disable(name: 'foo')).to be_a Elasticsearch::API::Response
   end
 end

--- a/elasticsearch-api/spec/unit/actions/streams/logs_enable_spec.rb
+++ b/elasticsearch-api/spec/unit/actions/streams/logs_enable_spec.rb
@@ -21,15 +21,15 @@ describe 'client.streams#logs_enable' do
   let(:expected_args) do
     [
       'POST',
-      '_streams/logs/_enable',
+      '_streams/foo/_enable',
       {},
       nil,
       {},
-      { endpoint: 'streams.logs_enable' }
+      { endpoint: 'streams.logs_enable', defined_params: { name: 'foo' } }
     ]
   end
 
   it 'performs the request' do
-    expect(client_double.streams.logs_enable).to be_a Elasticsearch::API::Response
+    expect(client_double.streams.logs_enable(name: 'foo')).to be_a Elasticsearch::API::Response
   end
 end


### PR DESCRIPTION
- Updates `inference.get`, adds path using task_type.
- `streams.logs_disable`, `streams.logs_enable` - new `name` parameter required, no longer behind feature flag.
- `streams.status` - no longer behind feature flag.