### PR TITLE
[Backport][9.2] Fixes NoMethodError when Content-Type lacks compatible-with parameter

### DIFF
--- a/.github/workflows/9.2.yml
+++ b/.github/workflows/9.2.yml
@@ -39,4 +39,4 @@ jobs:
     - name: elasticsearch
       run: cd elasticsearch && bundle exec rake test:all
     - name: elasticsearch-api
-      run: rake es:download_artifacts[9.2] && cd elasticsearch-api && bundle exec rake test:all
+      run: cd elasticsearch-api && bundle exec rake test:all

--- a/elasticsearch-api/lib/elasticsearch/api/utils.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/utils.rb
@@ -182,7 +182,7 @@ module Elasticsearch
       def update_ndjson_headers!(headers, client_headers)
         current_content = client_headers.keys.find { |c| c.match?(/content-?_?type/i) } || 'content-type'
         current_accept = client_headers.keys.find { |c| c.match?(/accept/i) } || 'accept'
-        version = client_headers[current_content].match(/compatible-with=([0-9]+)/)[1] || 9
+        version = client_headers[current_content].match(/compatible-with=([0-9]+)/)&.[](1) || 9
 
         headers.merge!(
           {

--- a/elasticsearch-api/spec/unit/ndjson_endpoints/bulk_spec.rb
+++ b/elasticsearch-api/spec/unit/ndjson_endpoints/bulk_spec.rb
@@ -33,14 +33,14 @@ describe 'bulk headers test' do
     it 'does not override headers' do
       allow(client)
         .to receive(:perform_request)
-              .with(
-                Elasticsearch::API::HTTP_POST,
-                '_bulk',
-                {},
-                {},
-                expected_headers,
-                { endpoint: 'bulk' }
-              )
+        .with(
+          Elasticsearch::API::HTTP_POST,
+          '_bulk',
+          {},
+          {},
+          expected_headers,
+          { endpoint: 'bulk' }
+        )
       expect(client.bulk(body: {})).to be_a Elasticsearch::API::Response
     end
   end
@@ -110,15 +110,43 @@ describe 'bulk headers test' do
     it 'does not override version in headers' do
       allow(client)
         .to receive(:perform_request)
-              .with(
-                Elasticsearch::API::HTTP_POST,
-                '_bulk',
-                {},
-                {},
-                expected_headers,
-                { endpoint: 'bulk' }
-              )
+        .with(
+          Elasticsearch::API::HTTP_POST,
+          '_bulk',
+          {},
+          {},
+          expected_headers,
+          { endpoint: 'bulk' }
+        )
       expect(client.bulk(body: {}, headers: { x_custom: 'Custom header' })).to be_a Elasticsearch::API::Response
+    end
+  end
+
+  context 'when using application/x-ndjson as a content-type header' do
+    let(:client) do
+      Elasticsearch::Client.new(
+        url: 'http://localhost:9200',
+        transport_options: {
+          headers: { 'Content-Type' => 'application/x-ndjson' }
+        }
+      )
+    end
+
+    it 'doesnt error when using bulk' do
+      allow(client)
+        .to receive(:perform_request)
+        .with(
+          Elasticsearch::API::HTTP_POST,
+          '_bulk',
+          {},
+          {},
+          {
+            'Content-Type' => 'application/vnd.elasticsearch+x-ndjson; compatible-with=9',
+            'accept' => 'application/vnd.elasticsearch+x-ndjson; compatible-with=9'
+          },
+          { endpoint: 'bulk' }
+        )
+      expect(client.bulk(body: {})).to be_a Elasticsearch::API::Response
     end
   end
 end


### PR DESCRIPTION
Backports #2974