### PR TITLE
[CI] Updates versions

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -10,16 +10,15 @@ steps:
           - '4.0'
           - '3.4'
           - '3.3'
-          - '3.2'
         ruby_source:
           - ruby
         transport:
-          - '8.4'
+          - '8.5'
       adjustments:
         - with: # JRuby tests
             ruby: '9.4'
             ruby_source: jruby
-            transport: '8.4'
+            transport: '8.5'
         - with: # Test for main branch of transport
             ruby: '3.4'
             ruby_source: ruby

--- a/.github/workflows/9.4.yml
+++ b/.github/workflows/9.4.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ['3.2', '3.3', '3.4', '4.0', 'jruby-9.3', 'jruby-9.4', 'jruby-10.0']
+        ruby: ['3.3', '3.4', '4.0', 'jruby-9.3', 'jruby-9.4', 'jruby-10.0']
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4.3.0

--- a/.github/workflows/license.yml
+++ b/.github/workflows/license.yml
@@ -7,9 +7,9 @@ jobs:
     - uses: actions/checkout@v4.3.0
       with:
         persist-credentials: false
-    - uses: ruby/setup-ruby@v1.263.0
+    - uses: ruby/setup-ruby@v1
       with:
-        ruby-version: '3.4'
+        ruby-version: '4.0'
     - name: Check license headers
       run: |
         ruby ./.github/check_license_headers.rb

--- a/.github/workflows/otel.yml
+++ b/.github/workflows/otel.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ['3.4', 'jruby-9.4']
+        ruby: ['4.0', 'jruby-9.4']
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4.3.0
@@ -31,7 +31,7 @@ jobs:
       - uses: elastic/elastic-github-actions/elasticsearch@master
         with:
           stack-version: 9.4.0-SNAPSHOT
-      - uses: ruby/setup-ruby@v1.263.0
+      - uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby }}
       - name: Build


### PR DESCRIPTION
* Bumps elastic-transport to 8.5
* Drops Ruby 3.2 (EOL) in testing
* Uses Ruby 4 in otel and license workflows