### PR TITLE
fix(automation): use current codegen rake task

### DIFF
--- a/rake_tasks/automation.rake
+++ b/rake_tasks/automation.rake
@@ -50,8 +50,7 @@ namespace :automation do
          " && cd #{generator_path} " \
          ' && bundle config set --local path vendor/bundle ' \
          ' && bundle install ' \
-         " && bundle exec rake update[#{branch}]" \
-         ' && bundle exec rake gen_es'
+         " && bundle exec rake run[#{branch}]"
     end
     FileUtils.rm_rf(generator_path)
   end


### PR DESCRIPTION
## Summary

- replace the removed generator `update` and `gen_es` rake tasks
- use the current `run[branch]` task to download the schema and generate client code

## Validation

- `ruby -c rake_tasks/automation.rake`
- `git diff --check`

Failure: https://github.com/elastic/dev-experience-team/actions/runs/29230550310/job/87411680754
