### PR TITLE
Revert "[Tests] Skips jbuilder for specific version of JRuby"

### DIFF
--- a/elasticsearch-api/Gemfile
+++ b/elasticsearch-api/Gemfile
@@ -32,4 +32,10 @@ group :development do
   else
     gem 'debug'
   end
+  # Related to https://github.com/ruby-i18n/i18n/issues/735
+  # Keeping here for compatiblity with JRuby 9.x
+  if Gem::Version.new(RUBY_VERSION) < Gem::Version.new('3.2') &&
+     Gem::Version.new(RUBY_VERSION) > Gem::Version.new('2.6')
+    gem 'i18n', '1.14'
+  end
 end

--- a/elasticsearch-api/spec/spec_helper.rb
+++ b/elasticsearch-api/spec/spec_helper.rb
@@ -28,17 +28,11 @@ else
 end
 require 'elasticsearch'
 require 'elasticsearch-api'
+require 'jbuilder'
 require 'jsonify'
 require 'logger'
 require 'openssl'
 require 'yaml'
-
-# TODO: There is a dependency issue with JRuby 9.4.15.0 and JBuilder at the moment:
-def jruby_exception?
-  defined?(JRUBY_VERSION) &&
-    JRUBY_VERSION == '9.4.15.0'
-end
-require 'jbuilder' unless jruby_exception?
 
 tracer = ::Logger.new(STDERR)
 tracer.formatter = lambda { |s, d, p, m| "#{m.gsub(/^.*$/) { |n| '   ' + n } }\n" }

--- a/elasticsearch-api/spec/unit/actions/json_builders_spec.rb
+++ b/elasticsearch-api/spec/unit/actions/json_builders_spec.rb
@@ -83,5 +83,4 @@ describe 'JSON builders' do
       expect(client_double.search(body: json)).to be_a Elasticsearch::API::Response
     end
   end
-end unless jruby_exception?
-# TODO: Exception for JRuby v9.4.15.0 ^
+end


### PR DESCRIPTION
The issue was related to https://github.com/ruby-i18n/i18n/issues/735

This reverts commit 43c2a33f3361be18a80d64ea28f8464633e8d7ac.