### PR TITLE
fix(automation): pass token to code generator

### DIFF
--- a/rake_tasks/automation.rake
+++ b/rake_tasks/automation.rake
@@ -50,7 +50,7 @@ namespace :automation do
          " && cd #{generator_path} " \
          ' && bundle config set --local path vendor/bundle ' \
          ' && bundle install ' \
-         " && bundle exec rake run[#{branch}]"
+         " && GITHUB_TOKEN=\"$CLIENTS_GITHUB_TOKEN\" bundle exec rake run[#{branch}]"
     end
     FileUtils.rm_rf(generator_path)
   end


### PR DESCRIPTION
## Summary

- pass the existing `CLIENTS_GITHUB_TOKEN` to the generator as `GITHUB_TOKEN`
- keep the token value out of the logged command

## Validation

- `ruby -c rake_tasks/automation.rake`
- `git diff --check`
- verified token propagation to a subprocess
