### PR TITLE
[CI] Drop EOL jruby 9.3

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ['3.3', '3.4', '4.0', 'jruby-9.3', 'jruby-9.4', 'jruby-10.0']
+        ruby: ['3.3', '3.4', '4.0', 'jruby-9.4', 'jruby-10.0']
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v6


### PR DESCRIPTION
Proposing we drop EOL jruby 9.3 from ~and add jruby 10.1 to~ our CI matrix. https://endoflife.date/jruby

<img width="1512" height="1040" alt="image" src="https://github.com/user-attachments/assets/6053d3d5-810a-41bd-a66f-98596d3b5cd7" />

Inspired by https://github.com/elastic/elasticsearch-ruby/pull/2992#issuecomment-4869849337.