### PR TITLE
[API] Updates generated code to 0c9c852ff3757a3710d354549860e4245d788b10 

### DIFF
--- a/elasticsearch-api/lib/elasticsearch/api/actions/cancel_reindex.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/cancel_reindex.rb
@@ -21,16 +21,37 @@
 module Elasticsearch
   module API
     module Actions
-      # Cancel a reindex task.
-      # Cancel an ongoing reindex task. If `wait_for_completion` is `true` (the default),
-      # the response contains the final task state after cancellation.
+      # Cancel an ongoing reindex task.
+      # If `wait_for_completion` is `true` (the default), the response contains the final task state after cancellation.
       # If `wait_for_completion` is `false`, the response contains only `acknowledged: true`.
+      # This API follows reindex tasks across node-shutdown relocations, so callers can
+      # keep using the original task ID throughout the lifetime of the operation.
+      # Returned task IDs and timings reflect the original task, not its relocated successor.
+      # Relocated task IDs are also supported. They are followed transparently and return the task ID and timings of the original task.
+      # When the task ID cannot be cancelled (unknown ID, non-reindex task, sliced child, finished task, or node left with no stored result), the API returns the following response with a 404 status code:
       #
-      # This API is only available behind a feature flag: `reindex_management_api`.
+      # ```
+      # {
+      #   "error": {
+      #     "type": "resource_not_found_exception",
+      #     "reason": "reindex task [r1A2WoRbTwKZ516z6NEs5A:36619] either not found or completed"
+      #   },
+      #   "status": 404
+      # }
+      # ```
       #
-      # This functionality is in technical preview and may be changed or removed in a future
-      # release. Elastic will apply best effort to fix any issues, but features in technical
-      # preview are not subject to the support SLA of official GA features.
+      # During a brief handoff window of a node-shutdown relocation, you may receive the response below with a 503 status code.
+      # Retry with the same task ID; the retry follows the relocated task transparently.
+      #
+      # ```
+      # {
+      #   "error": {
+      #     "type": "status_exception",
+      #     "reason": "cannot cancel task [36619] because it is being relocated"
+      #   },
+      #   "status": 503
+      # }
+      # ```
       #
       # @option arguments [String] :task_id The ID of the reindex task to cancel. (*Required*)
       # @option arguments [Boolean] :wait_for_completion If `true` (the default), the request blocks until the cancellation is complete and returns the final task state.

--- a/elasticsearch-api/lib/elasticsearch/api/actions/delete_by_query.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/delete_by_query.rb
@@ -119,7 +119,8 @@ module Elasticsearch
       #  Unlike the delete API, it does not support `wait_for`.
       # @option arguments [Boolean] :request_cache If `true`, the request cache is used for this request.
       #  Defaults to the index-level setting.
-      # @option arguments [Float] :requests_per_second The throttle for this request in sub-requests per second. Server default: -1.
+      # @option arguments [Float] :requests_per_second The maximum number of documents to delete per second, across the entire delete-by-query operation (including slices).
+      #  It can be either `-1` to turn off throttling or any decimal number like `1.7` or `12` to throttle to that level. Server default: -1.
       # @option arguments [String, Array<String>] :routing A custom value used to route operations to a specific shard.
       # @option arguments [String] :q A query in the Lucene query string syntax.
       # @option arguments [Time] :scroll The period to retain the search context for scrolling.

--- a/elasticsearch-api/lib/elasticsearch/api/actions/delete_by_query_rethrottle.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/delete_by_query_rethrottle.rb
@@ -26,8 +26,8 @@ module Elasticsearch
       # Rethrottling that speeds up the query takes effect immediately but rethrotting that slows down the query takes effect after completing the current batch to prevent scroll timeouts.
       #
       # @option arguments [String] :task_id The ID for the task. (*Required*)
-      # @option arguments [Float] :requests_per_second The throttle for this request in sub-requests per second.
-      #  To disable throttling, set it to `-1`. (*Required*)
+      # @option arguments [Float] :requests_per_second The maximum number of documents to delete per second, across the entire delete-by-query operation (including slices).
+      #  It can be either `-1` to turn off throttling or any decimal number like `1.7` or `12` to throttle to that level. (*Required*)
       # @option arguments [Boolean] :error_trace When set to `true` Elasticsearch will include the full stack trace of errors
       #  when they occur.
       # @option arguments [String, Array<String>] :filter_path Comma-separated list of filters in dot notation which reduce the response

--- a/elasticsearch-api/lib/elasticsearch/api/actions/get_reindex.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/get_reindex.rb
@@ -21,14 +21,23 @@
 module Elasticsearch
   module API
     module Actions
-      # Get a reindex task.
       # Get the status and progress of a specific reindex task.
+      # This API follows reindex tasks across node-shutdown relocations, so callers can
+      # keep using the original task ID throughout the lifetime of the operation.
+      # Returned task IDs and timings reflect the original task, not its relocated successor.
+      # Relocated task IDs are also supported. They are followed transparently and return the task ID and timings of the original task.
+      # When the task ID cannot be resolved, the API returns the response below with a 404 status code.
+      # This response is used whether the ID is unknown, refers to a non-reindex task, refers to a sliced child subtask, or refers to a task whose node left the cluster with no stored result (e.g. a non-graceful shutdown).
       #
-      # This API is only available behind a feature flag: `reindex_management_api`.
-      #
-      # This functionality is in technical preview and may be changed or removed in a future
-      # release. Elastic will apply best effort to fix any issues, but features in technical
-      # preview are not subject to the support SLA of official GA features.
+      # ```
+      # {
+      #   "error": {
+      #     "type": "resource_not_found_exception",
+      #     "reason": "Reindex operation [r1A2WoRbTwKZ516z6NEs5A:36619] not found"
+      #   },
+      #   "status": 404
+      # }
+      # ```
       #
       # @option arguments [String] :task_id The ID of the reindex task to retrieve. (*Required*)
       # @option arguments [Boolean] :wait_for_completion If `true`, the request blocks until the reindex task completes, then returns the result.

--- a/elasticsearch-api/lib/elasticsearch/api/actions/inference/put.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/inference/put.rb
@@ -31,7 +31,7 @@ module Elasticsearch
         # * AlibabaCloud AI Search (`completion`, `rerank`, `sparse_embedding`, `text_embedding`)
         # * Amazon Bedrock (`chat_completion`, `completion`, `text_embedding`)
         # * Amazon SageMaker (`chat_completion`, `completion`, `rerank`, `sparse_embedding`, `text_embedding`)
-        # * Anthropic (`completion`)
+        # * Anthropic (`chat_completion`, `completion`)
         # * Azure AI Studio (`completion`, `rerank`, `text_embedding`)
         # * Azure OpenAI (`chat_completion`, `completion`, `text_embedding`)
         # * Cohere (`completion`, `rerank`, `text_embedding`)

--- a/elasticsearch-api/lib/elasticsearch/api/actions/inference/put_anthropic.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/inference/put_anthropic.rb
@@ -26,7 +26,8 @@ module Elasticsearch
         # Create an inference endpoint to perform an inference task with the `anthropic` service.
         #
         # @option arguments [String] :task_type The task type.
-        #  The only valid task type for the model to perform is `completion`. (*Required*)
+        #  The valid task types for the model to perform are `completion` and `chat_completion`.
+        #  NOTE: The `chat_completion` task type only supports streaming and only through the _stream API. (*Required*)
         # @option arguments [String] :anthropic_inference_id The unique identifier of the inference endpoint. (*Required*)
         # @option arguments [Time] :timeout Specifies the amount of time to wait for the inference endpoint to be created. Server default: 30s.
         # @option arguments [Boolean] :error_trace When set to `true` Elasticsearch will include the full stack trace of errors

--- a/elasticsearch-api/lib/elasticsearch/api/actions/list_reindex.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/list_reindex.rb
@@ -21,14 +21,10 @@
 module Elasticsearch
   module API
     module Actions
-      # List active reindex tasks.
       # Get information about all currently running reindex tasks.
-      #
-      # This API is only available behind a feature flag: `reindex_management_api`.
-      #
-      # This functionality is in technical preview and may be changed or removed in a future
-      # release. Elastic will apply best effort to fix any issues, but features in technical
-      # preview are not subject to the support SLA of official GA features.
+      # Reindex tasks that are mid-relocation between nodes are reported once,
+      # under their original task ID, so callers do not see duplicates across the relocation chain.
+      # If the API returns a HTTP status of `200 OK`, but `node_failures` or `task_failures` are non-empty in the body, the listing is not a complete authoritative listing and may be missing tasks.
       #
       # @option arguments [Boolean] :detailed If `true`, include detailed task status information in the response.
       # @option arguments [Boolean] :error_trace When set to `true` Elasticsearch will include the full stack trace of errors

--- a/elasticsearch-api/lib/elasticsearch/api/actions/msearch.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/msearch.rb
@@ -73,7 +73,13 @@ module Elasticsearch
       #  Supported in serverless only.
       # @option arguments [Boolean] :rest_total_hits_as_int If true, hits.total are returned as an integer in the response. Defaults to false, which returns an object.
       # @option arguments [String, Array<String>] :routing Custom routing value used to route search operations to a specific shard.
+      #  Not allowed when `index.slice.enabled` is `true` for the target index; use `_slice` instead.
       # @option arguments [String] :search_type Indicates whether global term and document frequencies should be used when scoring returned documents.
+      # @option arguments [String] :_slice The slice identifier for routing the search to a specific slice.
+      #  When provided at the top level, all sub-searches are routed to shards matching the given slice value.
+      #  Use the special value `_all` to query all slices without restricting to a routing value.
+      #  Required when `index.slice.enabled` is `true` for the target index; not allowed when `index.slice.enabled` is `false`.
+      #  Individual sub-search headers can also specify `_slice` to override the top-level setting.
       # @option arguments [Boolean] :typed_keys Specifies whether aggregation and suggester names should be prefixed by their respective types in the response.
       # @option arguments [Boolean] :error_trace When set to `true` Elasticsearch will include the full stack trace of errors
       #  when they occur.

--- a/elasticsearch-api/lib/elasticsearch/api/actions/reindex.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/reindex.rb
@@ -60,9 +60,12 @@ module Elasticsearch
       # Refer to the linked documentation for examples of how to reindex documents.
       #
       # @option arguments [Boolean] :refresh If `true`, the request refreshes affected shards to make this operation visible to search.
-      # @option arguments [Float] :requests_per_second The throttle for this request in sub-requests per second.
-      #  By default, there is no throttle. Server default: -1.
-      # @option arguments [Time] :scroll The period of time that a consistent view of the index should be maintained for scrolled search. Server default: 5m.
+      # @option arguments [Float] :requests_per_second The maximum number of documents to index per second, across the entire reindex operation (including slices).
+      #  It can be either `-1` to turn off throttling or any decimal number like `1.7` or `12` to throttle to that level. Server default: -1.
+      # @option arguments [Time] :scroll The period of time that a consistent view of the index should be maintained for scrolled search.
+      #  In serverless, and stack versions >= v9.5.0, we use PIT rather than scroll for pagination.
+      #  We only use scroll for reindexing from remote clusters that are older than v7.10.0.
+      #  Therefore, this parameter is ignored unless you are reindexing from a remote cluster that is older than v7.10.0. Server default: 5m.
       # @option arguments [Integer, String] :slices The number of slices this task should be divided into.
       #  It defaults to one slice, which means the task isn't sliced into subtasks.Reindex supports sliced scroll to parallelize the reindexing process.
       #  This parallelization can improve efficiency and provide a convenient way to break the request down into smaller parts.NOTE: Reindexing from remote clusters does not support manual or automatic slicing.If set to `auto`, Elasticsearch chooses the number of slices to use.

--- a/elasticsearch-api/lib/elasticsearch/api/actions/reindex_rethrottle.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/reindex_rethrottle.rb
@@ -22,21 +22,32 @@ module Elasticsearch
   module API
     module Actions
       # Throttle a reindex operation.
-      # Change the number of requests per second for a particular reindex operation.
-      # For example:
+      # Change the maximum number of documents to index per second for a particular reindex operation.
+      # For example, to unthrottle to unlimited documents per second:
       #
       # ```
       # POST _reindex/r1A2WoRbTwKZ516z6NEs5A:36619/_rethrottle?requests_per_second=-1
       # ```
       #
       # Rethrottling that speeds up the query takes effect immediately.
-      # Rethrottling that slows down the query will take effect after completing the current batch.
+      # Rethrottling that slows down the query will take effect after completing the current batch of documents.
       # This behavior prevents scroll timeouts.
+      # This API follows reindex tasks across node-shutdown relocations, so callers can keep using
+      # the original task ID throughout the lifetime of the operation.
+      # The relocated task ID is also accepted and is followed transparently.
+      # In either case, returned task IDs and timings reflect the original task, not its relocated successor.
+      # The rethrottle may not have been applied to any tasks if either `node_failures` or `task_failures` are non-empty, or if the response contains
+      # no successfully rethrottled tasks — that is, no entries under `nodes` (returned with the default
+      # `group_by=nodes` in stack) or under `tasks` (returned in serverless, or in stack with
+      # `group_by=none` or `group_by=parents`).
       #
-      # @option arguments [String] :task_id The task identifier, which can be found by using the tasks API. (*Required*)
-      # @option arguments [Float] :requests_per_second The throttle for this request in sub-requests per second.
+      # @option arguments [String] :task_id The task identifier, returned when creating a reindex task, or by listing tasks via
+      #  `GET /_reindex` or `GET /_tasks`.
+      #  In stack, can be either the original task ID or the task ID of the relocated task. (*Required*)
+      # @option arguments [Float] :requests_per_second The maximum number of documents to index per second, across the entire reindex operation (including slices).
       #  It can be either `-1` to turn off throttling or any decimal number like `1.7` or `12` to throttle to that level. (*Required*)
-      # @option arguments [String] :group_by [TODO]
+      # @option arguments [String] :group_by The way to group the tasks in the response.
+      #  We recommend setting this to `none`, which provides the cleanest response format. Server default: nodes.
       # @option arguments [Boolean] :error_trace When set to `true` Elasticsearch will include the full stack trace of errors
       #  when they occur.
       # @option arguments [String, Array<String>] :filter_path Comma-separated list of filters in dot notation which reduce the response

--- a/elasticsearch-api/lib/elasticsearch/api/actions/search_shards.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/search_shards.rb
@@ -49,6 +49,11 @@ module Elasticsearch
       # @option arguments [String] :preference The node or shard the operation should be performed on.
       #  It is random by default.
       # @option arguments [String, Array<String>] :routing A custom value used to route operations to a specific shard.
+      #  Not allowed when `index.slice.enabled` is `true` for the target index; use `_slice` instead.
+      # @option arguments [String] :_slice The slice identifier for routing the search to a specific slice.
+      #  When provided, the request is limited to shards that match the given slice value.
+      #  Use the special value `_all` to query all slices without restricting to a routing value.
+      #  Required when `index.slice.enabled` is `true` for the target index; not allowed when `index.slice.enabled` is `false`.
       # @option arguments [Boolean] :error_trace When set to `true` Elasticsearch will include the full stack trace of errors
       #  when they occur.
       # @option arguments [String, Array<String>] :filter_path Comma-separated list of filters in dot notation which reduce the response

--- a/elasticsearch-api/lib/elasticsearch/api/actions/security/create_service_token.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/security/create_service_token.rb
@@ -26,6 +26,8 @@ module Elasticsearch
         # Create a service accounts token for access without requiring basic authentication.
         # NOTE: Service account tokens never expire.
         # You must actively delete them if they are no longer needed.
+        # IMPORTANT: On Serverless, non-operator users can create tokens for only `elastic/fleet-server` and `elastic/fleet-server-remote`.
+        # Creating tokens for any other service account requires operator privileges.
         #
         # @option arguments [String] :namespace The name of the namespace, which is a top-level grouping of service accounts. (*Required*)
         # @option arguments [String] :service The name of the service. (*Required*)

--- a/elasticsearch-api/lib/elasticsearch/api/actions/security/delete_service_token.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/security/delete_service_token.rb
@@ -24,6 +24,8 @@ module Elasticsearch
       module Actions
         # Delete service account tokens.
         # Delete service account tokens for a service in a specified namespace.
+        # IMPORTANT: On Serverless, non-operator users can delete tokens for only `elastic/fleet-server` and `elastic/fleet-server-remote`.
+        # Deleting tokens for any other service account requires operator privileges.
         #
         # @option arguments [String] :namespace The namespace, which is a top-level grouping of service accounts. (*Required*)
         # @option arguments [String] :service The service name. (*Required*)

--- a/elasticsearch-api/lib/elasticsearch/api/actions/synonyms/get_synonym.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/synonyms/get_synonym.rb
@@ -25,8 +25,11 @@ module Elasticsearch
         # Get a synonym set.
         #
         # @option arguments [String] :id The synonyms set identifier to retrieve. (*Required*)
-        # @option arguments [Integer] :from The starting offset for query rules to retrieve. Server default: 0.
-        # @option arguments [Integer] :size The max number of query rules to retrieve. Server default: 10.
+        # @option arguments [Integer] :from The starting offset for synonym rules to retrieve. Server default: 0.
+        # @option arguments [Integer] :size The max number of synonym rules to retrieve. Server default: 10.
+        # @option arguments [String] :search_after The synonym rule ID to use as a cursor for pagination.
+        #  The next page of results will start after this rule ID.
+        #  This parameter cannot be used with `from`.
         # @option arguments [Boolean] :error_trace When set to `true` Elasticsearch will include the full stack trace of errors
         #  when they occur.
         # @option arguments [String, Array<String>] :filter_path Comma-separated list of filters in dot notation which reduce the response

--- a/elasticsearch-api/lib/elasticsearch/api/actions/tasks/cancel.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/tasks/cancel.rb
@@ -31,6 +31,9 @@ module Elasticsearch
         # The cancelled flag in the response indicates that the cancellation command has been processed and the task will stop as soon as possible.
         # To troubleshoot why a cancelled task does not complete promptly, use the get task information API with the `?detailed` parameter to identify the other tasks the system is running.
         # You can also use the node hot threads API to obtain detailed information about the work the system is doing instead of completing the cancelled task.
+        # For relocatable tasks, this API transparently follows the task across graceful shutdown relocations,
+        # so callers can keep using the original task ID. The returned task reports its `original_task_id` and `original_start_time_in_millis`
+        # if it is continuing work from an earlier task.
         # This functionality is in technical preview and may be changed or removed in a future
         # release. Elastic will apply best effort to fix any issues, but features in technical
         # preview are not subject to the support SLA of official GA features.

--- a/elasticsearch-api/lib/elasticsearch/api/actions/tasks/get.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/tasks/get.rb
@@ -27,6 +27,9 @@ module Elasticsearch
         # WARNING: The task management API is new and should still be considered a beta feature.
         # The API may change in ways that are not backwards compatible.
         # If the task identifier is not found, a 404 response code indicates that there are no resources that match the request.
+        # For relocatable tasks, this API transparently follows the task across graceful shutdown relocations,
+        # so callers can keep using the original task ID. The returned task reports its `original_task_id` and `original_start_time_in_millis`
+        # if it is continuing work from an earlier task.
         # This functionality is in technical preview and may be changed or removed in a future
         # release. Elastic will apply best effort to fix any issues, but features in technical
         # preview are not subject to the support SLA of official GA features.

--- a/elasticsearch-api/lib/elasticsearch/api/actions/tasks/list.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/tasks/list.rb
@@ -26,6 +26,9 @@ module Elasticsearch
         # Get information about the tasks currently running on one or more nodes in the cluster.
         # WARNING: The task management API is new and should still be considered a beta feature.
         # The API may change in ways that are not backwards compatible.
+        # For relocatable tasks, this API transparently follows the task across graceful shutdown relocations,
+        # so callers can keep using the original task ID. The returned task reports its `original_task_id` and `original_start_time_in_millis`
+        # if it is continuing work from an earlier task.
         # **Identifying running tasks**
         # The `X-Opaque-Id header`, when provided on the HTTP request header, is going to be returned as a header in the response as well as in the headers field for in the task information.
         # This enables you to track certain calls or associate certain tasks with the client that started them.

--- a/elasticsearch-api/lib/elasticsearch/api/actions/update_by_query.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/update_by_query.rb
@@ -132,7 +132,8 @@ module Elasticsearch
       #  This is different than the update API's `refresh` parameter, which causes just the shard that received the request to be refreshed.
       # @option arguments [Boolean] :request_cache If `true`, the request cache is used for this request.
       #  It defaults to the index-level setting.
-      # @option arguments [Float] :requests_per_second The throttle for this request in sub-requests per second. Server default: -1.
+      # @option arguments [Float] :requests_per_second The maximum number of documents to update per second, across the entire update_by_query operation (including slices).
+      #  It can be either `-1` to turn off throttling or any decimal number like `1.7` or `12` to throttle to that level. Server default: -1.
       # @option arguments [String, Array<String>] :routing A custom value used to route operations to a specific shard.
       # @option arguments [Time] :scroll The period to retain the search context for scrolling. Server default: 5m.
       # @option arguments [Integer] :scroll_size The size of the scroll request that powers the operation. Server default: 1000.

--- a/elasticsearch-api/lib/elasticsearch/api/actions/update_by_query_rethrottle.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/update_by_query_rethrottle.rb
@@ -26,8 +26,8 @@ module Elasticsearch
       # Rethrottling that speeds up the query takes effect immediately but rethrotting that slows down the query takes effect after completing the current batch to prevent scroll timeouts.
       #
       # @option arguments [String] :task_id The ID for the task. (*Required*)
-      # @option arguments [Float] :requests_per_second The throttle for this request in sub-requests per second.
-      #  To turn off throttling, set it to `-1`. (*Required*)
+      # @option arguments [Float] :requests_per_second The maximum number of documents to update per second, across the entire update_by_query operation (including slices).
+      #  It can be either `-1` to turn off throttling or any decimal number like `1.7` or `12` to throttle to that level. (*Required*)
       # @option arguments [Boolean] :error_trace When set to `true` Elasticsearch will include the full stack trace of errors
       #  when they occur.
       # @option arguments [String, Array<String>] :filter_path Comma-separated list of filters in dot notation which reduce the response

--- a/elasticsearch-api/lib/elasticsearch/api/version.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/version.rb
@@ -18,6 +18,6 @@
 module Elasticsearch
   module API
     VERSION = '9.5.0'.freeze
-    ES_SPECIFICATION_COMMIT = 'ddbb639a46f7019d7f8cc479b623dd4b23969112'.freeze
+    ES_SPECIFICATION_COMMIT = '0c9c852ff3757a3710d354549860e4245d788b10'.freeze
   end
 end


### PR DESCRIPTION
* Promotes reindex APIs from technical preview: `cancel_reindex`, `get_reindex`, `list_reindex`. These endpoints are not behind a feature flag anymore.
* `msearch` - new String parameter `:_slice` - The slice identifier for routing the search to a specific slice.
* `synonyms.get_synonym` - new String parameter `:search_after` - The synonym rule ID to use as a cursor for pagination.