### PR TITLE
[API] Generates 4ab6ac571ef14c1bb76afcccd57d0fc2c6e65769

### DIFF
--- a/elasticsearch-api/lib/elasticsearch/api/actions/async_search/get.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/async_search/get.rb
@@ -36,6 +36,13 @@ module Elasticsearch
         # @option arguments [Time] :wait_for_completion_timeout Specifies to wait for the search to be completed up until the provided timeout.
         #  Final results will be returned if available before the timeout expires, otherwise the currently available results will be returned once the timeout expires.
         #  By default no timeout is set meaning that the currently available results will be returned without any additional wait.
+        # @option arguments [Boolean] :return_intermediate_results Specifies whether the response should contain intermediate results if the query is still running when the wait_for_completion_timeout
+        #  expires or if no wait_for_completion_timeout is specified.
+        #  If true and the search is still running, the search response
+        #  will include any hits and partial aggregations that are available.
+        #  If false and the search is still running, the search response will not include any hits (but possibly include
+        #  total hits) nor will include any partial aggregations.
+        #  When not specified, the intermediate results are returned for running queries.
         # @option arguments [Boolean] :error_trace When set to `true` Elasticsearch will include the full stack trace of errors
         #  when they occur.
         # @option arguments [String, Array<String>] :filter_path Comma-separated list of filters in dot notation which reduce the response

--- a/elasticsearch-api/lib/elasticsearch/api/actions/migration/deprecations.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/migration/deprecations.rb
@@ -23,9 +23,12 @@ module Elasticsearch
     module Migration
       module Actions
         # Get deprecation information.
-        # Get information about different cluster, node, and index level settings that use deprecated features that will be removed or changed in the next major version.
-        # TIP: This APIs is designed for indirect use by the Upgrade Assistant.
-        # You are strongly recommended to use the Upgrade Assistant.
+        # Returns information about deprecated features which are in use in the cluster.
+        # The reported features include cluster, node, and index level settings that will be removed or changed in the next major version.
+        # You must address the reported issues before upgrading to the next major version.
+        # However, no action is required when upgrading within the current major version.
+        # Deprecated features remain fully supported and will continue to work in the current version, and when upgrading to a newer minor or patch release in the same major version.
+        # Use this API to review your usage of these features and migrate away from them at your own pace, before upgrading to a new major version.
         #
         # @option arguments [String] :index Comma-separate list of data streams or indices to check. Wildcard (*) expressions are supported.
         # @option arguments [Boolean] :error_trace When set to `true` Elasticsearch will include the full stack trace of errors

--- a/elasticsearch-api/lib/elasticsearch/api/actions/searchable_snapshots/mount.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/searchable_snapshots/mount.rb
@@ -33,7 +33,8 @@ module Elasticsearch
         #  If the master node is not available before the timeout expires, the request fails and returns an error.
         #  To indicate that the request should never timeout, set it to `-1`. Server default: 30s.
         # @option arguments [Boolean] :wait_for_completion If true, the request blocks until the operation is complete.
-        # @option arguments [String] :storage The mount option for the searchable snapshot index. Server default: full_copy.
+        # @option arguments [String] :storage The mount option for the searchable snapshot index.
+        #  For further information on mount options, refer to: {https://www.elastic.co/docs/deploy-manage/tools/snapshot-and-restore/searchable-snapshots#searchable-snapshot-mount-storage-options Mount options} Server default: full_copy.
         # @option arguments [Boolean] :error_trace When set to `true` Elasticsearch will include the full stack trace of errors
         #  when they occur.
         # @option arguments [String, Array<String>] :filter_path Comma-separated list of filters in dot notation which reduce the response

--- a/elasticsearch-api/lib/elasticsearch/api/version.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/version.rb
@@ -18,6 +18,6 @@
 module Elasticsearch
   module API
     VERSION = '9.3.0'.freeze
-    ES_SPECIFICATION_COMMIT = '9f8c66bedb2d4b509c3f3a7dabbd274fd152c25a'.freeze
+    ES_SPECIFICATION_COMMIT = '4ab6ac571ef14c1bb76afcccd57d0fc2c6e65769'.freeze
   end
 end


### PR DESCRIPTION
async_search.get - Adds Boolean parameter
`:return_intermediate_results` -  Specifies whether the response should contain intermediate results if the query is still running when the wait_for_completion_timeout expires or if no
wait_for_completion_timeout is specified.