### PR TITLE
[Gem] Fixes header conflict on Serverless

### DIFF
--- a/elasticsearch-api/spec/spec_helper.rb
+++ b/elasticsearch-api/spec/spec_helper.rb
@@ -28,11 +28,17 @@ else
 end
 require 'elasticsearch'
 require 'elasticsearch-api'
-require 'jbuilder'
 require 'jsonify'
 require 'logger'
 require 'openssl'
 require 'yaml'
+
+# TODO: There is a dependency issue with JRuby 9.4.15.0 and JBuilder at the moment:
+def jruby_exception?
+  defined?(JRUBY_VERSION) &&
+    JRUBY_VERSION == '9.4.15.0'
+end
+require 'jbuilder' unless jruby_exception?
 
 tracer = ::Logger.new(STDERR)
 tracer.formatter = lambda { |s, d, p, m| "#{m.gsub(/^.*$/) { |n| '   ' + n } }\n" }

--- a/elasticsearch-api/spec/unit/actions/json_builders_spec.rb
+++ b/elasticsearch-api/spec/unit/actions/json_builders_spec.rb
@@ -83,4 +83,5 @@ describe 'JSON builders' do
       expect(client_double.search(body: json)).to be_a Elasticsearch::API::Response
     end
   end
-end
+end unless jruby_exception?
+# TODO: Exception for JRuby v9.4.15.0 ^

--- a/elasticsearch/lib/elasticsearch.rb
+++ b/elasticsearch/lib/elasticsearch.rb
@@ -189,13 +189,17 @@ module Elasticsearch
     def set_content_type!(arguments)
       headers = {}
       user_headers = arguments&.[](:transport_options)&.[](:headers)
-      unless user_headers&.keys&.detect { |h| h =~ /content-?_?type/i }
+      unless user_headers&.keys&.detect { |h| h =~ /content-?_?type/i } || api_version_set?(user_headers)
         headers['content-type'] = 'application/vnd.elasticsearch+json; compatible-with=9'
       end
-      unless user_headers&.keys&.detect { |h| h =~ /accept/i }
+      unless user_headers&.keys&.detect { |h| h =~ /accept/i } || api_version_set?(user_headers)
         headers['accept'] = 'application/vnd.elasticsearch+json; compatible-with=9'
       end
       set_header(headers, arguments) unless headers.empty?
+    end
+
+    def api_version_set?(headers)
+      !!headers.keys.find { |a| a.match?(/elastic-api-version/i) }
     end
 
     def set_header(header, arguments)

--- a/elasticsearch/lib/elasticsearch.rb
+++ b/elasticsearch/lib/elasticsearch.rb
@@ -199,7 +199,7 @@ module Elasticsearch
     end
 
     def api_version_set?(headers)
-      !!headers.keys.find { |a| a.match?(/elastic-api-version/i) }
+      !!headers&.keys&.find { |a| a.match?(/elastic-api-version/i) }
     end
 
     def set_header(header, arguments)

--- a/elasticsearch/spec/unit/headers_spec.rb
+++ b/elasticsearch/spec/unit/headers_spec.rb
@@ -142,4 +142,26 @@ describe Elasticsearch::Client do
       client.search
     end
   end
+
+  context 'when Elastic-Api-Version header is set' do
+    let!(:client) do
+      described_class.new(
+        host: 'http://localhost:9200',
+        transport_options: { headers: { 'Elastic-Api-Version' => '2023-10-31' } }
+      ).tap do |client|
+        client.instance_variable_set('@verified', true)
+      end
+    end
+
+    it 'does not modify the content-type header' do
+      expected_headers = client.transport.connections.connections.first.connection.headers
+      expect(expected_headers['Content-Type']).to eq 'application/json'
+      expect(expected_headers['Elastic-Api-Version']).to eq '2023-10-31'
+
+      expect_any_instance_of(Faraday::Connection)
+        .to receive(:run_request)
+              .with(:get, 'http://localhost:9200/_search', nil, expected_headers) { OpenStruct.new(body: '') }
+      client.search
+    end
+  end
 end


### PR DESCRIPTION
When a client also sets the Elastic-Api-Version header (required for Elasticsearch Serverless), serverless rejects the request with HTTP 400: The request includes both the [Elastic-Api-Version] header and a [compatible-with] parameter, but it is not valid to include both of these in a request

These two versioning mechanisms serve different deployment models and are mutually exclusive on the server side:

* compatible-with=N: REST API compatibility for self-managed/hosted major version upgrades
* Elastic-Api-Version: 2023-10-31: date-based API versioning for serverless

With this change, set_content_type! checks if Elastic-Api-Version is already present in transport_options[:headers]  for adding compatible-with headers.

Addresses #2983