### PR TITLE
ci: add x-access-token user to make.sh script

### DIFF
--- a/rake_tasks/automation.rake
+++ b/rake_tasks/automation.rake
@@ -41,7 +41,7 @@ namespace :automation do
     path = File.expand_path('../elasticsearch-api/', __dir__)
     branch = YAML.load_file(File.expand_path("#{__dir__}/../.buildkite/pipeline.yml"))['steps'].first['env']['ES_YAML_TESTS_BRANCH']
     unless File.exist?(File.expand_path('elastic-client-generator-ruby', __dir__))
-      sh "git clone https://#{ENV['CLIENTS_GITHUB_TOKEN']}@github.com/elastic/elastic-client-generator-ruby.git "
+      sh "git clone https://x-access-token:#{ENV['CLIENTS_GITHUB_TOKEN']}@github.com/elastic/elastic-client-generator-ruby.git "
     end
 
     sh "export ES_RUBY_CLIENT_PATH=#{path} " \


### PR DESCRIPTION
Codegen is failing since switching to ephemeral tokens with `fatal: could not read Password for 'https://***@github.com': No such device or address` 

This is working for [elasticsearch-js](https://github.com/elastic/elasticsearch-js/blob/4b336837419c49d3faee6ac34dbf7e3f10e7df80/.github/make.sh#L179) which uses `https://x-access-token:$CLIENTS_GITHUB_TOKEN@github.com/elastic/elastic-client-generator-js.git`