### PR TITLE
Replace `multi_json` and `oj` gems with standard Ruby `json` gem

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 **See the full release notes on the official documentation website: https://www.elastic.co/docs/release-notes/elasticsearch/clients/ruby**
 
+# Unreleased
+
+* Removes the `multi_json` and `oj` gems in favor of the standard Ruby `json` gem, which is now the default serializer implementation.
+
 # 9.4.3
 
 * Fixes header conflict when using Elasticsearch Serverless. [Pull Request](https://github.com/elastic/elasticsearch-ruby/pull/2984)

--- a/docs/examples/rabbitmq/Gemfile
+++ b/docs/examples/rabbitmq/Gemfile
@@ -21,5 +21,4 @@ gem 'elasticsearch'
 
 gem 'bunny'
 
-gem 'multi_json'
-gem 'oj'
+gem 'json'

--- a/docs/examples/rabbitmq/consumer-publisher.rb
+++ b/docs/examples/rabbitmq/consumer-publisher.rb
@@ -23,8 +23,7 @@
 #     $ bundle exec ruby consume-publish.rb
 #
 
-require 'multi_json'
-require 'oj'
+require 'json'
 
 require 'elasticsearch'
 
@@ -43,12 +42,12 @@ elasticsearch = Elasticsearch::Client.new log:true
 elasticsearch.indices.delete index: 'rabbit' rescue nil
 
 queue.subscribe do |delivery_info, metadata, payload|
-  hash = MultiJson.load(payload)
+  hash = JSON.load(payload)
   elasticsearch.index index: 'rabbit', type: 'event', id: hash.delete(:id), body: hash
 end
 
 (1..10).each do |i|
-  exchange.publish MultiJson.dump({id: i, title: "Test #{i}"}), routing_key: queue.name
+  exchange.publish JSON.dump({id: i, title: "Test #{i}"}), routing_key: queue.name
 end
 
 sleep 1.0
@@ -58,7 +57,7 @@ puts "Enter some words to index (use Ctrl+C to exit):"
 [:INT, :TERM].each do |signal| trap(signal) { puts "\nExiting..."; exit } end
 
 while input = gets
-  exchange.publish MultiJson.dump({title: input.chomp}), routing_key: queue.name unless input =~ /^\s*$/
+  exchange.publish JSON.dump({title: input.chomp}), routing_key: queue.name unless input =~ /^\s*$/
 end
 
 connection.close

--- a/docs/reference/advanced-config.md
+++ b/docs/reference/advanced-config.md
@@ -279,7 +279,7 @@ Elasticsearch::Client.new hosts: ['x1.search.org', 'x2.search.org'], selector_cl
 
 ## Serializer Implementations [serializer-implementations]
 
-By default, the [MultiJSON](https://rubygems.org/gems/multi_json) library is used as the serializer implementation, and it picks up the "right" adapter based on gems available.
+By default, the standard `JSON` library is used as the serializer implementation.
 
 The serialization component is pluggable, though, so you can write your own by including the `Elastic::Transport::Transport::Serializer::Base` module, implementing the required contract, and passing it to the client as the `serializer_class` or `serializer` parameter.
 

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -103,7 +103,7 @@ When you want to mix the library with your own client, it must conform to the fo
 A simple client could look like this (*with a dependency on `active_support` to parse the query params*):
 
 ```rb
-require 'multi_json'
+require 'json'
 require 'faraday'
 require 'elasticsearch/api'
 
@@ -118,7 +118,7 @@ class MySimpleClient
     CONNECTION.run_request \
       method.downcase.to_sym,
       path_with_params(path, params),
-      ( body ? MultiJson.dump(body): nil ),
+      ( body ? JSON.dump(body): nil ),
       {'Content-Type' => 'application/json'}
   end
 
@@ -201,7 +201,7 @@ mash.hits.hits.first._source.title
 
 ### Using a Custom JSON Serializer [_using_a_custom_json_serializer]
 
-The library uses the [MultiJson](https://rubygems.org/gems/multi_json/) gem by default but allows you to set a custom JSON library, provided it uses the standard `load/dump` interface:
+The library uses the standard `JSON` library by default but allows you to set a custom JSON library, provided it uses the standard `load/dump` interface:
 
 ```rb
 Elasticsearch::API.settings[:serializer] = JrJackson::Json

--- a/elasticsearch-api/elasticsearch-api.gemspec
+++ b/elasticsearch-api/elasticsearch-api.gemspec
@@ -44,7 +44,7 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = '>= 2.6' # For compatibility with JRuby 9.3
   s.add_dependency 'base64'
-  s.add_dependency 'multi_json'
+  s.add_dependency 'json', '~> 2.19'
 
   s.add_development_dependency 'ansi'
   s.add_development_dependency 'bundler'

--- a/elasticsearch-api/lib/elasticsearch/api.rb
+++ b/elasticsearch-api/lib/elasticsearch/api.rb
@@ -16,7 +16,7 @@
 # under the License.
 
 require 'cgi/escape'
-require 'multi_json'
+require 'json'
 require 'elasticsearch/api/version'
 require 'elasticsearch/api/utils'
 require 'elasticsearch/api/response'
@@ -29,7 +29,7 @@ module Elasticsearch
   module API
     include Elasticsearch::API::Actions
 
-    DEFAULT_SERIALIZER = MultiJson
+    DEFAULT_SERIALIZER = JSON
 
     HTTP_GET          = 'GET'.freeze
     HTTP_HEAD         = 'HEAD'.freeze

--- a/elasticsearch-api/spec/unit/actions/hashie_spec.rb
+++ b/elasticsearch-api/spec/unit/actions/hashie_spec.rb
@@ -80,7 +80,7 @@ describe 'Hashie' do
   end
 
   let(:response) do
-    Hashie::Mash.new(MultiJson.load(json))
+    Hashie::Mash.new(JSON.load(json))
   end
 
   it 'wraps the response' do

--- a/elasticsearch-api/spec/unit/api_spec.rb
+++ b/elasticsearch-api/spec/unit/api_spec.rb
@@ -24,7 +24,7 @@ describe Elasticsearch::API do
     end
 
     it 'has a default serializer' do
-      expect(Elasticsearch::API.serializer).to eq(MultiJson)
+      expect(Elasticsearch::API.serializer).to eq(JSON)
     end
 
     context 'when settings are changed' do

--- a/elasticsearch-api/spec/unit/perform_request_spec.rb
+++ b/elasticsearch-api/spec/unit/perform_request_spec.rb
@@ -29,7 +29,7 @@ class EndpointSpec
 
   def initialize(filepath)
     @path = Pathname(filepath)
-    json = MultiJson.load(File.read(@path))
+    json = JSON.load(File.read(@path))
     @endpoint_name = json.keys.first
 
     full_namespace = parse_full_namespace

--- a/elasticsearch-api/spec/unit/utils_spec.rb
+++ b/elasticsearch-api/spec/unit/utils_spec.rb
@@ -186,11 +186,11 @@ describe Elasticsearch::API::Utils do
       end
 
       let(:header) do
-        MultiJson.load(lines.first)
+        JSON.load(lines.first)
       end
 
       let(:data_string) do
-        MultiJson.load(lines.last)
+        JSON.load(lines.last)
       end
 
       it 'does not mutate the input' do

--- a/scripts/benchmark-vectors/Gemfile
+++ b/scripts/benchmark-vectors/Gemfile
@@ -23,5 +23,5 @@ else
 end
 gem 'elasticsearch-api', path: File.expand_path('../../elasticsearch-api', __dir__)
 gem 'elasticsearch', path: File.expand_path('../../elasticsearch', __dir__)
-gem 'multi_json'
+gem 'json'
 gem 'rake'

--- a/scripts/benchmark-vectors/app.rb
+++ b/scripts/benchmark-vectors/app.rb
@@ -17,7 +17,7 @@
 inicio = Time.now
 
 require 'jrjackson' if defined?(JRUBY_VERSION)
-require 'multi_json'
+require 'json'
 require 'elasticsearch'
 require 'elasticsearch/helpers/bulk_helper'
 
@@ -66,7 +66,7 @@ def benchmark(data, chunk_size, vector: false)
   bulk_helper = Elasticsearch::Helpers::BulkHelper.new(@client, @index)
   start = Time.now
   20.times do # repeat the dataset until 20k reached (1_000 * 20)
-    json = MultiJson.load("[#{data}]")
+    json = JSON.load("[#{data}]")
     json.each_slice(chunk_size) do |slice|
       slice.map { |j| j['emb'] = @client.pack_dense_vector(j['emb']) } if vector
       bulk_helper.ingest(slice)


### PR DESCRIPTION
### Description

Proposing we remove the `multi_json` and `oj` gems in favour of the standard Ruby `json` gem as it's now as fast or faster in the majority of cases compared to `oj`. Additionally allows us to simplify code quite a bit too. :sparkles: 

Related efforts
- https://github.com/opensearch-project/opensearch-ruby/pull/290
- https://github.com/mastodon/mastodon/pull/37752

### Implementation

More or less just a swap and cleanup. Nothing of particular note stands out.